### PR TITLE
Add no args expectEmit to testing best practices

### DIFF
--- a/src/tutorials/best-practices.md
+++ b/src/tutorials/best-practices.md
@@ -100,7 +100,7 @@ Additional best practices from [samsczun](https://twitter.com/samczsun)'s [How D
 
 1. When using assertions like `assertEq`, consider leveraging the last string param to make it easier to identify failures. These can be kept brief, or even just be numbers&mdash;they basically serve as a replacement for showing line numbers of the revert, e.g. `assertEq(x, y, "1")` or `assertEq(x, y, "sum1")`. _(Note: [foundry-rs/foundry#2328](https://github.com/foundry-rs/foundry/issues/2328) tracks integrating this natively)._
 
-1. When testing events, prefer setting all `expectEmit` arguments to `true`, i.e. `vm.expectEmit(true, true, true, true)`. Benefits:
+1. When testing events, prefer setting all `expectEmit` arguments to `true`, i.e. `vm.expectEmit(true, true, true, true)` or `vm.expectEmit()`. Benefits:
 
    - This ensures you test everything in your event.
    - If you add a topic (i.e. a new indexed parameter), it's now tested by default.


### PR DESCRIPTION
#### Description

- On the best practices page, using `vm.expectEmit(true, true, true, true)` is given, and I thought it would be a good idea to highlight the more concise version `vm.expectEmit()` as well.