### PR TITLE
docs: github pages alternative deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,26 @@
+name: github pages deployment
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.18'
+
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./book


### PR DESCRIPTION
Example: https://solarsend.github.io/foundrybook/

Creates a `pages.yml` mdbook workflow that:
- sets up the `peaceiris/actions-mdbook@v1` action
- builds using `mdbook build`
- pushes all artifacts to a branch named `gh-pages` for subsequent serves

---

For admins, set the source branch in the repo pages settings to `gh-pages` and dir to `root` for changes to take effect. 
![Screen Shot 2022-06-29 at 12 42 06 PM](https://user-images.githubusercontent.com/31051606/176524774-4390695c-e8ec-42c5-8cdc-3eae63a41369.png)

