### PR TITLE
docs: update rpc-url alias docs

### DIFF
--- a/src/reference/common/rpc-url-option.md
+++ b/src/reference/common/rpc-url-option.md
@@ -1,3 +1,3 @@
 `--rpc-url` *url*  
-&nbsp;&nbsp;&nbsp;&nbsp;The RPC endpoint.  
+&nbsp;&nbsp;&nbsp;&nbsp;The RPC endpoint. Accepts a URL or an existing alias in the [rpc_endpoints] table, like `mainnet`.
 &nbsp;&nbsp;&nbsp;&nbsp;Environment: `ETH_RPC_URL`


### PR DESCRIPTION
closes #601

mention argument accepts alias of [rpc_endpoints]