### PR TITLE
[fix] typo in `cast call --trace`

### DIFF
--- a/src/reference/cast/cast-call.md
+++ b/src/reference/cast/cast-call.md
@@ -19,7 +19,7 @@ The destination (*to*) can be an ENS name or an address.
 ### OPTIONS
 
 `--trace`  
-&nbsp;&nbsp;&nbsp;&nbsp;The block height you want to query at.
+&nbsp;&nbsp;&nbsp;&nbsp;Prints traces for the transaction.
 
 `--debug`  
 &nbsp;&nbsp;&nbsp;&nbsp;Opens an interactive debugger with the transaction. Needs `--trace`.


### PR DESCRIPTION
The book had a wrong description for the `--trace` flag