### PR TITLE
Remove --block-gas-limit from README.md

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -293,9 +293,6 @@ Returns the details of all transactions currently pending for inclusion in the n
 `--block-base-fee-per-gas <FEE>`  
 &nbsp;&nbsp;&nbsp;&nbsp; The base fee in a block
 
-`--block-gas-limit <GAS_LIMIT>`  
-&nbsp;&nbsp;&nbsp;&nbsp; The block gas limit
-
 `--chain-id <CHAIN_ID>`  
 &nbsp;&nbsp;&nbsp;&nbsp; The chain ID
 


### PR DESCRIPTION
The `--block-gas-limit` flag doesn't seem to work as a CLI argument for anvil (at least on macOS). The `--gas-limit` flag works and is already included below. This PR just removes mention of `--block-gas-limit`.