### PR TITLE
feat(`cheatcodes`): add docs for exists, isFile and isDir cheats

### DIFF
--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -338,6 +338,15 @@ interface CheatCodes {
     // - The user lacks permissions to remove the file.
     // (path) => ()
     function removeFile(string calldata) external;
+    // Returns true if the given path points to an existing entity, else returns false
+    // (path) => (bool)
+    function exists(string calldata) external returns (bool);
+    // Returns true if the path exists on disk and is pointing at a regular file, else returns false
+    // (path) => (bool)
+    function isFile(string calldata) external returns (bool);
+    // Returns true if the path exists on disk and is pointing at a directory, else returns false
+    // (path) => (bool)
+    function isDir(string calldata) external returns (bool);
     
     // Return the value(s) that correspond to 'key'
     function parseJson(string memory json, string memory key) external returns (bytes memory);

--- a/src/cheatcodes/fs.md
+++ b/src/cheatcodes/fs.md
@@ -108,9 +108,9 @@ assertEq(vm.readFile(path), data);
 Verify that a filesystem path is valid
 
 ```solidity
-// Verify that the path 'foo/files/bar.txt' exists
+// Verify that path 'foo/files/bar.txt' exists
 string memory validPath = "foo/files/bar.txt";
-assertTrue(vm.exists(validFilePath));
+assertTrue(vm.exists(validPath));
 ```
 
 Verify that a filesystem path points to a file or directory

--- a/src/cheatcodes/fs.md
+++ b/src/cheatcodes/fs.md
@@ -110,7 +110,7 @@ Verify that a filesystem path is valid
 ```solidity
 // Verify that the path 'foo/files/bar.txt' exists
 string memory validPath = "foo/files/bar.txt";
-assertTrue(vm.isFile(validFilePath));
+assertTrue(vm.exists(validFilePath));
 ```
 
 Verify that a filesystem path points to a file or directory

--- a/src/cheatcodes/fs.md
+++ b/src/cheatcodes/fs.md
@@ -22,6 +22,15 @@ function closeFile(string calldata) external;
 // - The user lacks permissions to remove the file.
 // (path) => ()
 function removeFile(string calldata) external;
+// Returns true if the given path points to an existing entity, else returns false
+// (path) => (bool)
+function exists(string calldata) external returns (bool);
+// Returns true if the path exists on disk and is pointing at a regular file, else returns false
+// (path) => (bool)
+function isFile(string calldata) external returns (bool);
+// Returns true if the path exists on disk and is pointing at a directory, else returns false
+// (path) => (bool)
+function isDir(string calldata) external returns (bool);
 ```
 
 ### Description

--- a/src/cheatcodes/fs.md
+++ b/src/cheatcodes/fs.md
@@ -104,3 +104,23 @@ vm.writeFile(path, data);
 
 assertEq(vm.readFile(path), data);
 ```
+
+Verify that a filesystem path is valid
+
+```solidity
+// Verify that the path 'foo/files/bar.txt' exists
+string memory validPath = "foo/files/bar.txt";
+assertTrue(vm.isFile(validFilePath));
+```
+
+Verify that a filesystem path points to a file or directory
+
+```solidity
+// Verify that path 'foo/file/bar.txt' points to a file
+string memory validFilePath = "foo/files/bar.txt";
+assertTrue(vm.isFile(validFilePath));
+
+// Verify that 'foo/file' points to a directory
+string memory validDirPath = "foo/files";
+assertTrue(vm.isDir(validDirPath));
+```


### PR DESCRIPTION
Add docs for new filesystem cheatcodes `exists`, `isFile` and `isDir` from foundry-rs/foundry#5719
* Update `src/cheatcodes/fs.md` with cheatcode sigs
* Update `src/cheatcodes/README.md` with cheatcode sigs