### PR TITLE
Fix `--contracts` and `--remappings` shortcut in `project-options`

### DIFF
--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -9,7 +9,7 @@
 `--root` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The project's root path. By default, this is the root directory of the current git repository, or the current working directory.
 
-`-c` *path*  
+`-C` *path*  
 `--contracts` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The contracts source directory.  
 &nbsp;&nbsp;&nbsp;&nbsp;Environment: `DAPP_SRC`

--- a/src/reference/forge/project-options.md
+++ b/src/reference/forge/project-options.md
@@ -17,7 +17,7 @@
 `--lib-paths` *path*  
 &nbsp;&nbsp;&nbsp;&nbsp;The path to the library folder.
 
-`-r` *remappings*  
+`-R` *remappings*  
 `--remappings` *remappings*  
 &nbsp;&nbsp;&nbsp;&nbsp;The project's remappings.
 


### PR DESCRIPTION
As title. If you run `forge test --help ` you will see that they changed the shortcuts to capital letters:

```bash
Project options:
      --root <PATH>
          The project's root path.

          By default root of the Git repository, if in one, or the current working directory.

  -C, --contracts <PATH>
          The contracts source directory

  -R, --remappings <REMAPPINGS>
          The project's remappings
```