### PR TITLE
Update foundry-docker.md example

### DIFF
--- a/src/tutorials/foundry-docker.md
+++ b/src/tutorials/foundry-docker.md
@@ -28,7 +28,7 @@ We will cover both, but let's start by taking a look at interfacing with foundry
 
 We can run any of the `cast` [commands](/reference/cast/) against our docker image. Let's fetch the latest block information:
 ```sh
-$ docker run foundry "cast block --rpc-url $RPC_URL latest"
+$ docker run foundry "cast block --rpc-url $RPC_URL --block latest"
 baseFeePerGas        "0xb634241e3"
 difficulty           "0x2e482bdf51572b"
 extraData            "0x486976656f6e20686b"


### PR DESCRIPTION
Trying to run the example command as described in the doc, I received an error:
```
❯ docker run foundry "cast block --rpc-url $RPC_URL latest"
error: Found argument 'latest' which wasn't expected, or isn't valid in this context

USAGE:
    cast block [OPTIONS] --block <BLOCK>

For more information try --help
```

`--help` guided me to use the `--block` option instead.

---

From the code at https://github.com/foundry-rs/foundry/blame/e306e24c9bcf223af0de6f54e1774b727c430cfa/cli/src/opts/cast.rs#L259-L278, I wasn't able to pinpoint when this changed. If someone else can easily decipher it, it might be a good idea to mention it here for future reference.