### PR TITLE
docs: fix `cast call` example command

### DIFF
--- a/scripts/generate-output-cast
+++ b/scripts/generate-output-cast
@@ -7,7 +7,7 @@ need_cmd cast
 echo "Generating output (cast)..."
 mkdir -p $OUTPUT_DIR/cast
 (
-  run_command cast call 0x6b175474e89094c44da98b954eedeac495271d0f "totalSupply()(uint256)" --rpc-url $ETH_RPC_URL
+  run_command cast call 0x6b175474e89094c44da98b954eedeac495271d0f "\"totalSupply()(uint256)\"" --rpc-url $ETH_RPC_URL
 ) > $OUTPUT_DIR/cast/cast-call
 (
   run_command cast 4byte-decode 0x1F1F897F676d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e7

--- a/src/output/cast/cast-call
+++ b/src/output/cast/cast-call
@@ -1,6 +1,6 @@
 // ANCHOR: all
 // ANCHOR: command
-$ cast call 0x6b175474e89094c44da98b954eedeac495271d0f totalSupply()(uint256) --rpc-url https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf
+$ cast call 0x6b175474e89094c44da98b954eedeac495271d0f "totalSupply()(uint256)" --rpc-url https://eth-mainnet.alchemyapi.io/v2/Lc7oIGYeL_QvInzI0Wiu_pOZZDEKBrdf
 // ANCHOR_END: command
 // ANCHOR: output
 8711540303313661493761947058


### PR DESCRIPTION
`cast call` example didn't have function name as string