### PR TITLE
chore: adds Docker setup instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM rust
+RUN cargo install mdbook
+EXPOSE 3000
+COPY . /book
+WORKDIR /book
+ENTRYPOINT ["mdbook", "serve", "-n", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM rust
-RUN cargo install mdbook
-EXPOSE 3000
-COPY . /book
-WORKDIR /book
-ENTRYPOINT ["mdbook", "serve", "-n", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ To see the book change live run:
 mdbook serve
 ```
 
+To run the book with docker, run:
+
+```sh
+docker run -p 3000:3000 -v `pwd`:/book peaceiris/mdbook serve
+```
+
 To add a new section (file) to the book, add it to [`SUMMARY.md`](src/SUMMARY.md).
 
 For a more structured overview of the current issues, see [the GitHub project](https://github.com/orgs/foundry-rs/projects/1).


### PR DESCRIPTION
This PR adds a Dockerfile to start `mdbook`. 

# Why?

I saw that the the main book URL [was down](https://twitter.com/gakonst/status/1542175547731480583) and I wanted to spin up a mirror. 