### PR TITLE
remove redundant dash from ---extra-output-files

### DIFF
--- a/src/reference/forge/compiler-options.md
+++ b/src/reference/forge/compiler-options.md
@@ -33,7 +33,7 @@
 
 &nbsp;&nbsp;&nbsp;&nbsp;For a full description, see the [Solidity docs][output-desc].
 
-`---extra-output-files` *selector*  
+`--extra-output-files` *selector*  
 &nbsp;&nbsp;&nbsp;&nbsp;Extra output to write to separate files.
 
 &nbsp;&nbsp;&nbsp;&nbsp;Example keys: `abi`, `storageLayout`, `evm.assembly`, `ewasm`, `ir`, `ir-optimized`, `metadata`.


### PR DESCRIPTION
I met an error

```
error: Found argument '---extra-output-files' which wasn't expected, or isn't valid in this context

	Did you mean '--extra-output-files'?
```
