### PR TITLE
Add weekly automated command output update workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: mdbook test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install mdbook
         run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,23 +6,6 @@ on:
   workflow_dispatch:
     # Needed so we can run it manually
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  BRANCH: output-update
-  TITLE: "chore(output): weekly `gen_output.sh`"
-  BODY: |
-    Automation to keep output and references current.
-
-    <details><summary><strong>output update log</strong></summary>
-    <p>
-
-    ```log
-    $output_update_log
-    ```
-
-    </p>
-    </details>
-
 jobs:
   update:
     name: Update
@@ -32,27 +15,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@nightly
+        uses: foundry-rs/foundry-toolchain@v1
 
       - name: Update
-        run: output_update_log=$(scripts/gen_output.sh)
-
-      - name: Create commit
         run: |
-          export output_update_log="$(cat output_update.log)"
+          git config --global user.email "update@update.com"
+          git config --global user.name "update"
+          ./scripts/gen_output.sh
 
-          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-          printf "$TITLE\n\n$output_update_log\n" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$BODY" | envsubst >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create Pull Request
+      - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: ${{ steps.msg.outputs.commit_message }}
-          title: ${{ env.TITLE }}
-          body: ${{ steps.msg.outputs.body }}
-          branch: ${{ env.BRANCH }}
+          commit-message: "update command output"
+          title: "chore(output): weekly command output update"
+          body: |
+            Automation to keep command output up to date.
+          branch: chore/output-update

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}
           title: ${{ env.TITLE }}
           body: ${{ steps.msg.outputs.body }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,59 @@
+name: update
+on:
+  schedule:
+    # Run weekly
+    - cron: "0 0 * * SUN"
+  workflow_dispatch:
+    # Needed so we can run it manually
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BRANCH: output-update
+  TITLE: "chore(output): weekly `gen_output.sh`"
+  BODY: |
+    Automation to keep output and references current.
+
+    <details><summary><strong>output update log</strong></summary>
+    <p>
+
+    ```log
+    $output_update_log
+    ```
+
+    </p>
+    </details>
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@nightly
+
+      - name: Update
+        run: output_update_log=$(scripts/gen_output.sh)
+
+      - name: Create commit
+        run: |
+          export output_update_log="$(cat output_update.log)"
+
+          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
+          printf "$TITLE\n\n$output_update_log\n" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" | envsubst >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          add-paths: ./Cargo.lock
+          commit-message: ${{ steps.msg.outputs.commit_message }}
+          title: ${{ env.TITLE }}
+          body: ${{ steps.msg.outputs.body }}
+          branch: ${{ env.BRANCH }}


### PR DESCRIPTION
This PR adds a weekly automated update workflow to more regularly update the command output in the documentation as command flags are added quite regularly in Foundry. You can also trigger this workflow manually.

The automated PR looks like this: https://github.com/zerosnacks/book/pull/3