### PR TITLE
document cast send create

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -23,6 +23,8 @@ The destination (*to*) can be an ENS name or an address.
 `--resend`  
 &nbsp;&nbsp;&nbsp;&nbsp;Reuse the latest nonce of the sending account.
 
+`--create`  
+&nbsp;&nbsp;&nbsp;&nbsp;Deploy a contract by specifying raw bytecode, in place of specifying *to* address 
 
 #### Receipt Options
 

--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -23,8 +23,8 @@ The destination (*to*) can be an ENS name or an address.
 `--resend`  
 &nbsp;&nbsp;&nbsp;&nbsp;Reuse the latest nonce of the sending account.
 
-`--create`  
-&nbsp;&nbsp;&nbsp;&nbsp;Deploy a contract by specifying raw bytecode, in place of specifying *to* address 
+`--create` *code* [*sig* *args...*]  
+&nbsp;&nbsp;&nbsp;&nbsp;Deploy a contract by specifying raw bytecode, in place of specifying a *to* address.
 
 #### Receipt Options
 


### PR DESCRIPTION
Closes #551 by documenting `cast send --create` option to deploy raw contract bytecode