### PR TITLE
fix:need to extend MockERC20,before use it

### DIFF
--- a/src/tutorials/testing-eip712.md
+++ b/src/tutorials/testing-eip712.md
@@ -143,8 +143,23 @@ While the Permit struct passed in the getStructHash() function above doesn't con
 - Mint the owner a test token
 
 ```solidity
+
+contract Token_ERC20 is MockERC20 {
+    constructor(string memory name, string memory symbol, uint8 decimals) {
+        initialize(name, symbol, decimals);
+    }
+
+    function mint(address to, uint256 value) public virtual {
+        _mint(to, value);
+    }
+
+    function burn(address from, uint256 value) public virtual {
+        _burn(from, value);
+    }
+}
+
 contract ERC20Test is Test {
-    MockERC20 internal token;
+    Token_ERC20 internal token;
     SigUtils internal sigUtils;
 
     uint256 internal ownerPrivateKey;
@@ -154,7 +169,7 @@ contract ERC20Test is Test {
     address internal spender;
 
     function setUp() public {
-        token = new MockERC20();
+        token = new Token_ERC20("Token", "TKN", 18);
         sigUtils = new SigUtils(token.DOMAIN_SEPARATOR());
 
         ownerPrivateKey = 0xA11CE;


### PR DESCRIPTION
method `_mint()` and `_burn()` in MockERC20 are `internal`. Before use it, we need to extends MockERC20, just like [MockERC20.t.sol](https://github.com/foundry-rs/forge-std/blob/master/test/mocks/MockERC20.t.sol)