### PR TITLE
Fix example for `parseJsonKeys`

### DIFF
--- a/src/cheatcodes/parse-json-keys.md
+++ b/src/cheatcodes/parse-json-keys.md
@@ -20,7 +20,7 @@ string[] memory keys = vm.parseJsonKeys(json, ".key"); // ["a", "b"]
 
 ```solidity
 string memory json = '{"key": "something"}';
-string[] memory keys = vm.parseJsonKeys(json, "."); // ["key"]
+string[] memory keys = vm.parseJsonKeys(json, "$"); // ["key"]
 ```
 
 ```solidity


### PR DESCRIPTION
I have introduced incorrect example of cheatcode usage in #976, this PR fixes it