### PR TITLE
mention solidity scripting as an alternative approach to deploying/verifying

### DIFF
--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -4,7 +4,7 @@ Forge can deploy smart contracts to a given network with the [`forge create`](..
 
 Forge CLI can deploy only one contract at a time.
 
-Another way to deploy and verify smart contracts is to use Forge's [Solidity scripting](../tutorials/solidity-scripting.md#deploying-our-contract)
+For deploying and verifying multiple smart contracts in one go, Forge's [Solidity scripting](../tutorials/solidity-scripting.md#deploying-our-contract) would be the more efficient approach.
 
 To deploy a contract, you must provide a RPC URL (env: `ETH_RPC_URL`) and the private key of the account that will deploy the contract.
 

--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -2,7 +2,9 @@
 
 Forge can deploy smart contracts to a given network with the [`forge create`](../reference/forge/forge-create.md) command.
 
-Forge can deploy only one contract at a time.
+Forge CLI can deploy only one contract at a time.
+
+Another way to deploy and verify smart contracts is to use Forge's [Solidity scripting](../tutorials/solidity-scripting.md#deploying-our-contract)
 
 To deploy a contract, you must provide a RPC URL (env: `ETH_RPC_URL`) and the private key of the account that will deploy the contract.
 


### PR DESCRIPTION
New Foundry users coming to the documentation wanting to find tutorials on deploying and verifying will always go to the "Deploying and Verifying" section of the doc because it's one of the top sections and sits at a more conspicuous location , but it only mentions the CLI approach. This would mislead the new devs to believe that there's no other way to deploy/verify multiple smart contracts using foundry. By mentioning the Solidity Scripting approach, the documentation will better inform the devs with the multiple approaches available to them


(I personally have been believing that Foundry's deployment CLI is the only way to deploy smart contracts with foundry and have been using a hybrid of hardhat + foundry as my setup...because its just impractical to use the CLI for deploying mid-large size projects with multiple contracts. It was not until very recently did I find out about the solidity scripting approach; now I only use foundry)

