### PR TITLE
enhance: add clarity to the set of valid inputs for anvil --hardfork

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -269,7 +269,7 @@ Returns the details of all transactions currently pending for inclusion in the n
 &nbsp;&nbsp;&nbsp;&nbsp; Print help information
 
 `--hardfork <HARDFORK>`  
-&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use [default: latest]
+&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use (must specify a hardfork name like `paris` or use `latest`) [default: latest]
 
 `--init <PATH>`  
 &nbsp;&nbsp;&nbsp;&nbsp; Initialize the genesis block with the given `genesis.json` file.

--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -269,7 +269,9 @@ Returns the details of all transactions currently pending for inclusion in the n
 &nbsp;&nbsp;&nbsp;&nbsp; Print help information
 
 `--hardfork <HARDFORK>`  
-&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use (must specify a hardfork name like `paris` or use `latest`) [default: latest]
+&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use 
+&nbsp;&nbsp;&nbsp;&nbsp; Choose the hardfork by name, e.g. `shanghai`, `paris`, `london`, etc...
+&nbsp;&nbsp;&nbsp;&nbsp; [default: latest]
 
 `--init <PATH>`  
 &nbsp;&nbsp;&nbsp;&nbsp; Initialize the genesis block with the given `genesis.json` file.


### PR DESCRIPTION
as a user, I was genuinely confused what were the valid inputs to `anvil --hardfork`, specifically because the example was for the default `latest`. i wasn't sure if it should be capitalized like `Shanghai` or just `shanghai`, or if it didn't matter.

<img width="617" alt="image" src="https://github.com/foundry-rs/book/assets/13951458/61090ba7-97b2-4415-b173-dfb796ab69ac">

an additionally nice feature could be to improve the error message to not only say `Unknown hardfork shanghai` but `Unknown hardfork shanghai. Currently supported hardforks are london|paris|shanghai|latest` etc., or something in that spirit.