### PR TITLE
Corrected 'cheats' to 'vm'

### DIFF
--- a/src/cheatcodes/start-broadcast.md
+++ b/src/cheatcodes/start-broadcast.md
@@ -30,17 +30,17 @@ function t(uint256 a) public returns (uint256) {
 }
 
 function deployOther() public {
-    cheats.startBroadcast(ACCOUNT_A);
+    vm.startBroadcast(ACCOUNT_A);
     Test test = new Test();
     
     // will trigger a transaction
     test.t(1);
     
-    cheats.stopBroadcast();
+    vm.stopBroadcast();
 
     // broadcast again, this time using a private key from your environment variables
-    cheats.startBroadcast(vm.envUint("PRIVATE_KEY"));
+    vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
     test.t(3);
-    cheats.stopBroadcast();
+    vm.stopBroadcast();
 }
 ```


### PR DESCRIPTION
The keyword 'cheats' doesn't work with the last version of Foundry, it should be replaced by 'vm' in the doc