### PR TITLE
fix: remove unsupported debug_traceTransaction

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -118,9 +118,7 @@ The standard methods are based on [this](https://eth.wiki/json-rpc/API) referenc
   
 * `eth_submitHashrate`  
   
-* `eth_feeHistory`  
-
-* `debug_traceTransaction`  
+* `eth_feeHistory`
   
 * `trace_transaction`
   


### PR DESCRIPTION
debug_traceTransaction not supported yet

https://github.com/foundry-rs/foundry/issues/1737