### PR TITLE
fix(tutorial): Fixed example tests in NFT tutorial

### DIFF
--- a/src/tutorials/solmate-nft.md
+++ b/src/tutorials/solmate-nft.md
@@ -279,9 +279,10 @@ contract NFTTest is Test {
     }
 
     function test_RevertUnSafeContractReceiver() public {
-        vm.etch(address(1), bytes("mock code"));
+        // Adress set to 11, because first 10 addresses are restricted for precompiles
+        vm.etch(address(11), bytes("mock code"));
         vm.expectRevert(bytes(""));
-        nft.mintTo{value: 0.08 ether}(address(1));
+        nft.mintTo{value: 0.08 ether}(address(11));
     }
 
     function test_WithdrawalWorksAsOwner() public {


### PR DESCRIPTION
### Motivation:
In this pull request, I've addressed the issue where the NFT tutorial tests were utilizing the older version of the etch cheatcode. The behavior of the etch cheatcode was recently altered in [foundry-rs/foundry#4905](https://github.com/foundry-rs/foundry/pull/4905), making the existing NFT tutorial tests incompatible.

### Solution:

- Updated the NFT tutorial tests to work with the new etch cheatcode behavior.
- Changed the address to 11th. I'm uncertain if this is the ideal approach, so feedback on this particular change would be greatly appreciated.

This should ensure that the NFT tutorial is now up-to-date and functions as expected with the latest changes in the foundry-rs repository.

Please review the changes and provide insights, especially regarding the address change to the 11th. Let me know if any further modifications are required.