### PR TITLE
current argument is --chain

### DIFF
--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -74,7 +74,7 @@ Let's say you want to verify `MyToken` (see above). You set the [number of optim
 Here's how to verify it:
 
 ```bash
-$ forge verify-contract --chain-id 42 --num-of-optimizations 1000000 --constructor-args \ 
+$ forge verify-contract --chain 42 --num-of-optimizations 1000000 --constructor-args \ 
     $(cast abi-encode "constructor(string,string,uint256,uint256)" "ForgeUSD" "FUSD" 18 1000000000000000000000) \
     --compiler-version v0.8.10+commit.fc410830 <the_contract_address> src/MyToken.sol:MyToken <your_etherscan_api_key>
 


### PR DESCRIPTION
Based on the latest command option, `--chain-id` should be `--chain`

```
 forge verify-contract --help
forge-verify-contract 
Verify smart contracts on Etherscan.

USAGE:
    forge verify-contract [OPTIONS] <ADDRESS> <CONTRACT> <ETHERSCAN_KEY>

ARGS:
    <ADDRESS>
            The address of the contract to verify.

    <CONTRACT>
            The contract identifier in the form `<path>:<contractname>`.

    <ETHERSCAN_KEY>
            Your Etherscan API key.
            
            [env: ETHERSCAN_API_KEY=]

OPTIONS:
        --chain <CHAIN>
            The chain ID the contract is deployed to.
            
            [env: CHAIN=]
            [default: mainnet]
            [aliases: chain-id]
```