### PR TITLE
Enhanced completion script installation with 'sudo tee'

### DIFF
--- a/src/config/shell-autocompletion.md
+++ b/src/config/shell-autocompletion.md
@@ -14,9 +14,9 @@ compinit -i
 Then run:
 
 ```sh
-forge completions zsh > /usr/local/share/zsh/site-functions/_forge
-cast completions zsh > /usr/local/share/zsh/site-functions/_cast
-anvil completions zsh > /usr/local/share/zsh/site-functions/_anvil
+forge completions zsh | sudo tee /usr/local/share/zsh/site-functions/_forge
+cast completions zsh | sudo tee /usr/local/share/zsh/site-functions/_cast
+anvil completions zsh | sudo tee /usr/local/share/zsh/site-functions/_anvil
 ```
 
 For ARM-based systems:


### PR DESCRIPTION
Revised the installation process for completion scripts for Forge, Cast, and Anvil commands to ensure proper permissions and prevent `permission denied` errors. Instead of direct file redirection with `>`, I used `sudo tee` to write the output to the respective completion script files in `/usr/local/share/zsh/site-functions/`. This change ensures that the completion scripts are installed with superuser privileges, allowing them to function correctly in the Zsh shell.