### PR TITLE
Add vm.sleep() & vm.unixTime() cheatcodes

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -273,6 +273,7 @@
       - [`getCode`](./cheatcodes/get-code.md)
       - [`getDeployedCode`](./cheatcodes/get-deployed-code.md)
       - [`sleep`](./cheatcodes/sleep.md)
+      - [`unixTime`](./cheatcodes/unix-time.md)
       - [`setEnv`](./cheatcodes/set-env.md)
       - [`envOr`](./cheatcodes/env-or.md)
       - [`envBool`](./cheatcodes/env-bool.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -272,6 +272,7 @@
       - [`projectRoot`](./cheatcodes/project-root.md)
       - [`getCode`](./cheatcodes/get-code.md)
       - [`getDeployedCode`](./cheatcodes/get-deployed-code.md)
+      - [`sleep`](./cheatcodes/sleep.md)
       - [`setEnv`](./cheatcodes/set-env.md)
       - [`envOr`](./cheatcodes/env-or.md)
       - [`envBool`](./cheatcodes/env-bool.md)

--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -4,6 +4,7 @@
 - [`projectRoot`](./project-root.md)
 - [`getCode`](./get-code.md)
 - [`getDeployedCode`](./get-deployed-code.md)
+- [`sleep`](./sleep.md)
 - [`setEnv`](./set-env.md)
 - [`envOr`](./env-or.md)
 - [`envBool`](./env-bool.md)

--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -5,6 +5,7 @@
 - [`getCode`](./get-code.md)
 - [`getDeployedCode`](./get-deployed-code.md)
 - [`sleep`](./sleep.md)
+- [`unixTime`](./unix-time.md)
 - [`setEnv`](./set-env.md)
 - [`envOr`](./env-or.md)
 - [`envBool`](./env-bool.md)

--- a/src/cheatcodes/sleep.md
+++ b/src/cheatcodes/sleep.md
@@ -1,0 +1,18 @@
+## `sleep`
+
+### Signature
+
+```solidity
+function sleep(uint256 milliseconds) external;
+```
+
+### Description
+
+Sleeps for a given amount of milliseconds.
+
+### Examples
+
+```solidity
+vm.sleep(10_000); // Halts execution for 10 seconds
+```
+

--- a/src/cheatcodes/unix-time.md
+++ b/src/cheatcodes/unix-time.md
@@ -1,0 +1,21 @@
+## `unixTime`
+
+### Signature
+
+```solidity
+function unixTime() external returns (uint milliseconds);
+```
+
+### Description
+
+Returns the time since unix epoch in milliseconds.
+
+### Examples
+
+```solidity
+uint start = vm.unixTime();
+vm.sleep(10_000); // Halts execution for 10 seconds
+uint end = vm.unixTime();
+assertEq(end - start, 10_000);
+```
+


### PR DESCRIPTION
Following https://github.com/foundry-rs/foundry/pull/5952 & https://github.com/foundry-rs/foundry/pull/5519

Adding documentation for `vm.sleep()` and `vm.unixTime()`.