### PR TITLE
Update new default sender address

### DIFF
--- a/src/reference/config/testing.md
+++ b/src/reference/config/testing.md
@@ -37,7 +37,7 @@ Whether or not to enable the `ffi` cheatcode.
 ##### `sender`
 
 - Type: string (address)
-- Default: 0x00a329c0648769a73afac7f9381e08fb43dbea72
+- Default: 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38
 - Environment: `FOUNDRY_SENDER` or `DAPP_SENDER`
 
 The value of `msg.sender` in tests.
@@ -45,7 +45,7 @@ The value of `msg.sender` in tests.
 ##### `tx_origin`
 
 - Type: string (address)
-- Default: 0x00a329c0648769a73afac7f9381e08fb43dbea72
+- Default: 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38
 - Environment: `FOUNDRY_TX_ORIGIN` or `DAPP_TX_ORIGIN`
 
 The value of `tx.origin` in tests.

--- a/src/static/config.default.toml
+++ b/src/static/config.default.toml
@@ -54,9 +54,9 @@ build_info = false
 # Whether or not to enable `vm.ffi`
 ffi = false
 # The address of `msg.sender` in tests
-sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+sender = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
 # The address of `tx.origin` in tests
-tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+tx_origin = '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38'
 # The initial balance of the test contract
 initial_balance = '0xffffffffffffffffffffffff'
 # The chain ID we are on in tests


### PR DESCRIPTION
Updates with the new default address: `0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38`.

Ref/Pending: https://github.com/foundry-rs/foundry/pull/3680