### PR TITLE
Update forking-mainnet-with-cast-anvil.md

### DIFF
--- a/src/tutorials/forking-mainnet-with-cast-anvil.md
+++ b/src/tutorials/forking-mainnet-with-cast-anvil.md
@@ -47,6 +47,7 @@ Let's transfer some tokens from the lucky user to Alice using [`cast send`][cast
 ```sh
 # This calls Anvil and lets us impersonate our lucky user
 $ cast rpc anvil_impersonateAccount $LUCKY_USER
+null
 $ cast send $DAI \
 --from $LUCKY_USER \
   "transfer(address,uint256)(bool)" \


### PR DESCRIPTION
Implementing change for Output Correction: `cast rpc anvil_impersonateAccount $LUCKY_USER` to properly reflect the `null` output 

Documented the issue here:
https://github.com/foundry-rs/book/issues/1122