### PR TITLE
Fixed two small typos in cast reference

### DIFF
--- a/src/reference/cast/cast-4byte.md
+++ b/src/reference/cast/cast-4byte.md
@@ -6,7 +6,7 @@ cast-4byte - Get the function signatures for the given selector from <https://4b
 
 ### SYNOPSIS
 
-``cast abi-encode`` [*options*] *sig*
+``cast 4byte`` [*options*] *sig*
 
 ### DESCRIPTION
 

--- a/src/reference/common/wallet-options-raw.md
+++ b/src/reference/common/wallet-options-raw.md
@@ -7,7 +7,7 @@
 `--private-key` *raw_private_key*  
 &nbsp;&nbsp;&nbsp;&nbsp;Use the provided private key.
 
-`--mnemnic-path` *path*  
+`--mnemonic-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;Use the mnemonic file at the specified path.
 
 `--mnemonic-index` *index*  


### PR DESCRIPTION
- 4byte example said abi-decode
- mnemonic was spelled wrong