### PR TITLE
Fix installation page

### DIFF
--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -20,7 +20,7 @@ This will download `foundryup`. Then install Foundry by running:
 foundryup
 ```
 
-If everything goes well, you will now have two binaries at your disposal: `forge` and `cast`.
+If everything goes well, you will now have three binaries at your disposal: `forge`, `cast`, and `anvil`.
 
 > 💡 **Tip**
 >

--- a/src/tutorials/solmate-nft.md
+++ b/src/tutorials/solmate-nft.md
@@ -49,7 +49,7 @@ contract NFT is ERC721 {
 }
 ```
 
-Let's take a look at this very basic implementation of an NFT. We start by importing to contracts from our git submodules. We import solmate's gas optimised implementation of the ERC721 standard which our NFT contract will inherit from. Our constructor takes the `_name` and `_symbol` arguments for our NFT and passes them on to the constructor of the parent ERC721 implementation. Lastly we implement the `mintTo` function which allows anyone to mint an NFT. This function increments the `currentTokenId` and makes use of the `_safeMint` function of our parent contract.
+Let's take a look at this very basic implementation of an NFT. We start by importing two contracts from our git submodules. We import solmate's gas optimized implementation of the ERC721 standard which our NFT contract will inherit from. Our constructor takes the `_name` and `_symbol` arguments for our NFT and passes them on to the constructor of the parent ERC721 implementation. Lastly we implement the `mintTo` function which allows anyone to mint an NFT. This function increments the `currentTokenId` and makes use of the `_safeMint` function of our parent contract.
 
 ### Compile & deploy with forge
 


### PR DESCRIPTION
When I installed the binaries using `foundryup`, I received three binaries.
```
$ foundryup
foundryup: installing foundry (version nightly, tag nightly-64fe4acc97e6d76551cea7598c201f05ecd65639)
foundryup: downloading latest forge, cast and anvil
######################################################################### 100.0%
foundryup: downloading manpages
######################################################################### 100.0%
foundryup: installed - forge 0.2.0 (64fe4ac 2022-07-26T00:04:05.891537523Z)
foundryup: installed - cast 0.2.0 (64fe4ac 2022-07-26T00:04:05.891537523Z)
foundryup: installed - anvil 0.1.0 (64fe4ac 2022-07-26T00:04:04.746772497Z)
foundryup: done
```
I updated the book to reflect that.