### PR TITLE
Update `signingExample.purchase()` call in sign.md

### DIFF
--- a/src/cheatcodes/sign.md
+++ b/src/cheatcodes/sign.md
@@ -96,8 +96,8 @@ contract SigningExampleTest is Test {
 
         signingExample.purchase(
             amount,
-            nonce
-            signature,
+            nonce,
+            signature
         );
         vm.stopPrank();
     }


### PR DESCRIPTION
Wrong placement of argument separator "," `signingExample.purchase()` in function call.