### PR TITLE
forge-coverage overview created

### DIFF
--- a/src/reference/forge/forge-coverage.md
+++ b/src/reference/forge/forge-coverage.md
@@ -1,0 +1,55 @@
+## forge coverage
+
+### NAME
+
+forge-coverage - Displays which parts of your code are covered by tests.
+
+### SYNOPSIS
+
+`forge coverage` [*options*]
+
+### DESCRIPTION
+
+Displays which parts of your code are covered by tests.
+
+### Options
+
+#### Report Options
+
+`--report` allows you to specify the report type to use for coverage. This flag can be used multiple times.
+
+It has three different options and is set to `summary` by default.
+
+`summary`  
+&nbsp;&nbsp;&nbsp;&nbsp;Outputs a chart showing what percentage of your code is covered by tests.
+
+`lcov`  
+&nbsp;&nbsp;&nbsp;&nbsp;Creates a lcov.info file containing your coverage data in the root of your project's directory.
+
+`debug`  
+&nbsp;&nbsp;&nbsp;&nbsp;Outputs lines describing the location of uncovered code.
+
+{{#include common-options.md}}
+
+### EXAMPLES
+
+1. View summarized coverage:
+
+   ```sh
+   forge coverage
+   ```
+
+2. Create lcov file with coverage data:
+
+   ```sh
+   forge coverage --report lcov
+   ```
+
+3. Output uncovered code locations:
+   ```sh
+   forge coverage --report debug
+   ```
+
+### SEE ALSO
+
+[forge](./forge.md), [forge test](./forge-test.md)


### PR DESCRIPTION
- Created `forge-coverage.md` inside src/reference/forge containing brief overview of the command.
- Examples for each of the `--report` options.
- The `common-options.md` included under reporting options.