### PR TITLE
#430 build-info and build-info-path options to the reference section

### DIFF
--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -1,5 +1,11 @@
 #### Project Options
 
+`--build-info`
+&nbsp;&nbsp;&nbsp;&nbsp;Generate build info files.
+
+`--build-info-path` *path*
+&nbsp;&nbsp;&nbsp;&nbsp;Output path to directory that build info files will be written to.
+
 `--root` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The project's root path. By default, this is the root directory of the current git repository, or the current working directory.
 

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -1,11 +1,9 @@
 #### Project Options
 
-`--build-info` 
-
+`--build-info`  
 &nbsp;&nbsp;&nbsp;&nbsp;Generate build info files.
 
-`--build-info-path` *path* 
-
+`--build-info-path` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;Output path to directory that build info files will be written to.
 
 `--root` *path*  

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -1,9 +1,11 @@
 #### Project Options
 
-`--build-info`
+`--build-info` 
+
 &nbsp;&nbsp;&nbsp;&nbsp;Generate build info files.
 
-`--build-info-path` *path*
+`--build-info-path` *path* 
+
 &nbsp;&nbsp;&nbsp;&nbsp;Output path to directory that build info files will be written to.
 
 `--root` *path*  


### PR DESCRIPTION
In regards to #430 I added `--build-info` and `--build-info-path` to the book's reference section. I took the options and the description from the `forge build --help` output and added it in.