### PR TITLE
Update shell-autocompletion.md

### DIFF
--- a/src/config/shell-autocompletion.md
+++ b/src/config/shell-autocompletion.md
@@ -21,7 +21,7 @@ source $HOME/.zshrc
 
 ```sh
 mkdir -p $HOME/.config/fish/completions
-forge completions fish > $HOME/.config/fish/completions/_forge.fish
-cast completions fish > $HOME/.config/fish/completions/_cast.fish
+forge completions fish > $HOME/.config/fish/completions/forge.fish
+cast completions fish > $HOME/.config/fish/completions/cast.fish
 source $HOME/.config/fish/config.fish
 ```


### PR DESCRIPTION
`fish` requires that the completion files not have an underscore. So the current commands do not work. Removing the underscore makes it work.