### PR TITLE
Added `--jobs` to `cast create2`

### DIFF
--- a/src/reference/cast/cast-create2.md
+++ b/src/reference/cast/cast-create2.md
@@ -35,6 +35,9 @@ Generate a deterministic contract address using CREATE2
 `--init-code-hash` *hash*
 &nbsp;&nbsp;&nbsp;&nbsp;Init code hash of the contract to be deployed
 
+`--jobs` *jobs*
+&nbsp;&nbsp;&nbsp;&nbsp;Number of threads to use. Defaults to and caps at the number of logical cores
+
 {{#include common-options.md}}
 
 ### EXAMPLES


### PR DESCRIPTION
The `--jobs` argument was added in https://github.com/foundry-rs/foundry/pull/6212 .

`cast create2` help:

```
❯ cast create2 -h
Generate a deterministic contract address using CREATE2

Usage: cast create2 [OPTIONS]

Options:
  -s, --starts-with <HEX>      Prefix for the contract address
  -e, --ends-with <HEX>        Suffix for the contract address
  -m, --matching <HEX>         Sequence that the address has to match
  -c, --case-sensitive         Case sensitive matching
  -d, --deployer <ADDRESS>     Address of the contract deployer [default: 0x4e59b44847b379578588920ca78fbf26c0b4956c]
  -i, --init-code <HEX>        Init code of the contract to be deployed
      --init-code-hash <HASH>  Init code hash of the contract to be deployed
  -j, --jobs <JOBS>            Number of threads to use. Defaults to and caps at the number of logical cores
  -h, --help                   Print help
```