### PR TITLE
Remove duplicate of function signature

### DIFF
--- a/src/reference/forge-std/assertApproxEqAbs.md
+++ b/src/reference/forge-std/assertApproxEqAbs.md
@@ -10,14 +10,6 @@ function assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta) internal virt
 function assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta, string memory err) internal virtual;
 ```
 
-```solidity
-function assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta) internal virtual;
-```
-
-```solidity
-function assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta, string memory err) internal virtual;
-```
-
 ### Description
 
 Asserts `a` is approximately equal to `b` with delta in absolute value.


### PR DESCRIPTION
The signatures of the 2 "assertApproxEqAbs" had a duplicate