### PR TITLE
Add more links in docs for forge coverage

### DIFF
--- a/src/reference/forge/forge.md
+++ b/src/reference/forge/forge.md
@@ -69,6 +69,9 @@ This program is a set of tools to build, test, fuzz, debug and deploy Solidity s
 [forge snapshot](./forge-snapshot.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;Create a snapshot of each test's gas usage.
 
+[forge coverage](./forge-coverage.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;Generate coverage reports.
+
 #### Deploy Commands
 
 [forge create](./forge-create.md)  

--- a/src/reference/forge/test-commands.md
+++ b/src/reference/forge/test-commands.md
@@ -2,3 +2,4 @@
 
 - [forge test](./forge-test.md)
 - [forge snapshot](./forge-snapshot.md)
+- [forge coverage](./forge-coverage.md)


### PR DESCRIPTION
`forge coverage` is in the sidebar, but not sometimes in the main copy. This adds a few links where it seems appropriate.