### PR TITLE
Update get-recorded-logs.md

### DIFF
--- a/src/cheatcodes/get-recorded-logs.md
+++ b/src/cheatcodes/get-recorded-logs.md
@@ -6,6 +6,7 @@
 struct Log {
   bytes32[] topics;
   bytes data;
+  address emitter;
 }
 
 function getRecordedLogs()


### PR DESCRIPTION
The Log struct in Vm.sol has an emitter property, however, it doesn't have it in the docs 
https://github.com/foundry-rs/forge-std/blob/master/src/Vm.sol#L16
https://book.getfoundry.sh/cheatcodes/get-recorded-logs