### PR TITLE
Add Precompile Documentation and Registry

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -311,6 +311,8 @@
       - [`makeAddr`](./reference/forge-std/make-addr.md)
       - [`makeAddrAndKey`](./reference/forge-std/make-addr-and-key.md)
       - [`noGasMetering`](./reference/forge-std/noGasMetering.md)
+      - [`assumeNoPrecompiles`](./reference/forge-std/assume-no-precompiles.md)
+      - [`assumePayable`](./reference/forge-std/assume-payable.md)
     - [Std Errors](./reference/forge-std/std-errors.md)
       - [`assertionError`](./reference/forge-std/assertionError.md)
       - [`arithmeticError`](./reference/forge-std/arithmeticError.md)
@@ -340,3 +342,4 @@
   - [DSTest Reference](./reference/ds-test.md)
 - [Miscellaneous](./misc/README.md)
   - [Struct encoding](./misc/struct-encoding.md)
+  - [Precompile Registry](./misc/precompile-registry.md)

--- a/src/misc/README.md
+++ b/src/misc/README.md
@@ -1,3 +1,4 @@
 ## Miscellaneous
 
 - [Struct encoding](./struct-encoding.md)
+- [Precompile Registry](./precompile-registry.md)

--- a/src/misc/precompile-registry.md
+++ b/src/misc/precompile-registry.md
@@ -1,0 +1,60 @@
+## Precompile Registry
+
+Precompiles are special contracts at fixed addresses that are included within the EVM. In addition to common precompiles included with other EVM environments, Foundry includes a few precompiles for environment mutation, logging data, and contract deployment.
+
+Note that, while some chains like Optimism have bytecode deployed at a predetermined address, making them 'pre-deploys', we treat them as precompiles within the context of Foundry.
+
+### Registry
+
+| Chain ID      | Address                                      | Name                             |
+| ------------- | -------------------------------------------- | -------------------------------- |
+| ALL           | `0x01`                                       | ECRecover                        |
+| ALL           | `0x02`                                       | SHA-256                          |
+| ALL           | `0x03`                                       | RIPEMD-160                       |
+| ALL           | `0x04`                                       | Identity                         |
+| ALL           | `0x05`                                       | ModExp                           |
+| ALL           | `0x06`                                       | ECAdd                            |
+| ALL           | `0x07`                                       | ECMul                            |
+| ALL           | `0x08`                                       | ECPairing                        |
+| ALL           | `0x09`                                       | Blake2F                          |
+| 10, 420       | `0x4200000000000000000000000000000000000016` | L2ToL1MessagePasser              |
+| 10, 420       | `0x4200000000000000000000000000000000000002` | DeployerWhitelist                |
+| 10, 420       | `0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000` | LegacyERC20ETH                   |
+| 10, 420       | `0x4200000000000000000000000000000000000006` | WETH9                            |
+| 10, 420       | `0x4200000000000000000000000000000000000007` | L2CrossDomainMessenger           |
+| 10, 420       | `0x4200000000000000000000000000000000000010` | L2StandardBridge                 |
+| 10, 420       | `0x4200000000000000000000000000000000000011` | SequencerFeeVault                |
+| 10, 420       | `0x4200000000000000000000000000000000000012` | OptimismMintableERC20Factory     |
+| 10, 420       | `0x4200000000000000000000000000000000000013` | L1BlockNumber                    |
+| 10, 420       | `0x420000000000000000000000000000000000000F` | GasPriceOracle                   |
+| 10, 420       | `0x4200000000000000000000000000000000000015` | L1Block                          |
+| 10, 420       | `0x4200000000000000000000000000000000000042` | GovernanceToken                  |
+| 10, 420       | `0x4200000000000000000000000000000000000000` | LegacyMessagePasser              |
+| 10, 420       | `0x4200000000000000000000000000000000000014` | L2ERC721Bridge                   |
+| 10, 420       | `0x4200000000000000000000000000000000000017` | OptimismMintableERC721Factory    |
+| 10, 420       | `0x4200000000000000000000000000000000000018` | ProxyAdmin                       |
+| 42161, 421613 | `0x0000000000000000000000000000000000000064` | ArbSys                           |
+| 42161, 421613 | `0x000000000000000000000000000000000000006E` | ArbRetryableTx                   |
+| 42161, 421613 | `0x000000000000000000000000000000000000006C` | ArbGasInfo                       |
+| 42161, 421613 | `0x0000000000000000000000000000000000000066` | ArbAddressTable                  |
+| 42161, 421613 | `0x000000000000000000000000000000000000006F` | ArbStatistics                    |
+| 42161, 421613 | `0x00000000000000000000000000000000000000C8` | NodeInterface                    |
+| 42161, 421613 | `0x0000000000000000000000000000000000000067` | ArbBLS                           |
+| 42161, 421613 | `0x0000000000000000000000000000000000000065` | ArbInfo                          |
+| 42161, 421613 | `0x000000000000000000000000000000000000006D` | ArbAggregator                    |
+| 42161, 421613 | `0x0000000000000000000000000000000000000068` | ArbFunctionTable                 |
+| 433114, 43113 | `0x0200000000000000000000000000000000000000` | ContractDeployerAllowListAddress |
+| 433114, 43113 | `0x0200000000000000000000000000000000000001` | ContractNativeMinterAddress      |
+| 433114, 43113 | `0x0200000000000000000000000000000000000002` | TxAllowListAddress               |
+| 433114, 43113 | `0x0200000000000000000000000000000000000003` | FeeConfigManagerAddress          |
+
+### Reserved Ranges
+
+Some chains also include reserved ranges for precompile contracts.
+
+| Chain ID      | Start                                        | Stop                                         |
+| ------------- | -------------------------------------------- | -------------------------------------------- |
+| ALL           | `0x00`                                       | `0xff`                                       |
+| 433114, 43113 | `0x0100000000000000000000000000000000000000` | `0x01000000000000000000000000000000000000ff` |
+| 433114, 43113 | `0x0200000000000000000000000000000000000000` | `0x02000000000000000000000000000000000000ff` |
+| 433114, 43113 | `0x0300000000000000000000000000000000000000` | `0x03000000000000000000000000000000000000ff` |

--- a/src/misc/precompile-registry.md
+++ b/src/misc/precompile-registry.md
@@ -47,6 +47,9 @@ Note that, while some chains like Optimism have bytecode deployed at a predeterm
 | 433114, 43113 | `0x0200000000000000000000000000000000000001` | ContractNativeMinterAddress      |
 | 433114, 43113 | `0x0200000000000000000000000000000000000002` | TxAllowListAddress               |
 | 433114, 43113 | `0x0200000000000000000000000000000000000003` | FeeConfigManagerAddress          |
+| ALL           | `0x04E59B44847b37957858892cA78fBf26C0b4956C` | (Foundry) Create2Deployer        |
+| ALL           | `0x7109709ECfa91a80626fF3989D68f67F5b1DD12D` | (Foundry) VM                     |
+| ALL           | `0x000000000000000000636F6e736F6c652e6c6f67` | (Foundry) Console                |
 
 ### Reserved Ranges
 

--- a/src/reference/forge-std/assume-no-precompiles.md
+++ b/src/reference/forge-std/assume-no-precompiles.md
@@ -1,0 +1,21 @@
+## `assumeNoPrecompiles`
+
+### Signature
+
+```solidity
+function assumeNoPrecompiles(address addr) public;
+```
+
+```solidity
+function assumeNoPrecompiles(address addr, uint256 chainid) public;
+```
+
+### Description
+
+Uses [`assume`](../../cheatcodes/assume.md) to filter precompile addresses from the fuzz tests.
+
+Optionally, a `chainid` may be specified to filter known precompiles on the repsective chain.
+
+### SEE ALSO
+
+[Precompile Registry](../../misc/precompile-registry.md)

--- a/src/reference/forge-std/assume-payable.md
+++ b/src/reference/forge-std/assume-payable.md
@@ -1,0 +1,13 @@
+## `assumePayable`
+
+### Signature
+
+```solidity
+function assumePayable(address addr) public;
+```
+
+### Description
+
+Uses [`assume`](../../cheatcodes/assume.md) to filter addresses that reject Ether transfers.
+
+This makes an external call to the specified `addr` with a no calldata and checks `assume` against the success of the call.


### PR DESCRIPTION
Adds the precompile registry to document addresses that are either reserved or exhibit potentially unexpected behavior for testing purposes.

Additionally, an entry for `assumePayable` was added.

Previously, these cheats and the precompile addresses appeared to be undocumented.