### PR TITLE
Fix typo in the `--chain-id` option

### DIFF
--- a/src/reference/forge/forge-verify-check.md
+++ b/src/reference/forge/forge-verify-check.md
@@ -18,7 +18,7 @@ You must provide an Etherscan API key, either by passing it as an argument or se
 
 #### Verify Contract Options
 
-`--chain` *chain*  
+`--chain-id` *chain_id*  
 &nbsp;&nbsp;&nbsp;&nbsp;The chain ID the contract is deployed to (either a number or a chain name).  
 &nbsp;&nbsp;&nbsp;&nbsp;Default: mainnet
 

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -42,7 +42,7 @@ This command will try to compile the source code of the flattened contract if `-
 `--constructor-args` *args...*  
 &nbsp;&nbsp;&nbsp;&nbsp;The ABI-encoded constructor arguments.
 
-`--chain` *chain*  
+`--chain-id` *chain_id*  
 &nbsp;&nbsp;&nbsp;&nbsp;The chain ID the contract is deployed to (either a number or a chain name).  
 &nbsp;&nbsp;&nbsp;&nbsp;Default: mainnet
 


### PR DESCRIPTION
Updated the docs for `verify-contract` and `verify-contract-check` to avoid `....argument wasn't expected` error.

Fixes: #337 

