### PR TITLE
Added `--caller` for `cast create2`

### DIFF
--- a/src/reference/cast/cast-create2.md
+++ b/src/reference/cast/cast-create2.md
@@ -38,6 +38,9 @@ Generate a deterministic contract address using CREATE2
 `--jobs` *jobs*
 &nbsp;&nbsp;&nbsp;&nbsp;Number of threads to use. Defaults to and caps at the number of logical cores
 
+`--caller` *address*
+&nbsp;&nbsp;&nbsp;&nbsp;Address of the caller. Used for the first 20 bytes of the salt
+
 {{#include common-options.md}}
 
 ### EXAMPLES


### PR DESCRIPTION
PR in the main repo got merged https://github.com/foundry-rs/foundry/pull/6363

The `--caller` flag will be added in the next nightly release, so I also added it here to the book.

```
Generate a deterministic contract address using CREATE2

Usage: cast create2 [OPTIONS]

Options:
  -s, --starts-with <HEX>      Prefix for the contract address
  -e, --ends-with <HEX>        Suffix for the contract address
  -m, --matching <HEX>         Sequence that the address has to match
  -c, --case-sensitive         Case sensitive matching
  -d, --deployer <ADDRESS>     Address of the contract deployer [default: 0x4e59b44847b379578588920ca78fbf26c0b4956c]
  -i, --init-code <HEX>        Init code of the contract to be deployed
      --init-code-hash <HASH>  Init code hash of the contract to be deployed
  -j, --jobs <JOBS>            Number of threads to use. Defaults to and caps at the number of logical cores
      --caller <ADDRESS>       Address of the caller. Used for the first 20 bytes of the salt
  -h, --help                   Print help
```