### PR TITLE
fix: delete extra hyphen in anvil script

### DIFF
--- a/src/tutorials/solidity-scripting.md
+++ b/src/tutorials/solidity-scripting.md
@@ -283,7 +283,7 @@ Start Anvil with the custom mnemonic:
 ```sh
 source .env
 
-anvil --m $MNEMONIC
+anvil -m $MNEMONIC
 ```
 
 Then run the following script:


### PR DESCRIPTION
The command is either `anvil --mnemonic` or `anvil -m`, never `anvil --m`.