### PR TITLE
Repositioned info box at page 'Deterministic deployment using CREATE2'  from bottom to top.

### DIFF
--- a/src/tutorials/create2-tutorial.md
+++ b/src/tutorials/create2-tutorial.md
@@ -4,7 +4,7 @@
 
 Enshrined into the EVM as part of the [Constantinople fork](https://ethereum.org/en/history/#constantinople) of 2019, `CREATE2` is an opcode that started its journey as [EIP-1014](https://eips.ethereum.org/EIPS/eip-1014).
 `CREATE2` allows you to deploy smart contracts to deterministic addresses, based on parameters controlled by the deployer.
-As a result, it's often mentioned as enabling "counterfactual" deployments, where you can interact with an addresses that haven't been created yet because CREATE2 guarantees known code can be placed at that address.
+As a result, it's often mentioned as enabling "counterfactual" deployments, where you can interact with an addresses that haven't been created yet because `CREATE2` guarantees known code can be placed at that address.
 This is in contrast to the `CREATE` opcode, where the address of the deployed contract is a function of the deployer's nonce.
  With `CREATE2`, you can use the same deployer account to deploy contracts to the same address across multiple networks, even if the address has varying nonces.
 

--- a/src/tutorials/create2-tutorial.md
+++ b/src/tutorials/create2-tutorial.md
@@ -8,6 +8,9 @@ As a result, it's often mentioned as enabling "counterfactual" deployments, wher
 This is in contrast to the `CREATE` opcode, where the address of the deployed contract is a function of the deployer's nonce.
  With `CREATE2`, you can use the same deployer account to deploy contracts to the same address across multiple networks, even if the address has varying nonces.
 
+> ℹ️ **Note**
+>This guide is intended to help understand `CREATE2`. In most use cases, you won't need to write and use your own deployer, and can use an existing deterministic deployer. In forge scripts, using `new MyContract{salt: salt}()` will use the deterministic deployer at [0x4e59b44847b379578588920ca78fbf26c0b4956c](https://github.com/Arachnid/deterministic-deployment-proxy).
+
 In this tutorial, we will:
 
 1. Look at a `CREATE2` factory implementation.
@@ -219,5 +222,3 @@ Create a new function named `testDeterministicDeploy()` that:
 Save all your files, and run the test using `forge test --match-path test/Create2.t.sol -vvvv`.
 Your test should pass without any errors.
 
-> ℹ️ **Note**
->This guide is intended to help understand `CREATE2`. In most use cases, you won't need to write and use your own deployer, and can use an existing deterministic deployer. In forge scripts, using `new MyContract{salt: salt}()` will use the deterministic deployer at [0x4e59b44847b379578588920ca78fbf26c0b4956c](https://github.com/Arachnid/deterministic-deployment-proxy).


### PR DESCRIPTION
A small change: re-positioned the info box ('This guide is intended to help understand `CREATE2`. [...]) from the bottom of the page to the top. It is now positioned just after the introductory paragraph. 

Reason: the reader needs this information before reading through the page, not after.  

Hope that makes sense & thanks to for all for the work on Foundry book. It's an amazing resource. 
  