### PR TITLE
Fix Slither command

### DIFF
--- a/src/config/static-analyzers.md
+++ b/src/config/static-analyzers.md
@@ -15,21 +15,23 @@ To test your project using [slither](https://github.com/crytic/slither), here is
 ```
 
 Note, you need to update `solc` used by Slither to the same version used by Forge with `solc-select`:
-```ignore
+
+```sh
 pip3 install slither-analyzer
 pip3 install solc-select
 solc-select install 0.8.13
 solc-select use 0.8.13
-slither src/Contract.sol
+slither .
 ```
 
 See the [slither wiki](https://github.com/crytic/slither/wiki/Usage) for more information.
 
 In order to use a custom configuration, such as the sample `slither.config.json` mentioned above, the following command is used as mentioned in the [slither-wiki](https://github.com/crytic/slither/wiki/Usage#configuration-file). By default slither looks for the `slither.config.json` but you can define the path and any other `json` file of your choice:
 
-```sh 
-slither --config-file <path>/file.config.json Counter.sol
+```sh
+slither --config-file <path>/file.config.json .
 ```
+
 Example output (Raw):
 
 ```bash 


### PR DESCRIPTION
## Issue

I tried running Slither on a specific contract, as currently suggested in the Foundry Book:

```sh
slither src/MyContract.sol
```

However, this failed with the following error:

> crytic_compile.platform.exceptions.InvalidCompilation: Solidity version not found:

I double-checked that the Solidity compiler was installed correctly `solc-select`, as indicated in the book. 

## Solution

The only thing made Slither work was to run `slither .` instead. This is also what's [recommended](https://github.com/crytic/slither/tree/7ea572723b4eddb18e716c4ae94e0d2100791127#bugs-and-optimizations-detection) in their README.

The following gets logged as soon as I run `slither .`, suggesting that Slither is aware that my project is a Foundry project and it compiles the code with Forge:

```text
'forge build --extra-output abi --extra-output userdoc --extra-output devdoc --extra-output evm.methodIdentifiers --force' running
```

## Environment

- slither 0.9.1
- pip 22.3.1
- forge 0.2.0 (f959af5 2023-01-06T12:01:47.706731Z)