### PR TITLE
add cast-create2 to utility-commands.md

### DIFF
--- a/src/reference/cast/utility-commands.md
+++ b/src/reference/cast/utility-commands.md
@@ -4,6 +4,7 @@
 - [cast sig-event](./cast-sig-event.md)
 - [cast keccak](./cast-keccak.md)
 - [cast compute-address](./cast-compute-address.md)
+- [cast create2](./cast-create2.md)
 - [cast interface](./cast-interface.md)
 - [cast index](./cast-index.md)
 - [cast --concat-hex](./cast--concat-hex.md)


### PR DESCRIPTION
add create2 to utility commands dropdown
currently doesn't show up per img below
<img width="886" alt="image" src="https://github.com/foundry-rs/book/assets/39510610/46703d52-be9d-470e-93b8-414bcaf66fc4">
