### PR TITLE
Document console.log format specifiers

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -273,6 +273,7 @@
       - [`abs`](./reference/forge-std/abs.md)
       - [`delta`](./reference/forge-std/delta.md)
       - [`percentDelta`](./reference/forge-std/percentDelta.md)
+    - [Console Logging](./reference/forge-std/console-log.md)
   - [DSTest Reference](./reference/ds-test.md)
 - [Miscellaneous](./misc/README.md)
   - [Struct encoding](./misc/struct-encoding.md)

--- a/src/faq.md
+++ b/src/faq.md
@@ -95,6 +95,6 @@ Forge will sometimes check for newer Solidity versions that fit your project. To
 [config-solc]: ./reference/config.md#solc_version
 [config]: ./config/
 [forge-build]: ./reference/forge/forge-build.md
-[console-log]: https://github.com/NomicFoundation/hardhat/blob/master/packages/hardhat-core/console.sol
+[console-log]: ./reference/forge-std/console-log.md
 [forge-std]: https://github.com/foundry-rs/forge-std
 [dstestplus]: https://github.com/transmissions11/solmate/blob/19a4f345970ed39ee6369f343d145e0d4071c18a/src/test/utils/DSTestPlus.sol#L10

--- a/src/reference/forge-std/README.md
+++ b/src/reference/forge-std/README.md
@@ -57,6 +57,7 @@ What's included:
   - [Std Errors](./std-errors.md): Wrappers around common internal Solidity errors and reverts.
   - [Std Storage](./std-storage.md): Utilities for storage manipulation.
   - [Std Math](./std-math.md): Useful mathematical functions.
+  - [Console Logging](./console-log.md): Console logging functions.
 
 - A cheatcodes instance `vm`, from which you invoke Forge cheatcodes (see [Cheatcodes Reference](../../cheatcodes/))
 

--- a/src/reference/forge-std/README.md
+++ b/src/reference/forge-std/README.md
@@ -12,7 +12,7 @@ What's included:
     import "forge-std/Vm.sol";
     ```
 
-- [`console.sol`](https://hardhat.org/hardhat-network/reference/#console-log) and `console2.sol`: Hardhat-style logging functionality
+- [`console.sol`](./console-log.md) and `console2.sol`: Hardhat-style logging functionality
 
     ```solidity
     import "forge-std/console.sol";
@@ -65,7 +65,7 @@ What's included:
     vm.startPrank(alice);
     ```
 
-- All Hardhat `console` functions for logging (see [Hardhat docs](https://hardhat.org/hardhat-network/reference/#console-log))
+- All Hardhat `console` functions for logging (see [Console Logging](./console-log.md))
 
     ```solidity
     console.log(alice.balance); // or `console2`

--- a/src/reference/forge-std/console-log.md
+++ b/src/reference/forge-std/console-log.md
@@ -1,0 +1,59 @@
+## Console Logging
+
+- Similar to Hardhat's console functions.
+- You can use it in calls and transactions. It works with view functions, but not in pure ones.
+- It always works, regardless of the call or transaction failing or being successful.
+- To use it you need to import hardhat/console.sol.
+- You can call console.log with up to 4 parameters in any order of following types:
+    - `uint`
+    - `string`
+    - `bool`
+    - `address`
+- There's also the single parameter API for the types above, and additionally bytes, bytes1... up to bytes32:
+    - `console.logInt(int i)`
+    - `console.logUint(uint i)`
+    - `console.logString(string memory s)`
+    - `console.logBool(bool b)`
+    - `console.logAddress(address a)`
+    - `console.logBytes(bytes memory b)`
+    - `console.logBytes1(bytes1 b)`
+    - `console.logBytes2(bytes2 b)`
+    - ...
+    - `console.logBytes32(bytes32 b)`
+- console.log implements the same formatting options that can be found in Hardhat's console.log.
+    - Example: `console.log("Changing owner from %s to %s", currentOwner, newOwner)`
+- console.log is implemented in standard Solidity and it is compatible Anvil and Hardhat Networks.
+- console.log calls can run in other networks, like mainnet, kovan, ropsten, etc. They do nothing in those networks, but do spend a minimal amount of gas.
+
+
+### `console.log(format[,...args])`
+The `console.log()` method returns a formatted string using the first argument as a printf-like format string which can contain zero or more format specifiers. Each specifier is replaced with the converted value from the corresponding argument. Supported specifiers are:
+
+- `%s`: String will be used to convert all values to a human-readable string. `uint256`, `int256` and `bytes` values are converted to their `0x` hex encoded values.
+- `%d`: Number will be used to convert all values to a human-readable string. This is identical to `%s`.
+- `%i`: Works the same way as `%d`.
+- `%o`: Object. A string representation of an object with generic JavaScript-styled object formatting. For solidity types, this basically surround the string representation of the value in single-quotes.
+- `%%`: single percent sign ('%'). This does not consume an argument.
+- Returns: `<string>` The formatted string
+
+If a specifier does not have a corresponding argument, it is not replaced:
+```
+console.log("%s:%s", "foo");
+// Returns: "foo:%s"
+```
+
+Values that are not part of the format string are formatted using as a human-readable string representation.
+
+If there are more arguments passed to the console.log() method than the number of specifiers, the extra arguments are concatenated to the returned string, separated by spaces:
+```
+console.log("%s:%s", "foo", "bar", "baz");
+// Returns: "foo:bar baz"
+```
+
+If only one argument is passed to console.log(), it is returned as it is without any formatting:
+```
+console.log("%% %s");
+// Returns: "%% %s"
+```
+
+The String format specifier (`%s`) should be used in most cases unless specific functionality is needed from other format specifiers.

--- a/src/reference/forge-std/console-log.md
+++ b/src/reference/forge-std/console-log.md
@@ -37,7 +37,7 @@ The `console.log()` method prints a formatted string using the first argument as
 - Returns: `<string>` The formatted string
 
 If a specifier does not have a corresponding argument, it is not replaced:
-```
+```solidity
 console.log("%s:%s", "foo");
 // Returns: "foo:%s"
 ```
@@ -45,13 +45,13 @@ console.log("%s:%s", "foo");
 Values that are not part of the format string are formatted using as a human-readable string representation.
 
 If there are more arguments passed to the console.log() method than the number of specifiers, the extra arguments are concatenated to the returned string, separated by spaces:
-```
+```solidity
 console.log("%s:%s", "foo", "bar", "baz");
 // Returns: "foo:bar baz"
 ```
 
 If only one argument is passed to console.log(), it is returned as it is without any formatting:
-```
+```solidity
 console.log("%% %s");
 // Returns: "%% %s"
 ```

--- a/src/reference/forge-std/console-log.md
+++ b/src/reference/forge-std/console-log.md
@@ -27,7 +27,7 @@
 
 
 ### `console.log(format[,...args])`
-The `console.log()` method returns a formatted string using the first argument as a printf-like format string which can contain zero or more format specifiers. Each specifier is replaced with the converted value from the corresponding argument. Supported specifiers are:
+The `console.log()` method prints a formatted string using the first argument as a printf-like format string which can contain zero or more format specifiers. Each specifier is replaced with the converted value from the corresponding argument. Supported specifiers are:
 
 - `%s`: String will be used to convert all values to a human-readable string. `uint256`, `int256` and `bytes` values are converted to their `0x` hex encoded values.
 - `%d`: Number will be used to convert all values to a human-readable string. This is identical to `%s`.


### PR DESCRIPTION
Document console.log string format specifiers implemented in https://github.com/foundry-rs/foundry/pull/2313.