### PR TITLE
update reference to struct encoding in cast-send

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -71,7 +71,7 @@ The destination (*to*) can be an ENS name or an address.
     }
     ```
 
-    Structs are encoded as tuples (see [struct encoding](./reference/common/struct-encoding.md))
+    Structs are encoded as tuples (see [struct encoding](./misc/struct-encoding.md))
 
     ```sh
     cast send 0x... "myfunction((address,uint256))" "(0x...,1)"


### PR DESCRIPTION
Reference was pointing to a dead end with 404.