### PR TITLE
Added Rust.exe and VS Code Installer for Windows

### DIFF
--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -42,7 +42,9 @@ It will download a script and start the installation.
 
 If you use Windows, you need to build from source to get Foundry.
 
-Download and run `rustup-init` from [rustup.rs](https://rustup.rs). It will start the installation in a console.
+Download and run `rustup-init` from [rustup.rs](https://win.rustup.rs/x86_64). It will start the installation in a console.
+
+If you encouner an error, it is most likely the case that you do not have the VS Code Installer which you can [download here](https://visualstudio.microsoft.com/downloads/) and install.
 
 After this, run the following to build Foundry from source:
 


### PR DESCRIPTION
I use Windows, and I encountered this installation issue. Windows users who do not have the VS Code Installer would not be able to successfully install Foundry. I just fixed that in this edit.