### PR TITLE
Eip-712 section should cover byte/string encoding

### DIFF
--- a/src/tutorials/testing-eip712.md
+++ b/src/tutorials/testing-eip712.md
@@ -131,6 +131,10 @@ contract SigUtils {
 }
 ```
 
+### Handling Dynamic Values
+
+While the Permit struct passed in the getStructHash() function above doesn't contain any dynamic value types, if you're using them it's important to remember that 'bytes' and 'string' types must be encoded as a 'keccak256' hash of their contents. More on this aspect of the [EIP 712 Spec here](https://github.com/ethereum/EIPs/blob/8061f8e2243eaae829d1fa91f7a763c889aca371/EIPS/eip-712.md?plain=1#L135).
+
 **Setup**
 
 - Deploy a mock ERC-20 token and `SigUtils` helper with the token's EIP-712 domain separator


### PR DESCRIPTION
Dynamic values of the EIP-712 struct hash (ie bytes and string types) must be encoded as a keccak256 hash of their contents. However since this tutorial codebase doesn't involve any bytes/string dynamic values, that aspect of 712 is not covered at all. It should be mentioned since it can confuse devs like me writing eip712 meta-tx contracts.

I wrote a brief informative blurb explaining why it's not shown here, why it's relevant regardless, and then linking to the exact line of the EIP spec gh repo where this is discussed.