### PR TITLE
remove actual/expected, now left/right is used

### DIFF
--- a/src/tutorials/best-practices.md
+++ b/src/tutorials/best-practices.md
@@ -96,10 +96,7 @@ Additional best practices from [samsczun](https://twitter.com/samczsun)'s [How D
    - `testFork_Description` for tests that fork from a network.
    - `testForkFuzz_Revert[If|When]_Condition` for a fuzz test that forks and expects a revert.
 
-1. When using assertions like `assertEq`:
-
-   - Consider leveraging the last string param to make it easier to identify failures. These can be kept brief, or even just be numbers&mdash;they basically serve as a replacement for showing line numbers of the revert, e.g. `assertEq(x, y, "1")` or `assertEq(x, y, "sum1")`. _(Note: [foundry-rs/foundry#2328](https://github.com/foundry-rs/foundry/issues/2328) tracks integrating this natively)._
-   - Forge expects the order of `assertEq` arguments to be `assertEq(actual, expected)`, and will use those terms in logs when there's an assertion failure. You can remember this order because it's alphabetical: "**a**ctual" comes before "**e**xpected".
+1. When using assertions like `assertEq`, consider leveraging the last string param to make it easier to identify failures. These can be kept brief, or even just be numbers&mdash;they basically serve as a replacement for showing line numbers of the revert, e.g. `assertEq(x, y, "1")` or `assertEq(x, y, "sum1")`. _(Note: [foundry-rs/foundry#2328](https://github.com/foundry-rs/foundry/issues/2328) tracks integrating this natively)._
 
 1. When testing events, prefer setting all `expectEmit` arguments to `true`, i.e. `vm.expectEmit(true, true, true, true)`. Benefits:
 


### PR DESCRIPTION
Per https://github.com/foundry-rs/forge-std/pull/290, failed assertions now use `left` and `right` like rust assertions, so this is now outdated 

(technically this is not true until forge-std v1.5.0 is released, which I'm planned to do later today)