### PR TITLE
Fix "acount" typo in wallet-options-keystore.md

### DIFF
--- a/src/reference/common/wallet-options-keystore.md
+++ b/src/reference/common/wallet-options-keystore.md
@@ -4,7 +4,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;Use the keystore in the given folder or file.  
 &nbsp;&nbsp;&nbsp;&nbsp;Environment: `ETH_KEYSTORE`
 
-`--acount` _account-name_  
+`--account` _account-name_  
 &nbsp;&nbsp;&nbsp;&nbsp;Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename.  
 &nbsp;&nbsp;&nbsp;&nbsp;Environment: `ETH_KEYSTORE_ACCOUNT`
 


### PR DESCRIPTION
There was a small typo in the `cast send` docs: "--acount" instead of "--account"