### PR TITLE
Update VSCode Default Formatter

### DIFF
--- a/src/config/vscode.md
+++ b/src/config/vscode.md
@@ -31,7 +31,7 @@ To enable the built-in formatter that comes with Foundry to automatically format
 {
   "editor.formatOnSave": true,
   "[solidity]": {
-    "editor.defaultFormatter": "JuanBlanco.vscode-solidity" 
+    "editor.defaultFormatter": "JuanBlanco.solidity" 
   },
   "solidity.formatter": "forge",
 }


### PR DESCRIPTION
Hello,

The Solidity extension by JuanBlanco seems to have updated, and the default formatter for the solidity language on VSCode now accepts `JuanBlanco.solidity` instead of `JuanBlanco.vscode-solidity`

Thanks.