### PR TITLE
Update working-on-an-existing-project.md

### DIFF
--- a/src/projects/working-on-an-existing-project.md
+++ b/src/projects/working-on-an-existing-project.md
@@ -10,6 +10,7 @@ First, clone the project and run [`forge install`][install] inside the project d
 $ git clone https://github.com/PaulRBerg/foundry-template
 $ cd foundry-template 
 $ forge install
+$ bun install # install Solhint, Prettier, and other Node.js deps
 ```
 
 We run [`forge install`][install] to install the submodule dependencies that are in the project.


### PR DESCRIPTION
Add bun install to avoid compilation errors. I got some errors when building the project:

```shell
$ forge build
[⠃] Compiling...2024-04-20T11:16:26.701267Z ERROR foundry_compilers::artifacts: error="/path/to/my-project/node_modules/forge-std/src/Script.sol": No such file or directory (os error 2)
[⠊] Compiling...
Error: 
failed to resolve file: "/path/to/my-project/node_modules/forge-std/src/Script.sol": No such file or directory (os error 2); check configured remappings
	--> /path/to/my-project/script/Base.s.sol
	forge-std/src/Script.sol

```

ref: https://github.com/PaulRBerg/foundry-template