### PR TITLE
docs(cheatcodes): add createWallet doc page

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -299,6 +299,7 @@
       - [`rememberKey`](./cheatcodes/remember-key.md)
       - [`toString`](./cheatcodes/to-string.md)
       - [`breakpoint`](./cheatcodes/breakpoint.md)
+      - [`createWallet`](./cheatcodes/create-wallet.md)
     - [Snapshots](./cheatcodes/snapshots.md)
     - [RPC](./cheatcodes/rpc.md)
     - [Files](./cheatcodes/fs.md)

--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -59,6 +59,28 @@ interface CheatCodes {
         RecurrentPrank
     }
 
+    struct Wallet {
+        address addr;
+        uint256 publicKeyX;
+        uint256 publicKeyY;
+        uint256 privateKey;
+    }
+
+    // Derives a private key from the name, labels the account with that name, and returns the wallet
+    function createWallet(string calldata) external returns (Wallet memory);
+
+    // Generates a wallet from the private key and returns the wallet
+    function createWallet(uint256) external returns (Wallet memory);
+
+    // Generates a wallet from the private key, labels the account with that name, and returns the wallet
+    function createWallet(uint256, string calldata) external returns (Wallet memory);
+
+    // Signs data, (Wallet, digest) => (v, r, s)
+    function sign(Wallet calldata, bytes32) external returns (uint8, bytes32, bytes32);
+
+    // Get nonce for a Wallet
+    function getNonce(Wallet calldata) external returns (uint64);
+
     // Set block.timestamp
     function warp(uint256) external;
 

--- a/src/cheatcodes/create-wallet.md
+++ b/src/cheatcodes/create-wallet.md
@@ -1,0 +1,100 @@
+## `createWallet`
+
+### Signature
+
+```solidity
+  struct Wallet {
+      address addr;
+      uint256 publicKeyX;
+      uint256 publicKeyY;
+      uint256 privateKey;
+  }
+```
+
+```solidity
+  function createWallet(string calldata) external returns (Wallet memory);
+```
+
+```solidity
+  function createWallet(uint256) external returns (Wallet memory);
+```
+
+```solidity
+  function createWallet(uint256, string calldata) external returns (Wallet memory);
+```
+
+### Description
+
+Creates a new Wallet struct when given a parameter to derive the private key from.
+
+### Tips
+
+[`sign()`](./sign.md) and [`getNonce()`](./get-nonce.md) both have supported function overloads for the Wallet struct as well.
+
+### Examples
+
+#### `uint256`
+
+```solidity
+Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))));
+
+emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("1")))
+
+emit log_address(wallet.addr); // vm.addr(wallet.privateKey)
+
+emit log_address(
+    address(
+        uint160(
+            uint256(
+                keccak256(abi.encode(wallet.publicKeyX, wallet.publicKeyY))
+            )
+        )
+    )
+); // wallet.addr
+
+emit log_string(vm.getLabel(wallet.addr)); // ""
+```
+
+#### `string`
+
+```solidity
+Wallet memory wallet = vm.createWallet("bob's wallet");
+
+emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("bob's wallet")))
+
+emit log_address(wallet.addr); // vm.addr(wallet.privateKey)
+
+emit log_address(
+    address(
+        uint160(
+            uint256(
+                keccak256(abi.encode(wallet.publicKeyX, wallet.publicKeyY))
+            )
+        )
+    )
+); // wallet.addr
+
+emit log_string(vm.getLabel(wallet.addr)); // "bob's wallet"
+```
+
+#### `uint256` and `string`
+
+```solidity
+Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))), "bob's wallet");
+
+emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("1")))
+
+emit log_address(wallet.addr); // vm.addr(wallet.privateKey)
+
+emit log_address(
+    address(
+        uint160(
+            uint256(
+                keccak256(abi.encode(wallet.publicKeyX, wallet.publicKeyY))
+            )
+        )
+    )
+); // wallet.addr
+
+emit log_string(vm.getLabel(wallet.addr)); // "bob's wallet"
+```

--- a/src/cheatcodes/get-nonce.md
+++ b/src/cheatcodes/get-nonce.md
@@ -6,13 +6,25 @@
 function getNonce(address account) external returns (uint64);
 ```
 
+```solidity
+function getNonce(Wallet memory wallet) external returns (uint64);
+```
+
 ### Description
 
-Gets the nonce of the given account.
+Gets the nonce of the given account or [Wallet](./create-wallet.md).
 
 ### Examples
 
+#### `address`
 ```solidity
 uint256 nonce = vm.getNonce(address(100));
+emit log_uint(nonce); // 0
+```
+
+#### `Wallet`
+```solidity
+Wallet memory alice = vm.createWallet("alice");
+uint256 nonce = vm.getNonce(nonce);
 emit log_uint(nonce); // 0
 ```

--- a/src/cheatcodes/sign.md
+++ b/src/cheatcodes/sign.md
@@ -6,9 +6,13 @@
 function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
 ```
 
+```solidity
+function sign(Wallet memory wallet, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+```
+
 ### Description
 
-Signs a digest `digest` with private key `privateKey`, returning `(v, r, s)`.
+Signs a digest `digest` with private key `privateKey` or [Wallet](./create-wallet.md`) `wallet`, returning `(v, r, s)`.
 
 This is useful for testing functions that take signed data and perform an `ecrecover` to verify the signer.
 
@@ -103,4 +107,16 @@ contract SigningExampleTest is Test {
         vm.stopPrank();
     }
 }
+```
+
+#### `Wallet`
+
+The Wallet overload is a simple wrapper that uses the wallet's private key to sign the digest
+
+```solidity
+Wallet memory alice = vm.createWallet("alice");
+bytes32 hash = keccak256("Signed by Alice");
+(uint8 v, bytes32 r, bytes32 s) = vm.sign(alice, hash);
+address signer = ecrecover(hash, v, r, s);
+assertEq(alice.addr, signer); // [PASS]
 ```

--- a/src/cheatcodes/utilities.md
+++ b/src/cheatcodes/utilities.md
@@ -8,3 +8,4 @@
 - [`rememberKey`](./remember-key.md)
 - [`toString`](./to-string.md)
 - [`breakpoint`](./breakpoint.md)
+- [`createWallet`](./create-wallet.md)


### PR DESCRIPTION
This adds the createWallet documentation introduced in https://github.com/foundry-rs/foundry/pull/5332/.

This also adds additional documentation to the `sign` and `getNonce` documentation pages for Wallet support.