### PR TITLE
Update invariant-testing.md

### DIFF
--- a/src/forge/invariant-testing.md
+++ b/src/forge/invariant-testing.md
@@ -208,7 +208,7 @@ contract InvariantExample1 is Test {
     }
 
     function invariant_B() external {
-        assertGe(foo.val1() + foo.val2(), foo.val1());
+        assertGe(foo.val1() + foo.val2(), foo.val3());
     }
 
 }


### PR DESCRIPTION
The invariant test example succeeds only if invariant_B is changed to 
```solidity
function invariant_B() external {
    assertEq(foo.val1() + foo.val2(), foo.val3());
  }
  ```


After the change it succeeds
  ```
➜  foundry-example git:(main) ✗ forge test --match-contract InvariantExample -vvv
[⠢] Compiling...
[⠒] Compiling 1 files with 0.8.24
[⠢] Solc 0.8.24 finished in 1.85s
Compiler run successful!

Ran 2 tests for test/InvariantExample.t.sol:InvariantExampleTest
[PASS] invariant_A() (runs: 256, calls: 3840, reverts: 1365)
[PASS] invariant_B() (runs: 256, calls: 3840, reverts: 1216)
Suite result: ok. 2 passed; 0 failed; 0 skipped; finished in 576.83ms (1.12s CPU time)

Ran 1 test suite in 582.81ms (576.83ms CPU time): 2 tests passed, 0 failed, 0 skipped (2 total tests)
  ```