### PR TITLE
Be more specific in "call_override" explainer

### DIFF
--- a/src/reference/config/testing.md
+++ b/src/reference/config/testing.md
@@ -404,7 +404,7 @@ Fails the invariant fuzzing if a revert occurs.
 - Default: false
 - Environment: `FOUNDRY_INVARIANT_CALL_OVERRIDE`
 
-Allows overriding an unsafe external call when running invariant tests. eg. reentrancy checks.
+Overrides unsafe external calls when running invariant tests, useful for e.g. performing reentrancy checks.
 
 ##### `dictionary_weight`
 


### PR DESCRIPTION
The current wording is a bit ambiguous - it's not clear if the reference is about the user's own reentrancy checks, or if Foundry performs the reentrancy checks by setting `call_override` to `true`.