### PR TITLE
Add a missing step for installing the forge-std library

### DIFF
--- a/src/getting-started/first-steps.md
+++ b/src/getting-started/first-steps.md
@@ -15,6 +15,13 @@ $ cd hello_foundry
 {{#include ../output/hello_foundry/tree:all}}
 ```
 
+Let's install the [Forge standard library](https://github.com/foundry-rs/forge-std) which our tests need to run:
+
+```sh
+$ forge install foundry-rs/forge-std --no-commit
+```
+
+
 We can build the project with [`forge build`](../reference/forge/forge-build.md):
 
 ```sh


### PR DESCRIPTION
I needed to install the standard library in order to `forge build` the demo repo.