### PR TITLE
Impersonation doc fix

### DIFF
--- a/src/tutorials/forking-mainnet-with-cast-anvil.md
+++ b/src/tutorials/forking-mainnet-with-cast-anvil.md
@@ -51,7 +51,8 @@ $ cast send $DAI \
 --from $LUCKY_USER \
   "transfer(address,uint256)(bool)" \
   $ALICE \
-  300000000000000000000000
+  300000000000000000000000 \
+  --unlocked
 blockHash               0xbf31c45f6935a0714bb4f709b5e3850ab0cc2f8bffe895fefb653d154e0aa062
 blockNumber             15052891
 ...


### PR DESCRIPTION
Current example doesn't work with 0.2.0 version. Adding switch `unlocked` fixes this.

Specifically it throws error:

```
Error accessing local wallet. Did you set a private key, mnemonic or keystore?
Run `cast send --help` or `forge create --help` and use the corresponding CLI
flag to set your key via:
--private-key, --mnemonic-path, --aws, --interactive, --trezor or --ledger.
Alternatively, if you're using a local node with unlocked accounts,
use the --unlocked flag and either set the `ETH_FROM` environment variable to the address
of the unlocked account you want to use, or provide the --from flag with the address directly.
```