### PR TITLE
Update shell-autocompletion.md for M1 machines

### DIFF
--- a/src/config/shell-autocompletion.md
+++ b/src/config/shell-autocompletion.md
@@ -19,6 +19,14 @@ cast completions zsh > /usr/local/share/zsh/site-functions/_cast
 anvil completions zsh > /usr/local/share/zsh/site-functions/_anvil
 ```
 
+For M1 machines:
+
+```sh
+forge completions zsh > /opt/homebrew/completions/zsh/_forge
+cast completions zsh > /opt/homebrew/completions/zsh/_cast
+anvil completions zsh > /opt/homebrew/completions/zsh/_anvil
+```
+
 ### fish
 
 ```sh

--- a/src/config/shell-autocompletion.md
+++ b/src/config/shell-autocompletion.md
@@ -19,7 +19,7 @@ cast completions zsh > /usr/local/share/zsh/site-functions/_cast
 anvil completions zsh > /usr/local/share/zsh/site-functions/_anvil
 ```
 
-For M1 machines:
+For ARM-based systems:
 
 ```sh
 forge completions zsh > /opt/homebrew/completions/zsh/_forge


### PR DESCRIPTION
When running the commands:
```sh
forge completions zsh > /usr/local/share/zsh/site-functions/_forge
cast completions zsh > /usr/local/share/zsh/site-functions/_cast
anvil completions zsh > /usr/local/share/zsh/site-functions/_anvil
```

I get this error:
```sh
zsh: no such file or directory: /usr/local/share/zsh/site-functions/_forge
zsh: no such file or directory: /usr/local/share/zsh/site-functions/_cast
zsh: no such file or directory: /usr/local/share/zsh/site-functions/_anvil
```

See: https://stackoverflow.com/questions/65747286/zsh-problem-compinit503-no-such-file-or-directory-usr-local-share-zsh-site

The autocomplete on ARM-based systems are not stored in the same directory.