### PR TITLE
docs: add envOr cheatcode docs page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -245,6 +245,7 @@
       - [`getCode`](./cheatcodes/get-code.md)
       - [`getDeployedCode`](./cheatcodes/get-deployed-code.md)
       - [`setEnv`](./cheatcodes/set-env.md)
+      - [`envOr`](./cheatcodes/env-or.md)
       - [`envBool`](./cheatcodes/env-bool.md)
       - [`envUint`](./cheatcodes/env-uint.md)
       - [`envInt`](./cheatcodes/env-int.md)

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -127,6 +127,24 @@ interface CheatCodes {
         external
         returns (bytes[] memory);
 
+    // Read environment variables with default value, (name, value) => (value)
+    function envOr(string calldata, bool) external returns (bool);
+    function envOr(string calldata, uint256) external returns (uint256);
+    function envOr(string calldata, int256) external returns (int256);
+    function envOr(string calldata, address) external returns (address);
+    function envOr(string calldata, bytes32) external returns (bytes32);
+    function envOr(string calldata, string calldata) external returns (string memory);
+    function envOr(string calldata, bytes calldata) external returns (bytes memory);
+    
+    // Read environment variables as arrays with default value, (name, value[]) => (value[])
+    function envOr(string calldata, string calldata, bool[] calldata) external returns (bool[] memory);
+    function envOr(string calldata, string calldata, uint256[] calldata) external returns (uint256[] memory);
+    function envOr(string calldata, string calldata, int256[] calldata) external returns (int256[] memory);
+    function envOr(string calldata, string calldata, address[] calldata) external returns (address[] memory);
+    function envOr(string calldata, string calldata, bytes32[] calldata) external returns (bytes32[] memory);
+    function envOr(string calldata, string calldata, string[] calldata) external returns (string[] memory);
+    function envOr(string calldata, string calldata, bytes[] calldata) external returns (bytes[] memory);
+
     // Convert Solidity types to strings
     function toString(address) external returns(string memory);
     function toString(bytes calldata) external returns(string memory);

--- a/src/cheatcodes/env-or.md
+++ b/src/cheatcodes/env-or.md
@@ -1,0 +1,71 @@
+## `envOr`
+
+### Signature
+
+```solidity
+function envOr(string calldata key, bool defaultValue) external returns (bool value);
+function envOr(string calldata key, uint256 defaultValue) external returns (uint256 value);
+function envOr(string calldata key, int256 defaultValue) external returns (int256 value);
+function envOr(string calldata key, address defaultValue) external returns (address value);
+function envOr(string calldata key, bytes32 defaultValue) external returns (bytes32 value);
+function envOr(string calldata key, string calldata defaultValue) external returns (string memory value);
+function envOr(string calldata key, bytes calldata defaultValue) external returns (bytes memory value);
+```
+
+```solidity
+function envOr(string calldata key, string calldata delimiter, bool[] calldata defaultValue) external returns (bool[] memory value);
+function envOr(string calldata key, string calldata delimiter, uint256[] calldata defaultValue) external returns (uint256[] memory value);
+function envOr(string calldata key, string calldata delimiter, int256[] calldata defaultValue) external returns (int256[] memory value);
+function envOr(string calldata key, string calldata delimiter, address[] calldata defaultValue) external returns (address[] memory value);
+function envOr(string calldata key, string calldata delimiter, bytes32[] calldata defaultValue) external returns (bytes32[] memory value);
+function envOr(string calldata key, string calldata delimiter, string[] calldata defaultValue) external returns (string[] memory value);
+function envOr(string calldata key, string calldata delimiter, bytes[] calldata defaultValue) external returns (bytes[] memory value);
+```
+
+### Description
+
+A non-failing way to read an environment variable of any type: if the requested environment key does not exist, `envOr()` will return a default value instead of reverting (works with arrays too).
+
+The returned type is determined by the type of `defaultValue` parameter passed.
+
+### Tips
+
+- Use `envOr(key, defaultValue)` to read a single value
+- Use `envOr(key, delimiter, defaultValue[])` to read an array with delimiter
+- The parsing of the environment variable will be done according to the type of `defaultValue` (e.g. if the default value type is `uint` - the environment variable will be also parsed as `uint`)
+- Use explicit casting for literals to specify type of default variable: `uint(69)` will return an `uint` but `int(69)` will return an `int`
+- Same with: `string("")` and `bytes("")` - these will return `string` and `bytes` accordingly
+- Use dynamic arrays (`bool[]`) instead of fixed-size arrays (`bool[4]`) when providing default values (only dynamic arrays are supported)
+
+### Examples
+
+#### Single Value
+If the environment variable `FORK` is not set, you can specify it to be `false` by default:
+```solidity
+bool fork = vm.envOr("FORK", false);
+```
+or
+```solidity
+address owner;
+
+function setUp() {
+  owner = vm.envOr("OWNER", address(this));
+}
+```
+
+#### Array
+If the environment variable `BAD_TOKENS` is not set, you can specify the default to be an empty array:
+```solidity
+address[] badTokens;
+
+function envBadTokens() public {
+  badTokens = vm.envOr("BAD_TOKENS", ",", badTokens);
+}
+```
+or
+```solidity
+function envBadTokens() public {
+  address[] memory defaultBadTokens = new address[](0);
+  address[] memory badTokens = vm.envOr("BAD_TOKENS", ",", defaultBadTokens);
+}
+```

--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -5,6 +5,7 @@
 - [`getCode`](./get-code.md)
 - [`getDeployedCode`](./get-deployed-code.md)
 - [`setEnv`](./set-env.md)
+- [`envOr`](./env-or.md)
 - [`envBool`](./env-bool.md)
 - [`envUint`](./env-uint.md)
 - [`envInt`](./env-int.md)


### PR DESCRIPTION
Docs to envOr cheatcode

Description: Issue https://github.com/foundry-rs/foundry/issues/3732
Implementation merged at: PR https://github.com/foundry-rs/foundry/pull/3810

Docs can be merged after the Vm interface (PR: https://github.com/foundry-rs/forge-std/pull/249) is merged to forge-std