### PR TITLE
correction of order in `EXAMPLES`(#3)

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -71,7 +71,7 @@ The destination (*to*) can be an ENS name or an address.
     Structs are encoded as tuples (see [struct encoding](./reference/common/struct-encoding.md))
 
     ```sh
-    cast send "myfunction((address,uint256))" 0x... "(0x...,1)"
+    cast send 0x... "myfunction((address,uint256))" "(0x...,1)"
     ```
 ### SEE ALSO
 


### PR DESCRIPTION
 according to `SYNOPSIS`