### PR TITLE
Fix revert message type in mockCallRevert example

### DIFF
--- a/src/cheatcodes/mock-call-revert.md
+++ b/src/cheatcodes/mock-call-revert.md
@@ -44,7 +44,7 @@ function testMockCallRevert() public {
     vm.mockCallRevert(
         address(0),
         abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)),
-        abi.encode("REVERT_MESSAGE")
+        "REVERT_MESSAGE"
     );
     vm.expectRevert("REVERT_MESSAGE");
     IERC20(address(0)).balanceOf(address(1));


### PR DESCRIPTION
`mockCallRevert(address, input, error)` makes a call revert with the bytestring from `error`.

The documentation example expects the mock that reverts with `abi.encode(error)` to return `error`, but abi-encoding a string makes the bytestrings not match anymore and the test to fail with a confusing error `REVERT_MESSAGE != REVERT_MESSAGE`.

This PR removes the unnecessary `abi.encode` wrapper.

### How to test

Try out the examples. Create a new Foundry project with `foundry init` and replace the default test with the following file:

<details><summary>MockCallRevert.t.sol</summary>

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

import {Test, console} from "forge-std/Test.sol";
import {Counter} from "../src/Counter.sol";

contract MockRevertTest is Test {
    function testMockCallRevert() public {
        vm.mockCallRevert(
            address(0),
            abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)),
            abi.encode("REVERT_MESSAGE")
        );
        vm.expectRevert("REVERT_MESSAGE");
        MyToken(address(0)).balanceOf(address(1));
    }

    function testMockCallRevertUpdated() public {
        vm.mockCallRevert(
            address(0),
            abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)),
            "REVERT_MESSAGE"
        );
        vm.expectRevert("REVERT_MESSAGE");
        MyToken(address(0)).balanceOf(address(1));
    }

    error TestError(string);

    function testMockCallRevertWithCustomError() public {
        bytes memory customError = abi.encodeWithSelector(TestError.selector, "ERROR_MESSAGE");
        vm.mockCallRevert(address(0), abi.encodeWithSelector(MyToken.balanceOf.selector, address(1)), customError);
        vm.expectRevert(customError);
        MyToken(address(0)).balanceOf(address(1));
    }
}

interface MyToken {
    function balanceOf(address) external returns (uint256);
}

```
</details>

<details><summary>Run forge-test</summary>

```
$ forge test
[⠒] Compiling...
No files changed, compilation skipped

Ran 3 tests for test/Counter.t.sol:MockRevertTest
[FAIL. Reason: Error != expected error: REVERT_MESSAGE != REVERT_MESSAGE] testMockCallRevert() (gas: 7351)
[PASS] testMockCallRevertUpdated() (gas: 6937)
[PASS] testMockCallRevertWithCustomError() (gas: 8048)
Suite result: FAILED. 2 passed; 1 failed; 0 skipped; finished in 1.17ms (1.23ms CPU time)

Ran 1 test suite in 9.14ms (1.17ms CPU time): 2 tests passed, 1 failed, 0 skipped (3 total tests)

Failing tests:
Encountered 1 failing test in test/Counter.t.sol:MockRevertTest
[FAIL. Reason: Error != expected error: REVERT_MESSAGE != REVERT_MESSAGE] testMockCallRevert() (gas: 7351)

Encountered a total of 1 failing tests, 2 tests succeeded
```
</details>

Observe that the current test in the docs (`testMockCallRevert`) fails with `Error != expected error: REVERT_MESSAGE != REVERT_MESSAGE` but the test in this PR succeeds (`testMockCallRevertUpdated`).