### PR TITLE
docs: update cover

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 
 Foundry is a smart contract development toolchain.
 
-Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line.
+Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line and via Solidity scripts.
 
 > 📖 **Contributing**
 >
@@ -26,6 +26,10 @@ The overview will give you all you need to know about how to use `forge` to deve
 
 Learn how to use `cast` to interact with smart contracts, send transactions, and get chain data from the command-line.
 
+**[Anvil Overview](anvil)**
+
+Learn about `anvil`, the Foundry's local node.
+
 **Configuration**
 
 Guides on configuring Foundry.
@@ -34,6 +38,7 @@ Guides on configuring Foundry.
 - [Continuous Integration](./config/continous-integration.md)
 - [Integrating with VSCode](./config/vscode.md)
 - [Shell Autocompletion](./config/shell-autocompletion.md)
+- [Static Analyzers](./config/static-analyzers.md)
 - [Integrating with Hardhat](./config/hardhat.md)
 
 **Tutorials**
@@ -43,19 +48,24 @@ Tutorials on building smart contracts with Foundry.
 - [Creating an NFT with Solmate](./tutorials/solmate-nft.md)
 - [Docker and Foundry](./tutorials/foundry-docker.md)
 - [Testing EIP-712 Signatures](./tutorials/testing-eip712.md)
-- [Solidity Scripting](./tutorials//solidity-scripting.md)
+- [Solidity Scripting](./tutorials/solidity-scripting.md)
+- [Testing on a Forked Network](./tutorials/testing-on-a-forked-network.md)
 <!-- - [Incremental Adoption]() -->
 
 **Appendix**
 
-References, troubleshooting and more.
+References, troubleshooting, and more.
 
+- [FAQ](./faq.md)
 - [forge Commands](./reference/forge/)
 - [cast Commands](./reference/cast/)
 - [anvil commands](./reference/anvil/)
 - [Config Reference](./reference/config.md)
+- [Cheatcodes Reference](./cheatcodes/)
 - [Forge Standard Library Reference](./reference/forge-std/)
 - [DSTest Reference](./reference/ds-test.md)
-- [Cheatcodes Reference](./cheatcodes/)
+- [Miscellaneous](misc)
 
-> You can also check out [Awesome Foundry](https://github.com/crisgarner/awesome-foundry), a curated list of awesome Foundry resources, tutorials, tools and libraries!
+<br>
+
+> You can also check out [Awesome Foundry](https://github.com/crisgarner/awesome-foundry), a curated list of awesome Foundry resources, tutorials, tools, and libraries!

--- a/src/README.md
+++ b/src/README.md
@@ -28,7 +28,7 @@ Learn how to use `cast` to interact with smart contracts, send transactions, and
 
 **[Anvil Overview](anvil)**
 
-Learn about `anvil`, the Foundry's local node.
+Learn about `anvil`, Foundry's local node.
 
 **Configuration**
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -271,4 +271,5 @@
       - [`delta`](./reference/forge-std/delta.md)
       - [`percentDelta`](./reference/forge-std/percentDelta.md)
   - [DSTest Reference](./reference/ds-test.md)
-- [Misc](./misc/README.md)
+- [Miscellaneous](./misc/README.md)
+  - [Struct encoding](./misc/struct-encoding.md)

--- a/src/misc/README.md
+++ b/src/misc/README.md
@@ -1,3 +1,3 @@
-## Misc
+## Miscellaneous
 
 - [Struct encoding](./struct-encoding.md)

--- a/src/reference/cast/cast-sig.md
+++ b/src/reference/cast/cast-sig.md
@@ -37,11 +37,11 @@ The signature (*sig*) is a fragment in the form `<function name>(<types...>)`.
     }
     ```
 
-    Structs are encoded as tuples (see [struct encoding](./reference/common/struct-encoding.md)).
+    Structs are encoded as tuples (see [struct encoding](../../misc/struct-encoding.md)).
 
     ```sh
     cast sig "myfunction((address,uint256))"
     ```
 ### SEE ALSO
 
-[cast](./cast.md), [struct encoding](./misc/struct-encoding.md)
+[cast](./cast.md), [struct encoding](../../misc/struct-encoding.md)


### PR DESCRIPTION
## Motivation

- Links to `misc/struct-encoding.md` are incorrect
- Some links on the cover are incorrect
- The cover is out of date

## Solution

- Fix links
- Update the cover