### PR TITLE
Removing no-section-label value from book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,7 +12,6 @@ edit-url-template = "https://github.com/foundry-rs/book/edit/master/{path}"
 default-theme = "ayu"
 additional-js = ["src/static/solidity.min.js"]
 cname = "book.getfoundry.sh"
-no-section-label = true
 additional-css = ["src/static/custom.css"]
 
 [output.html.fold]


### PR DESCRIPTION
Creating PR for this issue: [Issue #1008 ](https://github.com/foundry-rs/book/issues/1008)

The left-hand panel will look cleaner IMO with numerical listing.