### PR TITLE
Update `getCode` doc

### DIFF
--- a/src/cheatcodes/get-code.md
+++ b/src/cheatcodes/get-code.md
@@ -49,6 +49,17 @@ assembly {
 vm.etch(targetAddr, deployed.code);
 ```
 
+
+### Supported formats
+
+You can fetch artifacts by either contract path or contract name. Fetching artifacts for a specific version is also supported. If not provided, cheatcode will default to the version of a test being executed or the only version artifact was compiled with.
+```solidity
+vm.getCode("MyContract.sol:MyContract");
+vm.getCode("MyContract");
+vm.getCode("MyContract.sol:0.8.18");
+vm.getCode("MyContract:0.8.18");
+```
+
 ### SEE ALSO
 
 [`getDeployedCode`](./get-deployed-code.md)

--- a/src/cheatcodes/get-deployed-code.md
+++ b/src/cheatcodes/get-deployed-code.md
@@ -48,6 +48,17 @@ vm.etch(overrideAddress, code);
 assertEq(overrideAddress.code, code);
 ```
 
+### Supported formats
+
+You can fetch artifacts by either contract path or contract name. Fetching artifacts for a specific version is also supported. If not provided, cheatcode will default to the version of a test being executed or the only version artifact was compiled with.
+```solidity
+vm.getDeployedCode("MyContract.sol:MyContract");
+vm.getDeployedCode("MyContract");
+vm.getDeployedCode("MyContract.sol:0.8.18");
+vm.getDeployedCode("MyContract:0.8.18");
+```
+
+
 ### SEE ALSO
 
 Forge Standard Library


### PR DESCRIPTION
Updates `getCode` and `getDeployedCode` doc with artifact path formats supported. Ref https://github.com/foundry-rs/foundry/pull/7597#issuecomment-2042695764