### PR TITLE
fix: typo in cast balance

### DIFF
--- a/src/reference/cast/cast-balance.md
+++ b/src/reference/cast/cast-balance.md
@@ -2,7 +2,7 @@
 
 ### NAME
 
-cast-balance - Get the nonce of an account in wei.
+cast-balance - Get the balance of an account in wei.
 
 ### SYNOPSIS
 


### PR DESCRIPTION
Change "nonce" to "balance".