### PR TITLE
update src/README.md. Add a tip for macOS

### DIFF
--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -22,6 +22,12 @@ foundryup
 
 If everything goes well, you will now have three binaries at your disposal: `forge`, `cast`, and `anvil`.
 
+If you use macOS and display below error, you need type `brew install libusb` to install Library
+
+```sh
+dyld[32719]: Library not loaded: /usr/local/opt/libusb/lib/libusb-1.0.0.dylib
+```
+
 > 💡 **Tip**
 >
 >To update `foundryup` after installation, simply run `foundryup` again, and it will update to the latest Foundry release. You can also revert to a specific version of Foundry with `foundryup -v $VERSION`.


### PR DESCRIPTION
when i type `foundryup` on macOS. It display below error. In my opion, i add a tip to slove below error.
```sh
foundryup: installing foundry (version nightly, tag nightly-b28119b56d7dd18c268a471167a0c547c301c13e)
foundryup: downloading latest forge, cast and anvil
curl: (92) HTTP/2 stream 1 was not closed cleanly before end of the underlying stream

foundryup: command failed: curl -# -L https://github.com/foundry-rs/foundry/releases/download/nightly-b28119b56d7dd18c268a471167a0c547c301c13e/foundry_nightly_darwin_amd64.tar.gz
foundryup: downloading manpages
curl: (92) HTTP/2 stream 1 was not closed cleanly before end of the underlying stream

foundryup: command failed: curl -# -L https://github.com/foundry-rs/foundry/releases/download/nightly-b28119b56d7dd18c268a471167a0c547c301c13e/foundry_man_nightly.tar.gz
dyld[32719]: Library not loaded: /usr/local/opt/libusb/lib/libusb-1.0.0.dylib
  Referenced from: /Users/jackchen/.foundry/bin/forge
  Reason: tried: '/usr/local/opt/libusb/lib/libusb-1.0.0.dylib' (no such file), '/usr/local/lib/libusb-1.0.0.dylib' (no such file), '/usr/lib/libusb-1.0.0.dylib' (no such file)
foundryup: installed - 
dyld[32720]: Library not loaded: /usr/local/opt/libusb/lib/libusb-1.0.0.dylib
  Referenced from: /Users/jackchen/.foundry/bin/cast
  Reason: tried: '/usr/local/opt/libusb/lib/libusb-1.0.0.dylib' (no such file), '/usr/local/lib/libusb-1.0.0.dylib' (no such file), '/usr/lib/libusb-1.0.0.dylib' (no such file)
foundryup: installed - 
dyld[32721]: Library not loaded: /usr/local/opt/libusb/lib/libusb-1.0.0.dylib
  Referenced from: /Users/jackchen/.foundry/bin/anvil
  Reason: tried: '/usr/local/opt/libusb/lib/libusb-1.0.0.dylib' (no such file), '/usr/local/lib/libusb-1.0.0.dylib' (no such file), '/usr/lib/libusb-1.0.0.dylib' (no such file)
foundryup: installed - 
foundryup: done
```sh