### PR TITLE
Add note about git commit created by "forge install"

### DIFF
--- a/src/projects/dependencies.md
+++ b/src/projects/dependencies.md
@@ -10,6 +10,8 @@ To add a dependency, run [`forge install`](../reference/forge/forge-install.md):
 {{#include ../output/deps/forge-install:all}}
 ```
 
+This pulls the `solmate` library, stages the `.gitmodules` file in git and makes a commit with the message "Installed solmate".
+
 If we now check the `lib` folder:
 
 ```sh


### PR DESCRIPTION
I've been nonchalantly using `forge install` for some time now only to recently discover that it had been clogging up my git commit history.