### PR TITLE
`deal` instead of `vm.deal`

### DIFF
--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -30,7 +30,7 @@ log_uint256(alice.balance); // 1000000000000000000
 
 ```solidity
 address alice = address(1);
-deal(address(DAI), alice, 1 ether);
+deal(address(DAI), alice, 1 ether); // import StdUtils.sol first
 log_uint256(address(DAI).balanceOf(alice); // 1000000000000000000
 ```
 

--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -30,7 +30,7 @@ log_uint256(alice.balance); // 1000000000000000000
 
 ```solidity
 address alice = address(1);
-vm.deal(address(DAI), alice, 1 ether);
+deal(address(DAI), alice, 1 ether);
 log_uint256(address(DAI).balanceOf(alice); // 1000000000000000000
 ```
 


### PR DESCRIPTION
`deal` for dealing out ERC20 tokens is out of `StdUtils.sol` and not a native cheat implemented in Foundry itself. @PaulRBerg thanks for the clarification.