### PR TITLE
docs: removed Files link in cheatcode ref/external

### DIFF
--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -16,4 +16,3 @@
 - [`envString`](./env-string.md)
 - [`envBytes`](./env-bytes.md)
 - [`parseJson`](./parse-json.md)
-- [Files](./fs.md)

--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -16,5 +16,4 @@
 - [`envString`](./env-string.md)
 - [`envBytes`](./env-bytes.md)
 - [`parseJson`](./parse-json.md)
-- [`parseJson`](./parse-json.md)
 - [`fs`](./fs.md)

--- a/src/cheatcodes/external.md
+++ b/src/cheatcodes/external.md
@@ -16,3 +16,5 @@
 - [`envString`](./env-string.md)
 - [`envBytes`](./env-bytes.md)
 - [`parseJson`](./parse-json.md)
+- [`parseJson`](./parse-json.md)
+- [`fs`](./fs.md)


### PR DESCRIPTION
Not sure if this was intended, but saw a misplaced `Files` reference link in [Cheatcodes Reference/External ](https://book.getfoundry.sh/cheatcodes/external)(See Screenshot Below)

<img width="350" alt="oss" src="https://github.com/foundry-rs/book/assets/85150796/8911673b-c225-47b3-aba2-5de1759fa559">

