### PR TITLE
docs: `assumeNoPrecompiles` -> `assumeNotPrecompile`

### DIFF
--- a/src/reference/forge-std/assume-no-precompiles.md
+++ b/src/reference/forge-std/assume-no-precompiles.md
@@ -1,13 +1,13 @@
-## `assumeNoPrecompiles`
+## `assumeNotPrecompile`
 
 ### Signature
 
 ```solidity
-function assumeNoPrecompiles(address addr) public;
+function assumeNotPrecompile(address addr) public;
 ```
 
 ```solidity
-function assumeNoPrecompiles(address addr, uint256 chainid) public;
+function assumeNotPrecompile(address addr, uint256 chainid) public;
 ```
 
 ### Description


### PR DESCRIPTION
There was a breaking change in
https://github.com/foundry-rs/forge-std/pull/407 which renamed `assumeNoPrecompiles()` to `assumeNotPrecompile`.