### PR TITLE
Remove --include-fuzz-tests from forge docs

### DIFF
--- a/src/reference/forge/forge-snapshot.md
+++ b/src/reference/forge/forge-snapshot.md
@@ -15,7 +15,7 @@ Create a snapshot of each test's gas usage.
 The results are written to a file named `.gas-snapshot`. You can change the name of the file
 by passing `--snap <PATH>`.
 
-By default, fuzz tests are not included in the snapshot. To include them, pass `--include-fuzz-tests`.
+Fuzz tests are included by default in the snapshot. They use a static seed to achieve deterministic results.
 
 Snapshots can be compared with `--diff` and `--check`. The first flag will output a diff, and the second
 will output a diff *and* exit with code 1 if the snapshots do not match.
@@ -51,10 +51,6 @@ Sort results by gas used (ascending).
 `--snap` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;Output file for the snapshot. Default: `.gas-snapshot`.
 
-`--include-fuzz-tests`  
-&nbsp;&nbsp;&nbsp;&nbsp;Include the mean and median gas use of fuzz tests in the snapshot.  
-&nbsp;&nbsp;&nbsp;&nbsp;Environment: `FORGE_INCLUDE_FUZZ_TESTS`
-
 {{#include test-options.md}}
 
 {{#include evm-options.md}}
@@ -74,17 +70,12 @@ Sort results by gas used (ascending).
     forge snapshot
     ```
 
-2. Create a snapshot with fuzz tests:
-    ```sh
-    forge snapshot --include-fuzz-tests
-    ```
-
-3. Generate a diff:
+2. Generate a diff:
     ```sh
     forge snapshot --diff
     ```
 
-4. Check that the snapshots match:
+3. Check that the snapshots match:
     ```sh
     forge snapshot --check
     ```


### PR DESCRIPTION
`--include-fuzz-tests` was removed from `forge snapshot`, now it uses a deterministic seed.

Fixes #498.