### PR TITLE
Added failed test report behavior info.

### DIFF
--- a/src/forge/debugger.md
+++ b/src/forge/debugger.md
@@ -57,6 +57,11 @@ For the memory:
 
 For the stack, **cyan words** are either being read or popped by the current opcode.
 
+> ⚠️ **Note**
+>
+> In most test frameworks, the first test assertion to fail is the one reported.
+> In foundry, the last test assertion to fail (that comes from DSTest or cheatcodes) is the one to be reported.
+
 ### Navigating
 
 ### General


### PR DESCRIPTION
This pr adresses : https://github.com/foundry-rs/book/issues/1036

Added explanation of failed test reporting behavior as a 'Note' under 'Debugging' section.