### PR TITLE
Fix: update AccountAccessKind

### DIFF
--- a/src/cheatcodes/stop-and-return-state-diff.md
+++ b/src/cheatcodes/stop-and-return-state-diff.md
@@ -10,7 +10,11 @@ enum AccountAccessKind {
     StaticCall,
     Create,
     SelfDestruct,
-    Resume
+    Resume,
+    Balance,
+    Extcodesize,
+    Extcodehash,
+    Extcodecopy
 }
 
 struct ChainInfo {
@@ -72,6 +76,10 @@ If kind is a Resume, then account represents an execution context that had resum
 - `Create` - The account was created
 - `SelfDestruct` - The account was selfdestructed
 - `Resume` - Indicates that a previously pre-emptyed account access was resumed
+- `Balance` - The account's codesize was read
+- `Extcodesize` - The account's codesize was read
+- `Extcodehash` - The account's codehash was read
+- `Extcodecopy` - The account's code was copied
 
 ### `AccountAccess`
 


### PR DESCRIPTION
The enum `AccountAccessKind` is currently out of sync with the enum in foundry: https://github.com/foundry-rs/forge-std/blob/36c303b7ffdd842d06b1ec2744c9b9b5fb3083f3/src/Vm.sol#L26-L49