### PR TITLE
Update parse-json.md to reference `foundry.toml` permissions

### DIFF
--- a/src/cheatcodes/parse-json.md
+++ b/src/cheatcodes/parse-json.md
@@ -170,6 +170,14 @@ struct Tx1559Detail {
 }
 ```
 
+### Troubleshooting
+
+#### Cannot read file
+
+> FAIL. Reason: The path `<file-path>` is not allowed to be accessed for read operations
+
+If you receive this error, make sure that you enable read permissions in `foundry.toml` using the [`fs_permissions` key](./fs.md)
+
 ### References
 
 - Helper Library: [stdJson.sol](https://github.com/foundry-rs/forge-std/blob/master/src/StdJson.sol)


### PR DESCRIPTION
I was hitting into the same issue described in [issue #179](https://github.com/foundry-rs/forge-std/issues/179) and just found it through Google searching the error.

Just a minor suggestion to add the solution directly to the docs page