### PR TITLE
Add mocking of public variables to book

### DIFF
--- a/src/cheatcodes/mock-call.md
+++ b/src/cheatcodes/mock-call.md
@@ -86,3 +86,30 @@ function testMockCall() public {
     assertEq(example.pay{value: 1}(2), 2);
 }
 ```
+
+Mocking a public variable:
+
+
+```solidity
+contract Example {
+    uint256 public number = 10;
+}
+
+contract ExampleTest is Test {
+    Example public example;
+
+    function setUp() public {
+        example = new Example();
+    }
+
+    function testMockPublicVariable() public {
+        assertEq(example.number(), 10);
+        vm.mockCall(
+            address(example),
+            abi.encodeWithSelector(bytes4(keccak256("number()"))),
+            abi.encode(5)
+        );
+        assertEq(example.number(), 5);
+    }
+}
+```


### PR DESCRIPTION
While the `mockCall` cheat code in Foundry is advertised to support mocking of functions, it can be overloaded to mock a public variable's getter function. For example, the below code works to mock a public variable called "number":
```
vm.mockCall(
    address(example),
    abi.encodeWithSelector(bytes4(keccak256("number()"))),
    abi.encode(5)
);
```
This is useful when testing interactions with vendored contracts or precompiles, in which case the developer may not have control over a public variable otherwise.