### PR TITLE
Add projectRoot cheatcode page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -229,6 +229,7 @@
       - [`isPersistent`](./cheatcodes/is-persistent.md)
     - [External](./cheatcodes/external.md)
       - [`ffi`](./cheatcodes/ffi.md)
+      - [`projectRoot`](./cheatcodes/project-root.md)
       - [`getCode`](./cheatcodes/get-code.md)
       - [`setEnv`](./cheatcodes/set-env.md)
       - [`envBool`](./cheatcodes/env-bool.md)

--- a/src/cheatcodes/project-root.md
+++ b/src/cheatcodes/project-root.md
@@ -1,0 +1,11 @@
+## `projectRoot`
+
+### Signature
+
+```solidity
+function projectRoot() external returns (string memory);
+```
+
+### Description
+
+Returns the root directory of the current foundry project.


### PR DESCRIPTION
Adds a page for the cheatcode added in https://github.com/foundry-rs/foundry/pull/2762

This PR closes https://github.com/foundry-rs/book/issues/523

Simple feature, so not much to say here.