### PR TITLE
Update anvil docs given `debug_traceCall`

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -133,6 +133,9 @@ The standard methods are based on [this](https://eth.wiki/json-rpc/API) referenc
 * `debug_traceTransaction`  
 Use `anvil --steps-tracing` to get `structLogs`  
 
+* `debug_traceCall`
+Note that non-standard traces are not yet support.  This means you can't pass any arguments to the `trace` parameter.
+
 * `trace_transaction`
   
 * `trace_block`


### PR DESCRIPTION
Hi, 

I wanted to use `debug_traceCall` with `tracer = 'callTracer'`, and based on this PR, https://github.com/foundry-rs/foundry/pull/3990, I thought it might be supported.

Alas, I'm getting a blocking error `non-default tracer not supported yet`. 

I'm sending this PR to the docs to either help future users and/or get clarity myself.

I'm a bit confused by...

```
if opts.tracer.is_some() {
     return Err(RpcError::invalid_params("non-default tracer not supported yet").into())
}
```
 
Does this mean `tracer` cannot be set at all?  

Should I be able to use  `debug_traceCall` in Avil against a forked mainnet, *on an unmined transaction*?  

