### PR TITLE
remove value_type from arguments

### DIFF
--- a/src/reference/cast/cast-index.md
+++ b/src/reference/cast/cast-index.md
@@ -6,7 +6,7 @@ cast-index - Compute the storage slot for an entry in a mapping.
 
 ### SYNOPSIS
 
-``cast index`` *key_type* *value_type* *key* *slot*
+``cast index`` *key_type* *key* *slot*
 
 ### DESCRIPTION
 


### PR DESCRIPTION
It seems that value_type is not a valid argument for `cast index`. 
`cast index -h` gives me:

Compute the storage slot for an entry in a mapping.
Usage: cast index <KEY_TYPE> <KEY> <SLOT_NUMBER>
Arguments:
  <KEY_TYPE>     The mapping key type.
  <KEY>          The mapping key.
  <SLOT_NUMBER>  The storage slot of the mapping.
Options:
  -h, --help  Print help information