### PR TITLE
Fixed the code for the ExampleContract1 contract

### DIFF
--- a/src/forge/invariant-testing.md
+++ b/src/forge/invariant-testing.md
@@ -168,9 +168,9 @@ The default configuration for target contracts is set to all contracts that are 
 ```solidity
 contract ExampleContract1 {
 
-    uint256 val1;
-    uint256 val2;
-    uint256 val3;
+    uint256 public val1;
+    uint256 public val2;
+    uint256 public val3;
 
     function addToA(uint256 amount) external {
         val1 += amount;


### PR DESCRIPTION
The variables in ExampleContract1 should be public, otherwise compiling in InvariantExample1 will fail.