### PR TITLE
Cheatcode Documentation Revision

### DIFF
--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -15,7 +15,7 @@ vm.prank(address(0));
 ```
 ### Forge Standard Library Cheatcodes
 
-Forge-std implements 'cheatcodes' through a wrapper which combines multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather a composition of Forge's cheatcodes.
+Forge Std implements wrappers around cheatcodes, which combine multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather compositions of Forge's cheatcodes.
 
 You can view the list of Forge Standard Library's 'cheatcodes' [in the references section](../reference/forge-std/std-cheats.md) and see how each of them uses the Forge cheatcodes in the [Forge-std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol).
 

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -8,11 +8,7 @@ Cheatcodes are made available through use of the cheatcode address (`0x7109709EC
 vm.assume(address_ != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 ```
 
-You can also access cheatcodes easily via `vm` available in Forge Standard Library's [`Test`](../reference/forge-std/#forge-stds-test) contract. For example, using the `prank` cheatcode to send the next call from the zero address can be done as follows:
-
-```solidity
-vm.prank(address(0));
-```
+You can also access cheatcodes easily via `vm` available in Forge Standard Library's [`Test`](../reference/forge-std/#forge-stds-test) contract.
 ### Forge Standard Library Cheatcodes
 
 Forge Std implements wrappers around cheatcodes, which combine multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather compositions of Forge's cheatcodes.

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -17,7 +17,7 @@ vm.prank(address(0));
 
 Forge Std implements wrappers around cheatcodes, which combine multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather compositions of Forge's cheatcodes.
 
-You can view the list of Forge Standard Library's 'cheatcodes' [in the references section](../reference/forge-std/std-cheats.md) and see how each of them uses the Forge cheatcodes in the [Forge-std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol).
+You can view the list of Forge Standard Library's cheatcode wrappers [in the references section](../reference/forge-std/std-cheats.md). You can reference the [Forge Std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol) to learn more about how the wrappers work under the hood.
 
 ### Cheatcode Types
 

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -17,7 +17,7 @@ vm.prank(address(0));
 
 Forge-std implements 'cheatcodes' through a wrapper which combines multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather a composition of Forge's cheatcodes.
 
-You can view the list of Forge Standard Library's 'cheatcodes' [in the references section](../../reference/forge-std/std-cheats.md) and see how each of them uses the Forge cheatcodes in the [Forge-std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol).
+You can view the list of Forge Standard Library's 'cheatcodes' [in the references section](../reference/forge-std/std-cheats.md) and see how each of them uses the Forge cheatcodes in the [Forge-std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol).
 
 ### Cheatcode Types
 

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -4,9 +4,11 @@ Cheatcodes give you powerful assertions, the ability to alter the state of the E
 
 Cheatcodes are made available through use of the cheatcode address (`0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`). If you encounter errors for this address when using fuzzed addresses in your tests, you may wish to exclude it from your fuzz tests by using the following line:
 
-```solidity
-vm.assume(address_ != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
-```
+> ℹ️ **Note**
+>
+> ```solidity
+> vm.assume(address_ != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+> ```
 
 You can also access cheatcodes easily via `vm` available in Forge Standard Library's [`Test`](../reference/forge-std/#forge-stds-test) contract.
 ### Forge Standard Library Cheatcodes

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -1,10 +1,25 @@
 ## Cheatcodes Reference
 
-Cheatcodes give you powerful assertions, the ability to alter the state of the EVM, mock data, and more.
+Cheatcodes give you powerful assertions, the ability to alter the state of the EVM, mock data, and more. 
 
-To enable a cheatcode you call designated functions on the cheatcode address: `0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`.
+Cheatcodes are made available through use of the cheatcode address (`0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`). If you encounter errors for this address when using fuzzed addresses in your tests, you may wish to exclude it from your fuzz tests by using the following line:
 
-You can access cheatcodes easily via `vm` available in Forge Standard Library's [`Test`](../reference/forge-std/#forge-stds-test) contract.
+```solidity
+vm.assume(address_ != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+```
+
+You can also access cheatcodes easily via `vm` available in Forge Standard Library's [`Test`](../reference/forge-std/#forge-stds-test) contract. For example, using the `prank` cheatcode to send the next call from the zero address can be done as follows:
+
+```solidity
+vm.prank(address(0));
+```
+### Forge Standard Library Cheatcodes
+
+Forge-std implements 'cheatcodes' through a wrapper which combines multiple standard cheatcodes to improve development experience. These are not technically cheatcodes, but rather a composition of Forge's cheatcodes.
+
+You can view the list of Forge Standard Library's 'cheatcodes' [in the references section](../../reference/forge-std/std-cheats.md) and see how each of them uses the Forge cheatcodes in the [Forge-std source code](https://github.com/foundry-rs/forge-std/blob/master/src/Test.sol).
+
+### Cheatcode Types
 
 Below are some subsections for the different Forge cheatcodes.
 
@@ -203,3 +218,4 @@ interface CheatCodes {
     function rpcUrls() external returns(string[2][] memory);
 }
 ```
+

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -2,9 +2,12 @@
 
 Cheatcodes give you powerful assertions, the ability to alter the state of the EVM, mock data, and more.
 
-Cheatcodes are made available through use of the cheatcode address (`0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`). If you encounter errors for this address when using fuzzed addresses in your tests, you may wish to exclude it from your fuzz tests by using the following line:
+Cheatcodes are made available through use of the cheatcode address (`0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`). 
 
 > ℹ️ **Note**
+>
+> If you encounter errors for this address when using fuzzed addresses in your tests, you may wish to 
+> exclude it from your fuzz tests by using the following line:
 >
 > ```solidity
 > vm.assume(address_ != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -1,6 +1,6 @@
 ## Cheatcodes Reference
 
-Cheatcodes give you powerful assertions, the ability to alter the state of the EVM, mock data, and more. 
+Cheatcodes give you powerful assertions, the ability to alter the state of the EVM, mock data, and more.
 
 Cheatcodes are made available through use of the cheatcode address (`0x7109709ECfa91a80626fF3989D68f67F5b1DD12D`). If you encounter errors for this address when using fuzzed addresses in your tests, you may wish to exclude it from your fuzz tests by using the following line:
 
@@ -218,4 +218,3 @@ interface CheatCodes {
     function rpcUrls() external returns(string[2][] memory);
 }
 ```
-


### PR DESCRIPTION
Hi,

I have made some revisions to the `cheatcodes` section following [this discussion](https://twitter.com/0xArbiter/status/1550126535440379911) on Twitter with Bjerg.

### Why did you make these changes?

I felt that there wasn't sufficient documentation surrounding the forge-std 'cheatcodes', which was weird considering they're meant for DX improvements.

### What did you do?

- Refactored parts of the document to make it easier to read
- Added in a section explaining how to exclude the cheatcode address from fuzz testing (this and the precompile addresses personally cost me 3 days of dev time when I was learning Foundry, luckily a fellow dev explained what I needed to do)
- Added a link to the Forge Standard Library 'cheatcodes' directly from this document
- Added a link to the forge-std GitHub for those who want to see how the 'cheatcodes' work under the hood, to avoid confusion

### What is controversial about this?

Calling the forge-std functions 'cheatcodes' is a bit controversial since technically they're just fancy wrappers, so I tried to make that clear in my revision.

Explaining how to use `vm.assume` to exclude the cheatcode address might be a bit controversial since it's not technically in the same theme as cheatcodes (the topic) but this is the most prominent mention of the cheatcode address (0x7109709ECfa91a80626fF3989D68f67F5b1DD12D) and so where someone encountering an error with this address would end up when searching the docs.


Let me know what you guys think.

Cheers,
Arby