### PR TITLE
Revert "Remove unused error message argument in example code (#1091)"

### DIFF
--- a/src/cheatcodes/expect-revert.md
+++ b/src/cheatcodes/expect-revert.md
@@ -42,7 +42,7 @@ There are 3 signatures:
 >
 > ```solidity
 > function testLowLevelCallRevert() public {
->     vm.expectRevert();
+>     vm.expectRevert(bytes("error message"));
 >     (bool revertsAsExpected, ) = address(myContract).call(myCalldata);
 >     assertTrue(revertsAsExpected, "expectRevert: call did not revert");
 > }


### PR DESCRIPTION
This reverts commit dbefc9af30ebd288fbf1ef5dd4e568113196c8ad (from https://github.com/foundry-rs/book/pull/1091)

Discussed with @Evalir in discord and this should work as expected, cc @maurelian 