### PR TITLE
Fixed links and added "Forge Standard Library Reference" to references

### DIFF
--- a/src/cheatcodes/ffi.md
+++ b/src/cheatcodes/ffi.md
@@ -8,7 +8,7 @@ function ffi(string[] calldata) external returns (bytes memory);
 
 ### Description
 
-Calls an arbitrary command if [`ffi`](./config.md#ffi) is enabled.
+Calls an arbitrary command if [`ffi`](../reference/config.md#ffi) is enabled.
 
 It is generally advised to use this cheat code as a last resort, and to not enable it by default, as anyone who can change the tests of a project will be able to execute arbitrary commands on devices that run the tests.
 

--- a/src/forge/forge-std.md
+++ b/src/forge/forge-std.md
@@ -91,6 +91,17 @@ stdstore
     .checked_write(10);
 ```
 
+#### Std Math
+
+Std Math is a library that simplifies the process of some mathematical calculations.
+
+The `Test` contract also provides access to Std Math. You can use the Std Math functions by typing `stdMath.` before the name of the function, just like in the next example:
+
+```solidity
+// Expected result is 10
+stdMath.abs(-10)
+```
+
 <br>
 
 > 📚 **Reference**

--- a/src/reference/README.md
+++ b/src/reference/README.md
@@ -3,5 +3,6 @@
 - [forge Commands](./forge/)
 - [cast Commands](./cast/)
 - [Config Reference](./config.md)
+- [Forge Standard Library Reference](./forge-std)
 - [ds-test Reference](./ds-test.md)
 - [Cheatcodes Reference](../cheatcodes/)

--- a/src/reference/forge-std/README.md
+++ b/src/reference/forge-std/README.md
@@ -48,6 +48,7 @@ What's included:
   - [Std Cheats](./std-cheats.md): Wrappers around Forge cheatcodes for improved safety and UX.
   - [Std Errors](./std-errors.md): Wrappers around common internal Solidity errors and reverts.
   - [Std Storage](./std-storage.md): Contract storage manipulation helpers.
+  - [Std Math](./std-math.md): Covers some mathematical calculations.
 
 - A cheatcodes instance `vm`, from which you invoke Forge cheatcodes (see [Cheatcodes Reference](../../cheatcodes/))
 

--- a/src/reference/forge-std/std-math.md
+++ b/src/reference/forge-std/std-math.md
@@ -1,0 +1,45 @@
+## Std Math
+
+Std Math is a library that simplifies the process of some mathematical calculations.
+
+### Functions
+
+Std Math has 3 different functions. Their explanation and examplification of the expected behavior are the following:
+
+`abs`: return the absolute value of your int256
+```solidity
+// If a = 10, returns 10 | If a = -1001, returns 1001
+    function AbsInt(int256 a) public pure returns(uint256) {
+        return stdMath.abs(a);
+    }
+```
+
+`delta`: difference between the first value and second value
+
+```solidity
+// If a = 10 and b = 2, returns 8 | If a = 6 and b = 9, returns 3
+    function DeltaUint(uint256 a, uint256 b) public pure returns(uint256) {
+        return stdMath.delta(a, b);
+    }
+
+// If a = 5 and b = -4, returns 9 | If a = -15 and b = -20, returns 5
+    function DeltaInt(int256 a, int256 b) public pure returns(uint256) {
+        return stdMath.delta(a, b);
+    }
+```
+
+`percentdelta`: delta in percentage (multiplied by 1e18)
+
+```solidity
+// First, it calculates (a - b) / b. To avoid a result with comma, the function multiplies the result by 1e18
+// If a = 10 and b = 5, returns 1000000000000000000 (100%) |  If a = 10 and b = 7, returns 428571428571428571 (~42.86%)
+    function PercentDeltaUint(uint256 a, uint256 b) public pure returns(uint256) {
+        return stdMath.percentDelta(a, b);
+    }
+
+// First, it calculates (a - b) / abs(b). To avoid a result with comma, the function multiplies the result by 1e18
+// If a = -12 and b = -3, returns 3000000000000000000 (300%) |  If a = 15 and b = -4, returns 4750000000000000000 (475%)
+    function PercentDeltaInt(int256 a, int256 b) public pure returns(uint256) {
+        return stdMath.percentDelta(a, b);
+    }
+```


### PR DESCRIPTION
1) The ffi link was broken. I redirected it to the place it should go for, which is https://book.getfoundry.sh/reference/config.html#ffi

2) Added the Forge Standard Library Reference name and link to the References part