### PR TITLE
docs: update verify documentation

### DIFF
--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -47,6 +47,11 @@ $ forge create --rpc-url <your_rpc_url> \
 
 ## Verifying
 
+It is recommended to use the `--verify` flag with `forge create` to automatically verify the contract on Etherscan after a deployment.
+Note that [`ETHERSCAN_API_KEY`](../reference/config.md#etherscan_api_key) must be set.
+
+If you are verifying an already deployed contract, read on.
+
 You can verify a contract on Etherscan with the [`forge verify-contract`](../reference/forge/forge-verify-contract.md) command.
 
 You must provide:

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -50,14 +50,14 @@ $ forge create --rpc-url <your_rpc_url> \
 You can verify a contract on Etherscan with the [`forge verify-contract`](../reference/forge/forge-verify-contract.md) command.
 
 You must provide:
-- [compiler version](https://etherscan.io/solcversions) used for build, with 8 hex digits from the commit version prefix (the commit will usually not be a nightly build)
 - the contract address
 - the path to the contract `<path>:<contractname>`
 - your Etherscan API key (env: `ETHERSCAN_API_KEY`).
 
 Moreover, you may need to provide:
+- [compiler version](https://etherscan.io/solcversions) used for build, with 8 hex digits from the commit version prefix (the commit will usually not be a nightly build).  It is auto-detected if not specified.
 - the constructor arguments in the ABI-encoded format, if there are any
-- the number of optimizations, if the Solidity optimizer was activated
+- the number of optimizations, if the Solidity optimizer was activated.  It is auto-detected if not specified.
 - the [chain ID](https://evm-chainlist.netlify.app/), if the contract is not on Ethereum Mainnet
 
 Let's say you want to verify `MyToken` (see above). You set the [number of optimizations](../reference/config.md#optimizer_runs) to 1 million, compiled it with v0.8.10, and deployed it, as shown above, to the Kovan testnet (chain ID: 42). Note that `--num-of-optimizations` will default to 0 if not set on verification, while it defaults to 200 if not set on deployment, so make sure you pass `--num-of-optimizations 200` if you left the default compilation settings. 

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -45,7 +45,7 @@ $ forge create --rpc-url <your_rpc_url> \
     --private-key <your_private_key> src/MyToken.sol:MyToken
 ```
 
-## Verifying
+## Verifying a pre-existing contract
 
 It is recommended to use the `--verify` flag with `forge create` to automatically verify the contract on Etherscan after a deployment.
 Note that [`ETHERSCAN_API_KEY`](../reference/config.md#etherscan_api_key) must be set.

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -39,10 +39,13 @@ contract MyToken is ERC20 {
 }
 ```
 
+Additionally, we can tell Forge to verify our contract on Etherscan, if the network is supported, by passing `--verify`.
+
 ```sh
 $ forge create --rpc-url <your_rpc_url> \
     --constructor-args "ForgeUSD" "FUSD" 18 1000000000000000000000 \
-    --private-key <your_private_key> src/MyToken.sol:MyToken
+    --private-key <your_private_key> src/MyToken.sol:MyToken \
+    --verify
 ```
 
 ## Verifying a pre-existing contract

--- a/src/reference/forge/core-build-options.md
+++ b/src/reference/forge/core-build-options.md
@@ -16,9 +16,6 @@
 
 {{#include project-options.md}}
 
-`--config-path` *file*  
-&nbsp;&nbsp;&nbsp;&nbsp;Path to the config file.
-
 `-o` *path*  
 `--out` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The project's artifacts directory.

--- a/src/reference/forge/forge-create.md
+++ b/src/reference/forge/forge-create.md
@@ -33,6 +33,9 @@ Dynamic linking is not supported: you should predeploy your libraries and manual
 `--constructor-args-path` *file*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to a file containing the constructor arguments.
 
+`--verify`  
+&nbsp;&nbsp;&nbsp;&nbsp;Verify contract after creation. Runs `forge verify-contract` with the appropriate parameters.
+
 #### Transaction Options
 
 `--gas-limit` *gas_limit*  

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -60,8 +60,8 @@ This command will try to compile the source code of the flattened contract if `-
 &nbsp;&nbsp;&nbsp;&nbsp;Number of attempts for retrying. Defaults to 1.
 
 `--watch`  
-&nbsp;&nbsp;&nbsp;&nbsp;Wait for verification result after submission.
-Automatically runs `forge verify-check` until the verification either fails or succeeds.
+&nbsp;&nbsp;&nbsp;&nbsp;Wait for verification result after submission.  
+&nbsp;&nbsp;&nbsp;&nbsp;Automatically runs `forge verify-check` until the verification either fails or succeeds.
 
 {{#include project-options.md}}
 

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -57,7 +57,7 @@ This command will try to compile the source code of the flattened contract if `-
 &nbsp;&nbsp;&nbsp;&nbsp;Optional timeout to apply in between attempts in seconds.
 
 `--retries` *retries*  
-&nbsp;&nbsp;&nbsp;&nbsp;Number of attempts for retrying [default: 1].
+&nbsp;&nbsp;&nbsp;&nbsp;Number of attempts for retrying. Defaults to 1.
 
 `--watch`  
 &nbsp;&nbsp;&nbsp;&nbsp;Wait for verification result after submission.

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -53,6 +53,16 @@ This command will try to compile the source code of the flattened contract if `-
 `--force`  
 &nbsp;&nbsp;&nbsp;&nbsp;Do not compile the flattened smart contract before verifying.
 
+`--delay` *delay*  
+&nbsp;&nbsp;&nbsp;&nbsp;Optional timeout to apply in between attempts in seconds.
+
+`--retries` *retries*  
+&nbsp;&nbsp;&nbsp;&nbsp;Number of attempts for retrying [default: 1].
+
+`--watch`  
+&nbsp;&nbsp;&nbsp;&nbsp;Wait for verification result after submission.
+Automatically runs `forge verify-check` until the verification either fails or succeeds.
+
 {{#include project-options.md}}
 
 {{#include common-options.md}}

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -18,7 +18,6 @@
 &nbsp;&nbsp;&nbsp;&nbsp;The parameter is a comma-separated list of remappings in the format `<source>=<dest>`.
 
 `--remappings-env` *env*  
-&nbsp;&nbsp;&nbsp;&nbsp;The project's remappings from the environment. Returns `None` if the env var is not set, otherwise all remappings.
 
 `--cache-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to the compiler cache.

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -17,8 +17,6 @@
 
 &nbsp;&nbsp;&nbsp;&nbsp;The parameter is a comma-separated list of remappings in the format `<source>=<dest>`.
 
-`--remappings-env` *env*  
-
 `--cache-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to the compiler cache.
 

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -17,9 +17,16 @@
 
 &nbsp;&nbsp;&nbsp;&nbsp;The parameter is a comma-separated list of remappings in the format `<source>=<dest>`.
 
+`--remappings-env` *env*  
+&nbsp;&nbsp;&nbsp;&nbsp;The project's remappings from the environment. Returns `None` if the env var is not set, otherwise all remappings.
+
 `--cache-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to the compiler cache.
+
+`--config-path` *path*  
+&nbsp;&nbsp;&nbsp;&nbsp;Path to the config file.
 
 `--hh`  
 `--hardhat`  
 &nbsp;&nbsp;&nbsp;&nbsp;This is a convenience flag, and is the same as passing `--contracts contracts --lib-paths node-modules`.
+

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -23,7 +23,7 @@
 `--cache-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to the compiler cache.
 
-`--config-path` *path*  
+`--config-path` *file*  
 &nbsp;&nbsp;&nbsp;&nbsp;Path to the config file.
 
 `--hh`  


### PR DESCRIPTION
closes: https://github.com/foundry-rs/book/issues/323
closes: https://github.com/foundry-rs/book/issues/236


## verify-contract
I added 2 missing flags `--delay` and `--retries`from 
```sh
forge verify-contract -h
```


## project options
I also saw 2 missing options from `project-options`
```sh
--remappings-env
--config-path
```

It looks like `forge-flatten` and `forge-tree` also use `{{#include project-options.md}}`
- and it shows up on their `-h`
