### PR TITLE
Cast subcommand syntax in README.md

### DIFF
--- a/src/cast/README.md
+++ b/src/cast/README.md
@@ -27,7 +27,7 @@ Let's use `cast` to retrieve the total supply of the DAI token:
 You can also use `cast` to send arbitrary messages. Here's an example of sending a message between two Anvil accounts.
 
 ```bash
-$ cast send --private-key <Your Private Key> 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc $(cast --from-utf8 "hello world") --rpc-url http://127.0.0.1:8545/
+$ cast send --private-key <Your Private Key> 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc $(cast from-utf8 "hello world") --rpc-url http://127.0.0.1:8545/
 ```
 
 <br>


### PR DESCRIPTION
`cast --from-utf8` -> `cast from-utf8` 

Cast subcommand doesn't execute properly as shown due to outdated syntax