### PR TITLE
docs: add debug_traceTransaction method

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -129,7 +129,10 @@ The standard methods are based on [this](https://eth.wiki/json-rpc/API) referenc
 * `eth_feeHistory`
 
 * `eth_getProof`
-  
+
+* `debug_traceTransaction`  
+Use `anvil --steps-tracing` to get `structLogs`  
+
 * `trace_transaction`
   
 * `trace_block`


### PR DESCRIPTION
closes: https://github.com/foundry-rs/book/issues/721

included the debug_traceTransaction method  together with a statement that the --steps-tracing is required to get structLogs