### PR TITLE
removed alternative `deal` function within the Cheatcodes interface

### DIFF
--- a/src/cheatcodes/README.md
+++ b/src/cheatcodes/README.md
@@ -216,12 +216,6 @@ interface CheatCodes {
 
     // Sets an address' balance
     function deal(address who, uint256 newBalance) external;
-
-    // Set the balance of an account for any ERC20 token
-    function deal(address token, address to, uint256 give) external;
-    
-    // Alternative signature to update `totalSupply`
-    function deal(address token, address to, uint256 give, bool adjust) external;
     
     // Sets an address' code
     function etch(address who, bytes calldata code) external;

--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -10,6 +10,8 @@ function deal(address who, uint256 newBalance) external;
 
 Sets the balance of an address `who` to `newBalance`.
 
+If the alternative signature of `deal` is used (defined in `StdCheats.sol`), then we can additionally specify ERC20 token address, as well as an option to update `totalSupply`.
+
 ### Examples
 
 ```solidity

--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -19,6 +19,13 @@ vm.deal(alice, 1 ether);
 log_uint256(alice.balance); // 1000000000000000000
 ```
 
+```solidity
+address alice = makeAddr("alice");
+emit log_address(alice);
+deal(address(DAI), alice, 1 ether); // import StdUtils.sol first
+log_uint256(address(DAI).balanceOf(alice)); // 1000000000000000000
+```
+
 ### SEE ALSO
 
 Forge Standard Library

--- a/src/cheatcodes/deal.md
+++ b/src/cheatcodes/deal.md
@@ -6,19 +6,9 @@
 function deal(address who, uint256 newBalance) external;
 ```
 
-```solidity
-function deal(address token, address to, uint256 give) external;
-```
-
-```solidity
-function deal(address token, address to, uint256 give, bool adjust) external;
-```
-
 ### Description
 
 Sets the balance of an address `who` to `newBalance`.
-
-If the alternative signature of `deal` is used, then we can additionally specify ERC20 token address, as well as an option to update `totalSupply`.
 
 ### Examples
 
@@ -27,13 +17,6 @@ address alice = makeAddr("alice");
 emit log_address(alice);
 vm.deal(alice, 1 ether);
 log_uint256(alice.balance); // 1000000000000000000
-```
-
-```solidity
-address alice = makeAddr("alice");
-emit log_address(alice);
-deal(address(DAI), alice, 1 ether); // import StdUtils.sol first
-log_uint256(address(DAI).balanceOf(alice); // 1000000000000000000
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Noted that the `deal` function in the cheatcodes interface allows for modifying ERC-20 token balances. However, based on the current implementation of forge-std, this function isn't directly provided by the VM (which can only change native token balances like ETH). Instead, it's implemented in StdCheats.sol and utilized not through VM calls but directly in test (with support for various ERC standard tokens already added).
This clarification is provided to address potential confusion, which I encountered.