### PR TITLE
Fix import path error, improve readability

### DIFF
--- a/src/reference/forge-std/console-log.md
+++ b/src/reference/forge-std/console-log.md
@@ -3,7 +3,8 @@
 - Similar to Hardhat's console functions.
 - You can use it in calls and transactions. It works with view functions, but not in pure ones.
 - It always works, regardless of the call or transaction failing or being successful.
-- To use it you need to import forge-std/src/console.sol.
+- To use it you need import it:
+    - `import "forge-std/console.sol";`
 - You can call console.log with up to 4 parameters in any order of following types:
     - `uint`
     - `string`


### PR DESCRIPTION
This import path was incorrect and caused my build to fail. Path was `forge-std/src/console.sol` which failed with error:
```
% forge build
[⠊] Compiling...
Error: 
Failed to resolve file: "/Users/user/Documents/Projects/fluidity-contracts/lib/forge-std/src/src/console.sol": No such file or directory (os error 2).
 Check configured remappings..
    --> "/Users/user/Documents/Projects/fluidity-contracts/contracts/liquidity/userModule/main.sol"
        "forge-std/src/console.sol"
 ```
 The correct path was found here on this page of the book: https://book.getfoundry.sh/reference/forge-std/