### PR TITLE
docs: add example of cast send message

### DIFF
--- a/src/cast/README.md
+++ b/src/cast/README.md
@@ -23,6 +23,13 @@ Let's use `cast` to retrieve the total supply of the DAI token:
 ```bash
 {{#include ../output/cast/cast-4byte-decode:all}}
 ```
+
+You can also use `cast` to send arbitrary messages. Here's an example of sending a message between two Anvil accounts.
+
+```bash
+$ cast send --from 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc $(cast --from-utf8 "hello world") --rpc-url http://127.0.0.1:8545/
+```
+
 <br>
 
 > 📚 **Reference**

--- a/src/cast/README.md
+++ b/src/cast/README.md
@@ -27,7 +27,7 @@ Let's use `cast` to retrieve the total supply of the DAI token:
 You can also use `cast` to send arbitrary messages. Here's an example of sending a message between two Anvil accounts.
 
 ```bash
-$ cast send --from 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc $(cast --from-utf8 "hello world") --rpc-url http://127.0.0.1:8545/
+$ cast send --private-key <Your Private Key> 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc $(cast --from-utf8 "hello world") --rpc-url http://127.0.0.1:8545/
 ```
 
 <br>


### PR DESCRIPTION
Adds an example of using `cast send` to send an arbitrary message.

Note: I wasn't sure how to run `anvil` in the background so that the command output could be generated rather than hard-coded. If anyone has pointers on that, please let me know. Related: https://github.com/foundry-rs/book/issues/173 