### PR TITLE
Fix variable names used in config for test matching

### DIFF
--- a/src/reference/config/testing.md
+++ b/src/reference/config/testing.md
@@ -194,57 +194,59 @@ The url of the rpc server that should be used for any rpc calls.
 
 The etherscan API key for RPC calls.
 
-##### `test_pattern`
+##### `match-test`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_TEST_PATTERN` or `DAPP_TEST_PATTERN`
+- Environment: `FOUNDRY_MATCH_TEST` or `DAPP_MATCH_TEST`
 
 Only run test methods matching regex.
 Equivalent to `forge test --match-test <TEST_PATTERN>`
 
-##### `test_pattern_inverse`
+##### `no-match-test`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_TEST_PATTERN_INVERSE` or `DAPP_TEST_PATTERN_INVERSE`
+- Environment: `FOUNDRY_NO_MATCH_TEST` or `DAPP_NO_MATCH_TEST`
 
 Only run test methods not matching regex.
 Equivalent to `forge test --no-match-test <TEST_PATTERN_INVERSE>`
 
-##### `contract_pattern`
+##### `match-contract`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_CONTRACT_PATTERN` or `DAPP_CONTRACT_PATTERN`
+- Environment: `FOUNDRY_MATCH_CONTRACT` or `DAPP_MATCH_CONTRACT`
 
 Only run test methods in contracts matching regex.
 Equivalent to `forge test --match-contract <CONTRACT_PATTERN>`
 
-##### `contract_pattern_inverse`
+##### `no-match-contract`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_CONTRACT_PATTERN_INVERSE` or `DAPP_CONTRACT_PATTERN_INVERSE`
+- Environment: `FOUNDRY_NO_MATCH_CONTRACT` or `DAPP_NO_MATCH_CONTRACT`
 
 Only run test methods in contracts not matching regex.
 Equivalent to `forge test --no-match-contract <CONTRACT_PATTERN_INVERSE>`
 
-##### `path_pattern`
+##### `match-path`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_PATH_PATTERN` or `DAPP_PATH_PATTERN`
+- Environment: `FOUNDRY_MATCH_PATH` or `DAPP_MATCH_PATH`
 
 Only runs test methods on files matching the path.
+Equivalent to `forge test --match-path <PATH_PATTERN>`
 
-##### `path_pattern_inverse`
+##### `no-match-path`
 
 - Type: regex
 - Default: none
-- Environment: `FOUNDRY_PATH_PATTERN_INVERSE` or `DAPP_PATH_PATTERN_INVERSE`
+- Environment: `FOUNDRY_NO_MATCH_PATH` or `DAPP_NO_MATCH_PATH`
 
 Only runs test methods on files not matching the path.
+Equivalent to `forge test --no-match-path <PATH_PATTERN_INVERSE>`
 
 ##### `block_gas_limit`
 


### PR DESCRIPTION
The config variable names in the documentation do not work for matching tests/contracts/paths when trying to run tests. 

The naming that works is the same as the command line flag (e.g. `match-contract` rather than `contract-pattern`).

This PR changes those variable names in the documentation, both for the foundry.toml config and the ENV variables referenced:

### Foundry.toml Config
- `test-pattern` -> `match-test`
- `test-pattern-inverse` -> `no-match-test`
- `contract-pattern` -> `match-contract`
- `contract-pattern-inverse` -> `no-match-contract`
- `path-pattern` -> `match-path`
- `path-pattern-inverse` -> `no-match-path`

### ENV variables (with both the FOUNDRY and DAPP prefixes):
- `_TEST_PATTERN ` -> `_MATCH_TEST`
- `_TEST_PATTERN_INVERSE` -> `_NO_MATCH_TEST`
- `_CONTRACT_PATTERN ` -> `_MATCH_CONTRACT`
- `_CONTRACT_PATTERN_INVERSE` -> `_NO_MATCH_CONTRACT`
- `_PATH_PATTERN ` -> `MATCH_PATH`
- `_PATH_PATTERN_INVERSE` -> `_NO_MATCH_PATH`
