### PR TITLE
docs: Add meaning of x and y in forge verify reference

### DIFF
--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -33,8 +33,8 @@ This command will try to compile the source code of the flattened contract if `-
 `--compiler-version` *version*  
 &nbsp;&nbsp;&nbsp;&nbsp;The compiler version used to build the smart contract.
 
-&nbsp;&nbsp;&nbsp;&nbsp;To find the exact compiler version, run `~/.svm/x.y.z/solc-x.y.z --version`  
-&nbsp;&nbsp;&nbsp;&nbsp;and search for the 8 hex digits in the version string [here](https://etherscan.io/solcversions).
+&nbsp;&nbsp;&nbsp;&nbsp;To find the exact compiler version, run `~/.svm/x.y.z/solc-x.y.z --version` where `x` and
+`y` are major and minor version numbers respectively, then search for the 8 hex digits in the version string [here](https://etherscan.io/solcversions).
 
 `--num-of-optimizations` *num*  
 &nbsp;&nbsp;&nbsp;&nbsp;The number of optimization runs used to build the smart contract.


### PR DESCRIPTION
The 'Deploying' section had the meaning of `x` and `y` for the command `~/.svm/x.y.z/solc-x.y.z --version`, but the forge verify reference didn't. It caused a bit of confusion for me, hence I hope this PR can help others avoid the confusion in the future.