### PR TITLE
Deprecate vm.addr() from examples declaring new addresses for 'alice'

### DIFF
--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -23,13 +23,15 @@ If the alternative signature of `deal` is used, then we can additionally specify
 ### Examples
 
 ```solidity
-address alice = address(1);
+address alice = makeAddr("alice");
+emit log_address(alice);
 vm.deal(alice, 1 ether);
 log_uint256(alice.balance); // 1000000000000000000
 ```
 
 ```solidity
-address alice = address(1);
+address alice = makeAddr("alice");
+emit log_address(alice);
 deal(address(DAI), alice, 1 ether); // import StdUtils.sol first
 log_uint256(address(DAI).balanceOf(alice); // 1000000000000000000
 ```

--- a/src/cheatcodes/etch.md
+++ b/src/cheatcodes/etch.md
@@ -14,7 +14,7 @@ Sets the bytecode of an address `who` to `code`.
 
 ```solidity
 bytes memory code = address(awesomeContract).code;
-address targetAddr = address(1);
+address targetAddr = makeAddr("target");
 vm.etch(targetAddr, code);
 log_bytes(address(targetAddr).code); // 0x6080604052348015610010...
 ```

--- a/src/cheatcodes/expect-call.md
+++ b/src/cheatcodes/expect-call.md
@@ -49,7 +49,8 @@ If the test terminates without the call being made, the test fails.
 Expect that `transfer` is called on a token `MyToken` one time:
 
 ```solidity
-address alice = address(10);
+address alice = makeAddr("alice");
+emit log_address(alice);
 vm.expectCall(
   address(token), abi.encodeCall(token.transfer, (alice, 10))
 );
@@ -60,7 +61,8 @@ token.transfer(alice, 10);
 Expect that `transfer` is called on a token `MyToken` *at least* two times:
 
 ```solidity
-address alice = address(10);
+address alice = makeAddr("alice");
+emit log_address(alice);
 vm.expectCall(
   address(token), abi.encodeCall(token.transfer, (alice, 10))
 );
@@ -76,7 +78,8 @@ token.transfer(alice, 10);
 Expect that `transfer` is not called on a token `MyToken`:
 
 ```solidity
-address alice = address(10);
+address alice = makeAddr("alice");
+emit log_address(alice);
 vm.expectCall(
   address(token), abi.encodeCall(token.transfer, (alice, 10)), 0
 );
@@ -87,7 +90,8 @@ token.transferFrom(alice, address(0), 10);
 Expect that `transfer` with any calldata is called on a token `MyToken` 2 times:
 
 ```solidity
-address alice = address(10);
+address alice = makeAddr("alice");
+emit log_address(alice);
 vm.expectCall(
   address(token), abi.encodeWithSelector(token.transfer), 2
 );

--- a/src/cheatcodes/sign.md
+++ b/src/cheatcodes/sign.md
@@ -15,7 +15,8 @@ This is useful for testing functions that take signed data and perform an `ecrec
 ### Examples
 
 ```solidity
-address alice = vm.addr(1);
+address alice = makeAddr("alice");
+emit log_address(alice);
 bytes32 hash = keccak256("Signed by Alice");
 (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, hash);
 address signer = ecrecover(hash, v, r, s);


### PR DESCRIPTION
Alice deserves better