### PR TITLE
docs: update book to include 'forge inspect --pretty <contract> abi' example

### DIFF
--- a/src/reference/forge/forge-inspect.md
+++ b/src/reference/forge/forge-inspect.md
@@ -50,6 +50,11 @@ The field to inspect (*field*) can be any of:
     forge inspect MyContract storage
     ```
 
+3. Inspect the abi of a contract in a pretty format:
+   ```sh 
+   forge inspect --pretty MyContract abi
+   ```
+
 ### SEE ALSO
 
 [forge](./forge.md), [forge build](./forge-build.md)


### PR DESCRIPTION
This change provides an example using `forge inspect --pretty <contract> abi` included in https://github.com/foundry-rs/foundry/pull/5306