### PR TITLE
feature(`reference`): forge verify contract Blockscout URL bug fix

### DIFF
--- a/src/reference/common/verifier-options.md
+++ b/src/reference/common/verifier-options.md
@@ -1,5 +1,5 @@
 `--verifier` *name*   
-&nbsp;&nbsp;&nbsp;&nbsp;The verification provider. Available options: `etherscan`, `sourcify` & `blockscout`. Default: `etherscan`.
+&nbsp;&nbsp;&nbsp;&nbsp;The verification provider. Available options: `etherscan`, `sourcify` & `blockscout`. Default: `etherscan`. Note: make sure you add "/api\?" to the end of the Blockscout homepage explorer URL.
 
 `--verifier-url` *url*  
 &nbsp;&nbsp;&nbsp;&nbsp;The optional verifier url for submitting the verification request.  

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -107,7 +107,11 @@ you can specify a file containing **space-separated** constructor arguments with
     ```text
     ForgeUSD FUSD 18 1000000000000000000000
     ```
-
+    
+5. Verify a contract with Blockscout right after deployment (make sure you add "/api\?" to the end of the Blockscout homepage explorer URL)
+    ```sh
+    forge create --rpc-url <rpc_https_endpoint> --private-key $devTestnetPrivateKey src/Contract.sol:SimpleStorage --verify --verifier blockscout --verifier-url <blockscout_homepage_explorer_url>/api\? 
+    ```
 
 ### SEE ALSO
 

--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -108,7 +108,7 @@ you can specify a file containing **space-separated** constructor arguments with
     ForgeUSD FUSD 18 1000000000000000000000
     ```
     
-5. Verify a contract with Blockscout right after deployment (make sure you add "/api\?" to the end of the Blockscout homepage explorer URL)
+5. Verify a contract with Blockscout right after deployment (make sure you add "/api\?" to the end of the Blockscout homepage explorer URL):
     ```sh
     forge create --rpc-url <rpc_https_endpoint> --private-key $devTestnetPrivateKey src/Contract.sol:SimpleStorage --verify --verifier blockscout --verifier-url <blockscout_homepage_explorer_url>/api\? 
     ```


### PR DESCRIPTION
Documentation to fix Blockscout contract verification bug suggested here:
https://github.com/foundry-rs/foundry/issues/5160#issuecomment-1599602416