### PR TITLE
fix default evm version (london=>paris)

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -156,7 +156,7 @@ If enabled, Foundry will treat Solidity compiler warnings as errors, stopping ar
 ##### `evm_version`
 
 - Type: string
-- Default: london
+- Default: paris
 - Environment: `FOUNDRY_EVM_VERSION` or `DAPP_EVM_VERSION`
 
 The EVM version to use during tests. The value **must** be an EVM hardfork name, such as `london`, `byzantium`, etc.


### PR DESCRIPTION
It seems to me that the default evm_version is actually paris, and not london.

https://github.com/foundry-rs/foundry/blob/ce22450e4d625d12ff88fae347a68e3d3d9d2b61/crates/config/src/lib.rs#L1856