### PR TITLE
docs: update hardhat snippet

### DIFF
--- a/src/config/hardhat.md
+++ b/src/config/hardhat.md
@@ -41,7 +41,7 @@ function getRemappings() {
 }
 ```
 
-*Thanks to [@DrakeEvansV1](https://twitter.com/drakeevansv1) for this snippet*
+*Thanks to [@DrakeEvansV1](https://twitter.com/drakeevansv1) and [@colinnielsen](https://github.com/colinnielsen) for this snippet*
 
 4. Add the following to your exported `HardhatUserConfig` object:
 
@@ -51,11 +51,12 @@ preprocess: {
   eachLine: (hre) => ({
     transform: (line: string) => {
       if (line.match(/^\s*import /i)) {
-        getRemappings().forEach(([find, replace]) => {
-          if (line.match(find)) {
-            line = line.replace(find, replace);
+        for (const [from, to] of getRemappings()) {
+          if (line.includes(from)) {
+            line = line.replace(from, to);
+            break;
           }
-        });
+        }
       }
       return line;
     },


### PR DESCRIPTION
The hardhat preprocessor snippet will apply multiple transformations on a single line with an import statement. This becomes an issue when multiple matching substrings appear in an import statement.

Consider the following repo:
```ignore
# remappings.txt
openzeppelin-contracts/=lib/openzeppelin-contracts/
contracts/=src/ # a convenience import remapping
```
and the import statement
```solidity
import "openzeppelin-contracts/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
```

expected output:
```solidity
import "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
```

actual
```solidity
import "lib/openzeppelin-src/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
```
___

This change proposes that the preprocessor loop `breaks` after finding a matching substring.