### PR TITLE
Fix default depth in invariant runs from 256 to 15

### DIFF
--- a/src/reference/config/testing.md
+++ b/src/reference/config/testing.md
@@ -387,7 +387,7 @@ The number of runs that must execute for each invariant test group. See also [fu
 ##### `depth`
 
 - Type: integer
-- Default: 256
+- Default: 15
 - Environment: `FOUNDRY_INVARIANT_DEPTH`
 
 The number of calls executed to attempt to break invariants in one run.


### PR DESCRIPTION
Default depth can be double checked here:
https://github.com/foundry-rs/foundry/blob/master/config/src/invariant.rs#L27

Edit:
Commits to foundry-rs changed the line that initializes the default depth. Prev line 30, now it is on line 27.
Default depth is still 15 though.