### PR TITLE
updating output to include the script directory and file

### DIFF
--- a/src/output/hello_foundry/tree
+++ b/src/output/hello_foundry/tree
@@ -5,9 +5,10 @@ $ tree . -d -L 1
 // ANCHOR: output
 .
 ├── lib
+├── script
 ├── src
 └── test
 
-3 directories
+4 directories
 // ANCHOR_END: output
 // ANCHOR_END: all

--- a/src/output/hello_foundry/tree-with-files
+++ b/src/output/hello_foundry/tree-with-files
@@ -12,11 +12,13 @@ $ tree . -L 3 -I output
 │       ├── LICENSE-MIT
 │       ├── README.md
 │       └── src
+├── script
+│   └── Contract.s.sol
 ├── src
 │   └── Contract.sol
 └── test
     └── Contract.t.sol
 
-6 directories, 6 files
+7 directories, 7 files
 // ANCHOR_END: output
 // ANCHOR_END: all


### PR DESCRIPTION
Updating the output of the `tree` command to include the new `script` directory and file.