### PR TITLE
Document forge verify-contract --show-standard-json-input option

### DIFF
--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -68,6 +68,9 @@ you can specify a file containing **space-separated** constructor arguments with
 
 {{#include ../common/retry-options.md}}
 
+`--show-standard-json-input`  
+&nbsp;&nbsp;&nbsp;&nbsp;Command outputs JSON suitable for saving to a file and uploading to block explorers for verification.
+
 `--watch`  
 &nbsp;&nbsp;&nbsp;&nbsp;Wait for verification result after submission.  
 &nbsp;&nbsp;&nbsp;&nbsp;Automatically runs `forge verify-check` until the verification either fails or succeeds.


### PR DESCRIPTION
I found this option in this issue - https://github.com/foundry-rs/foundry/issues/3507

This was helpful for verifying a contract on Zora's blockscout based explorer.

I don't really know where this standard comes from or anything about it, so hoping someone more knowledgeable is willing to take this over the finish line.