### PR TITLE
docs: add example to /reference/cast/cast-send

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -79,6 +79,12 @@ The destination (*to*) can be an ENS name or an address.
     ```sh
     cast send 0x... "myfunction((address,uint256))" "(0x...,1)"
     ```
+
+4. Send a transaction with hex data in the `input` field of the transaction object:
+    ```sh
+    cast send 0x... 0x68656c6c6f20776f726c64
+    ```
+
 ### SEE ALSO
 
 [cast](./cast.md), [cast call](./cast-call.md), [cast publish](./cast-publish.md), [cast receipt](./cast-receipt.md), [struct encoding](../../misc/struct-encoding.md)


### PR DESCRIPTION
Even though there is technically an example of how to add hex data to the `input` field of the transaction object [here](https://book.getfoundry.sh/cast/), it took me a long time to find this. This PR adds an example of how to do this directly on the `cast-send` page.