### PR TITLE
Remove unused error message argument in example code

### DIFF
--- a/src/cheatcodes/expect-revert.md
+++ b/src/cheatcodes/expect-revert.md
@@ -42,7 +42,7 @@ There are 3 signatures:
 >
 > ```solidity
 > function testLowLevelCallRevert() public {
->     vm.expectRevert(bytes("error message"));
+>     vm.expectRevert();
 >     (bool revertsAsExpected, ) = address(myContract).call(myCalldata);
 >     assertTrue(revertsAsExpected, "expectRevert: call did not revert");
 > }


### PR DESCRIPTION
According to the documentation regarding the unexpected behaviour of `vm.expectRevert()` on low level calls, the return data is clobbered, and according to my tests it does not seem like the `bytes` argument matters at all, ie. I can remove it, or include something nonsensical, and it doesn't affect the outcome of the test.

Therefore the docs should not suggest providing this argument.