### PR TITLE
Minor changes to anvil overview readme

### DIFF
--- a/src/anvil/README.md
+++ b/src/anvil/README.md
@@ -1,16 +1,18 @@
 ## Overview of Anvil
 
-Anvil is Foundry's local testnet node implementation written in Rust. You can use it for testing your contracts from frontends or interacting over RPC.
+Anvil is a local testnet node shipped with Foundry. You can use it for testing your contracts from frontends or for interacting over RPC.
 
-Anvil is a part of Foundry, so as long as you have the updated version of Foudry, You should have it installed. [Foundry installation](../getting-started/installation.md)
+Anvil is part of the Foundry suite and is installed alongside `forge` and `cast`. If you haven't installed Foundry yet, see [Foundry installation](../getting-started/installation.md). 
+
+> Note: If you have an older version of Foundry installed, you'll need to re-install `foundryup` in order for Anvil to be downloaded.
 
 ### How to use Anvil
 
-To use Anvil, run `anvil`.
+To use Anvil, simply type `anvil`. You should see a list of accounts and private keys available for use, as well as the address and port that the node is listening on. 
 
-You should see a list of accounts and private keys available for use, there are also some options you could run to configure the test node. You can run `anvil -h` to see them.
+Anvil is highly configurable. You can run `anvil -h` to see all the configuration options.
 
-Some examples of them are:
+Some basic options are:
 
 ```bash
 #  Number of dev accounts to generate and configure. [default: 10]
@@ -25,4 +27,4 @@ anvil  -p, --port <PORT>
 
 > 📚 **Reference**
 >
-> See the [`anvil` Reference](../reference/anvil/) for a complete overview of all the available options.
+> See the [`anvil` Reference](../reference/anvil/) for in depth information on Anvil and its capabilities.


### PR DESCRIPTION
Mainly adding the note on re-installing foundryup for users on older versions. Also a typo fix or two and some re-wording.