### PR TITLE
Remove "solc_remaps" in Slither config

### DIFF
--- a/src/config/static-analyzers.md
+++ b/src/config/static-analyzers.md
@@ -6,13 +6,11 @@ To test your project using [slither](https://github.com/crytic/slither), here is
 
 ```json
 {
-  "filter_paths": "lib",
-  "solc_remaps": [
-    "ds-test/=lib/ds-test/src/",
-    "forge-std/=lib/forge-std/src/"
-  ]
+  "filter_paths": "lib"
 }
 ```
+
+You do not need to provide remappings via the `solc_remaps` option as Slither will automatically detect remappings in a Foundry project.
 
 Note, you need to update `solc` used by Slither to the same version used by Forge with `solc-select`:
 


### PR DESCRIPTION
As indicated by a Slither maintainer in this [comment](https://github.com/crytic/slither/issues/1421#issuecomment-1383280980), Foundry users don't have to provide the remappings via the `solc_remaps` option anymore. Slither automatically detects the remappings in a Foundry project now.