### PR TITLE
Add missing link for page getLabel

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -297,6 +297,7 @@
       - [`sign`](./cheatcodes/sign.md)
       - [`skip`](./cheatcodes/skip.md)
       - [`label`](./cheatcodes/label.md)
+      - [`getLabel`](./cheatcodes/get-label.md)
       - [`deriveKey`](./cheatcodes/derive-key.md)
       - [`parseBytes`](./cheatcodes/parse-bytes.md)
       - [`parseAddress`](./cheatcodes/parse-address.md)


### PR DESCRIPTION
The getLabel cheatcode page is not working (error 404), adding the link in Summary fixes it
https://book.getfoundry.sh/cheatcodes/get-label.html