### PR TITLE
add docs on `anvil_dumpState` and `anvil_loadState`

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -172,6 +172,12 @@ Set the minimum gas price for the node
 `anvil_setNextBlockBaseFeePerGas`  
 Sets the base fee of the next block
 
+`anvil_dumpState`
+Returns a hex string representing the complete state of the chain. Can be re-imported into a fresh/restarted instance of Anvil to reattain the same state.
+
+`anvil_loadState`
+When given a hex string previously returned by `anvil_dumpState`, merges the contents into the current chain state. Will overwrite any colliding accounts/storage slots.
+
 ##### Special Methods
 The special methods come from Ganache. You can take a look at the documentation [here](https://github.com/trufflesuite/ganache-cli-archive/blob/master/README.md).
 


### PR DESCRIPTION
these commands will be added to the main CLI https://github.com/foundry-rs/foundry/pull/2256 , so this PR brings the docs into parity.