### PR TITLE
Update forge-verify-contract.md to add --skip-is-verified-check flag …

### DIFF
--- a/src/reference/forge/forge-verify-contract.md
+++ b/src/reference/forge/forge-verify-contract.md
@@ -36,6 +36,9 @@ you can specify a file containing **space-separated** constructor arguments with
 
 {{#include ../common/verifier-options.md}}
 
+`--skip-is-verified-check`
+&nbsp;&nbsp;&nbsp;&nbsp;Send the verification request even if the contract is already verified.
+
 `--compiler-version` *version*  
 &nbsp;&nbsp;&nbsp;&nbsp;The compiler version used to build the smart contract.
 


### PR DESCRIPTION
## Motivation
There wasn't any mention of --skip-is-verified-check flag in the documentation so I decided to add it.

Solution
Added the necessary description of the --skip-is-verified-check flag to the documentation