### PR TITLE
Add etherscan-api-key flag

### DIFF
--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -45,6 +45,7 @@ Additionally, we can tell Forge to verify our contract on Etherscan, if the netw
 $ forge create --rpc-url <your_rpc_url> \
     --constructor-args "ForgeUSD" "FUSD" 18 1000000000000000000000 \
     --private-key <your_private_key> src/MyToken.sol:MyToken \
+    --etherscan-api-key <your_etherscan_api_key> \
     --verify
 ```
 


### PR DESCRIPTION
The etherscan-api-key flag is missing, which leads to an error when you copy paste the commands without including it
