### PR TITLE
fix: github actions checkout v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: mdbook test
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install mdbook
         run: |


### PR DESCRIPTION
Just updating actions checkout to v3

looks like v3 was recent: https://github.com/actions/checkout/tags

