### PR TITLE
Small docs options updates.

### DIFF
--- a/src/reference/common/display-options.md
+++ b/src/reference/common/display-options.md
@@ -2,4 +2,4 @@
 
 `-j`  
 `--json`  
-&nbsp;&nbsp;&nbsp;&nbsp;Output in JSON format.
+&nbsp;&nbsp;&nbsp;&nbsp; Print the deployment information as JSON.

--- a/src/reference/common/verifier-options.md
+++ b/src/reference/common/verifier-options.md
@@ -2,4 +2,5 @@
 &nbsp;&nbsp;&nbsp;&nbsp;The verification provider. Available options: `etherscan`, `sourcify` & `blockscout`. Default: `etherscan`.
 
 `--verifier-url` *url*  
-&nbsp;&nbsp;&nbsp;&nbsp;The optional verifier url for submitting the verification request.
+&nbsp;&nbsp;&nbsp;&nbsp;The optional verifier url for submitting the verification request.  
+&nbsp;&nbsp;&nbsp;&nbsp;Environment: `VERIFIER_URL`

--- a/src/reference/common/wallet-options-hardware.md
+++ b/src/reference/common/wallet-options-hardware.md
@@ -7,6 +7,3 @@
 `-l`  
 `--ledger`  
 &nbsp;&nbsp;&nbsp;&nbsp;Use a Ledger hardware wallet.
-
-`--hd-path` *path*  
-&nbsp;&nbsp;&nbsp;&nbsp;The derivation path to use with hardware wallets.

--- a/src/reference/common/wallet-options-raw.md
+++ b/src/reference/common/wallet-options-raw.md
@@ -1,15 +1,24 @@
-#### Wallet Options - Raw
-
+#### WALLET OPTIONS - RAW:
 `-i`  
-`--interactive`  
-&nbsp;&nbsp;&nbsp;&nbsp;Open an interactive prompt to enter your private key.
+`--interactives <NUM>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Open an interactive prompt to enter your private key. Takes a value for the number of keys to enter.  
+&nbsp;&nbsp;&nbsp;&nbsp; Defaults to `0`.  
 
-`--private-key` *raw_private_key*  
-&nbsp;&nbsp;&nbsp;&nbsp;Use the provided private key.
+`--mnemonic-derivation-paths <PATHS>`  
+&nbsp;&nbsp;&nbsp;&nbsp; The wallet derivation path. Works with both `--mnemonic-path` and hardware wallets.  
 
-`--mnemonic-path` *path*  
-&nbsp;&nbsp;&nbsp;&nbsp;Use the mnemonic file at the specified path.
+`--mnemonic-indexes <INDEXES>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Use the private key from the given mnemonic index. Used with --mnemonic-paths.  
+&nbsp;&nbsp;&nbsp;&nbsp; Defaults to `0`.
 
-`--mnemonic-index` *index*  
-&nbsp;&nbsp;&nbsp;&nbsp;Use the private key from the given mnemonic index. Used with `--mnemonic-path`.  
-&nbsp;&nbsp;&nbsp;&nbsp;Defaults to `0`.
+`--mnemonic-passphrases <PASSPHRASE>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Use a BIP39 passphrases for the mnemonic.  
+
+`--mnemonics <PATHS>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Use the mnemonic phrases or mnemonic files at the specified paths.  
+
+`--private-key <RAW_PRIVATE_KEY>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Use the provided private key.
+
+`--private-keys <RAW_PRIVATE_KEYS>`  
+&nbsp;&nbsp;&nbsp;&nbsp; Use the provided private keys.  


### PR DESCRIPTION
This PR updates some of the documentation for command line options to be in line with the current release of foundry.

Closes #650. 

Also has some extra little fixes (mostly for wallet-related options), but I absolutely did not get every discrepancy.

From what I saw, I think the best approach might be to have someone eventually implement a bash script that autogenerates docs from parsing the output of various `--help` calls, and plug that into CI... the docs have diverged very significantly from what's actually in the binary, and it'd be such a headache to have people keep manually updating them...