### PR TITLE
Docnewignwarning

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -115,6 +115,11 @@ If both `offline` and `auto-detect-solc` are set to `true`, the required version
 An array of file paths from which warnings should be ignored during the compulation process. This is useful when you have a specific
 directories of files that produce known warning and you wish to suppress these warnings without affecting others.
 
+Each entry in the array should be a path to a directory or a specific file. For Example:
+
+`ignored_warnings_from = ["path/to/warnings/file1.sol", "path/to/warnings/file2.sol"]`
+
+This configuration will cause the compiler to ignore any warnings that originate from the specified paths.
 
 ##### `ignored_error_codes`
 

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -108,6 +108,13 @@ If both `offline` and `auto-detect-solc` are set to `true`, the required version
 
 ##### `ignored_warnings_from`
 
+- Type: array of strings (file paths)
+- Default: none
+- Environment: `FOUNDRY_IGNORED_WARNINGS_FROM` OR `DAPP_IGNORED_WARNINGS_FROM`
+
+An array of file paths from which warnings should be ignored during the compulation process. This is useful when you have a specific
+directories of files that produce known warning and you wish to suppress these warnings without affecting others.
+
 
 ##### `ignored_error_codes`
 

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -106,6 +106,9 @@ If enabled, Foundry will not attempt to download any missing solc versions.
 
 If both `offline` and `auto-detect-solc` are set to `true`, the required version(s) of solc will be auto detected but any missing versions will _not_ be installed.
 
+##### `ignored_warnings_from`
+
+
 ##### `ignored_error_codes`
 
 - Type: array of integers/strings


### PR DESCRIPTION
Documented about the "new ignored_warnings_from config setting", wrote it with an example under the Solidity Compiler section and under general section of the Solidity compiler configuration.  I wrote it just above "ignored_error_code" section, attached a screenshot as well. I've run it  and tested the doc page.
![Screenshot 2024-02-11 054233](https://github.com/foundry-rs/book/assets/93962265/a69a900d-5aa9-4d00-b06b-b94aee9b5f19)
