### PR TITLE
fix(docs): add missing flag to example

### DIFF
--- a/src/tutorials/forking-mainnet-with-cast-anvil.md
+++ b/src/tutorials/forking-mainnet-with-cast-anvil.md
@@ -48,6 +48,7 @@ Let's transfer some tokens from the lucky user to Alice using [`cast send`][cast
 # This calls Anvil and lets us impersonate our lucky user
 $ cast rpc anvil_impersonateAccount $LUCKY_USER
 $ cast send $DAI \
+--unlocked \
 --from $LUCKY_USER \
   "transfer(address,uint256)(bool)" \
   $ALICE \


### PR DESCRIPTION
Since https://github.com/foundry-rs/foundry/pull/4874 the `--from` flag only works in combination with the `--unlocked` flag.  This commit adds the missing `--unlocked` flag to an example that is using `--from`.