### PR TITLE
Update invariant-testing.md

### DIFF
--- a/src/forge/invariant-testing.md
+++ b/src/forge/invariant-testing.md
@@ -371,6 +371,12 @@ function deposit(uint256 assets) public virtual {
     assertEq(asset.balanceOf(address(this)), beforeBalance - assets);
 
     sumBalanceOf += shares;
+
+    // We can also check the previously mentioned `totalSupply == sumBalanceOf` invariant here
+    assertEq(token.totalSupply(), sumBalanceOf);
+
+    // Another invariant: the shares and deposited assets should remain in 1:1 ratio
+    assertEq(sumBalanceOf, asset.balanceOf(address(token)));
 }
 ```
 

--- a/src/forge/invariant-testing.md
+++ b/src/forge/invariant-testing.md
@@ -453,11 +453,11 @@ function deposit(
 
     asset.approve(address(token), assets);
 
-    uint256 beforeBalance = asset.balanceOf(address(this));
+    uint256 beforeBalance = asset.balanceOf(currentActor);
 
     uint256 shares = token.deposit(assets, address(this));
 
-    assertEq(asset.balanceOf(address(this)), beforeBalance - assets);
+    assertEq(asset.balanceOf(currentActor), beforeBalance - assets);
 
     sumBalanceOf += shares;
 


### PR DESCRIPTION
The balance is deducted from msg.sender, which is `currentActor`