### PR TITLE
fix: clarify default location for contracts

### DIFF
--- a/src/projects/dependencies.md
+++ b/src/projects/dependencies.md
@@ -77,6 +77,6 @@ $ forge remove lib/solmate
 
 ### Hardhat compatibility
 
-Forge also supports Hardhat-style projects where dependencies are npm packages (stored in `node_modules`) and contracts are stored in `contracts` as opposed to source.
+Forge also supports Hardhat-style projects where dependencies are npm packages (stored in `node_modules`) and contracts are stored in `contracts` as opposed to `src`.
 
 To enable Hardhat compatibility mode pass the `--hh` flag.


### PR DESCRIPTION
Contracts in forge projects are in the `src` directory. Would be clearer to say that instead of the word "source". 