### PR TITLE
chore: Include `--ir-minimum` flag in forge coverage doc

### DIFF
--- a/src/reference/forge/forge-coverage.md
+++ b/src/reference/forge/forge-coverage.md
@@ -31,6 +31,10 @@ It has three different options and is set to `summary` by default.
 
 {{#include common-options.md}}
 
+#### Optimization Option
+
+`--ir-minimum` allows you to run the coverage with `via-ir` enabled for the "[minimum amount of optimization](https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350)" necessary.
+
 ### EXAMPLES
 
 1. View summarized coverage:


### PR DESCRIPTION
Doc update corresponding to [forge feature update](https://github.com/foundry-rs/foundry/pull/5349).

thanks to @mds1's [suggestion](https://github.com/foundry-rs/foundry/issues/6592#issuecomment-1854096788)!