### PR TITLE
Fix bug that causes Compiler run failed when forge build

### DIFF
--- a/src/tutorials/solidity-scripting.md
+++ b/src/tutorials/solidity-scripting.md
@@ -39,8 +39,8 @@ Once that’s done, you should open up your preferred code editor and copy the c
 pragma solidity >=0.8.10;
 
 import "solmate/tokens/ERC721.sol";
-import "openzeppelin-contracts/contracts/utils/Strings.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/utils/Strings.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 
 error MintPriceNotPaid();
 error MaxSupply();


### PR DESCRIPTION
Openzepplin changed its contract structure. The original code is:

```solidity
import "openzeppelin-contracts/contracts/utils/Strings.sol";
import "openzeppelin-contracts/contracts/access/Ownable.sol";
```

which will cause error when using `forge build`:
```shell
Compiler run failed
error[6275]: ParserError: Source "lib/openzeppelin-contracts/contracts/contracts/utils/Strings.sol" not found: File not found. Searched the following locations: "/Users/liang/Documents/Fight for PHD/work/MiniSolidity/Code/Test/solidity-scripting".
 --> src/NFT.sol:4:1:
  |
4 | import "openzeppelin-contracts/contracts/utils/Strings.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[6275]: ParserError: Source "lib/openzeppelin-contracts/contracts/contracts/access/Ownable.sol" not found: File not found. Searched the following locations: "/Users/liang/Documents/Fight for PHD/work/MiniSolidity/Code/Test/solidity-scripting".
 --> src/NFT.sol:5:1:
  |
5 | import "openzeppelin-contracts/contracts/access/Ownable.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

The forge remappings output:

```
ds-test/=lib/forge-std/lib/ds-test/src/
forge-std/=lib/forge-std/src/
lib/=lib/
openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
solmate/=lib/solmate/src/
```

To fix, change `openzeppelin-contracts/contracts` in the import to `openzeppelin-contracts`:

```solidity
import "openzeppelin-contracts/utils/Strings.sol";
import "openzeppelin-contracts/access/Ownable.sol";
```