### PR TITLE
Fixed spelling error in solidity snippet

### DIFF
--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -74,10 +74,10 @@ interface CheatCodes {
     // Computes address for a given private key
     function addr(uint256 privateKey) external returns (address);
 
-    // Derive a private key from a provided mnenomic string,
-    // or mnenomic file path, at the derivation path m/44'/60'/0'/0/{index}.
+    // Derive a private key from a provided mnemonic string,
+    // or mnemonic file path, at the derivation path m/44'/60'/0'/0/{index}.
     function deriveKey(string calldata, uint32) external returns (uint256);
-    // Derive a private key from a provided mnenomic string, or mnenomic file path,
+    // Derive a private key from a provided mnemonic string, or mnemonic file path,
     // at the derivation path {path}{index}
     function deriveKey(string calldata, string calldata, uint32) external returns (uint256);
 


### PR DESCRIPTION
4 typos fixed, all the same: 'mnenomic' -> 'mnemonic'

BTW, love the cheatcodes! Comprehensive, concise, and useful.