### PR TITLE
cast: update `call` flags

### DIFF
--- a/src/reference/cast/cast-call.md
+++ b/src/reference/cast/cast-call.md
@@ -24,9 +24,6 @@ The destination (*to*) can be an ENS name or an address.
 `--debug`  
 &nbsp;&nbsp;&nbsp;&nbsp;Opens an interactive debugger with the transaction. Needs `--trace`.
 
-`--verbose`  
-&nbsp;&nbsp;&nbsp;&nbsp;Prints a more verbose trace. Needs `--trace`.
-
 `--labels <address:label>`  
 &nbsp;&nbsp;&nbsp;&nbsp;Labels to apply to the traces, with the format `address:label`. Needs `--trace`.
 

--- a/src/reference/cli/cast/call.md
+++ b/src/reference/cli/cast/call.md
@@ -32,11 +32,6 @@ Options:
           
           opens an interactive debugger
 
-      --verbose
-          Can only be used with "--trace"
-          
-          prints a more verbose trace
-
       --labels <LABELS>
           Can only be used with "--trace" Labels to apply to the traces.
           


### PR DESCRIPTION
This updates the docs to reflect that the `--verbose` flag was removed from `call`.

See:

https://github.com/foundry-rs/foundry/pull/6939
https://github.com/foundry-rs/foundry/pull/6219