### PR TITLE
docs: References-anvil Reference - Examples - missing backtick in codeblock

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -344,7 +344,7 @@ Supported shells are:
 1. Generate shell completions script for zsh:
     ```sh
     anvil completions zsh > $HOME/.oh-my-zsh/completions/_anvil
-    ``
+    ```
 
 
 ### Usage within Docker


### PR DESCRIPTION
References
   |__ anvil Reference 
        |__ EXAMPLES 
                 |__  Codeblock for point number 1  missing a backtick , that has been added, its not a major issue , just when copying the block directly, generates some errors. 
