### PR TITLE
Update Solidity Scripting Tutorial

### DIFF
--- a/src/tutorials/solidity-scripting.md
+++ b/src/tutorials/solidity-scripting.md
@@ -32,7 +32,7 @@ Since the NFT contract from the solmate tutorial inherits both `solmate` and `Op
 cd solidity-scripting
 
 # Install Solmate and OpenZeppelin contracts as dependencies
-forge install transmissions11/solmate Openzeppelin/openzeppelin-contracts
+forge install transmissions11/solmate Openzeppelin/openzeppelin-contracts@v5.0.1
 ```
 
 Next, we have to delete the `Counter.sol` file in the `src` folder and create another file called `NFT.sol`. You can do this by running:
@@ -70,7 +70,7 @@ contract NFT is ERC721, Ownable {
         string memory _name,
         string memory _symbol,
         string memory _baseURI
-    ) ERC721(_name, _symbol) {
+    ) ERC721(_name, _symbol) Ownable(msg.sender) {
         baseURI = _baseURI;
     }
 


### PR DESCRIPTION
Updates Solidity Scripting Tutorial code example so that it complies with OpenZeppelin dependency.

The function signature of the OpenZeppelin Ownable class has changed in v5 from v4, the constructor now requires an "initialOwner" parameter, which has now been included and uses `msg.sender` as the argument. This change also sets a ref pointing to a release tag for the OpenZeppelin library in the `forge install` command so that it does not default to retrieving the master branch and won't pull in backwards incompatible changes in future. 

 Fixes foundry-rs/book#1119.