### PR TITLE
Add PointEvaluation precompile (0x0a) to the Precompile Registry

### DIFF
--- a/src/misc/precompile-registry.md
+++ b/src/misc/precompile-registry.md
@@ -17,6 +17,7 @@ Note that, while some chains like Optimism have bytecode deployed at a predeterm
 | ALL           | `0x07`                                       | ECMul                            |
 | ALL           | `0x08`                                       | ECPairing                        |
 | ALL           | `0x09`                                       | Blake2F                          |
+| ALL           | `0x0a`                                       | PointEvaluation                  |
 | 10, 420       | `0x4200000000000000000000000000000000000016` | L2ToL1MessagePasser              |
 | 10, 420       | `0x4200000000000000000000000000000000000002` | DeployerWhitelist                |
 | 10, 420       | `0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000` | LegacyERC20ETH                   |


### PR DESCRIPTION
This pull request updates the Precompile Registry in the Foundry Book to include the PointEvaluation precompile (address 0x0a) introduced in the Dencun upgrade as part of EIP-4844.

As this is a minor addition and correction, it is being submitted directly as a pull request without an associated issue.