### PR TITLE
Add `depth` field to AccountAccess in stopAndReturnStateDiff docs

### DIFF
--- a/src/cheatcodes/stop-and-return-state-diff.md
+++ b/src/cheatcodes/stop-and-return-state-diff.md
@@ -35,6 +35,7 @@ struct AccountAccess {
     bytes data;
     bool reverted;
     StorageAccess[] storageAccesses;
+    uint64 depth;
 }
 
 struct StorageAccess {
@@ -69,7 +70,7 @@ If kind is Create, then the account is the newly created account.
 If kind is SelfDestruct, then the account is the selfdestruct recipient.
 If kind is a Resume, then account represents an execution context that had resumed.
 
-- `Call` - The account was called 
+- `Call` - The account was called
 - `DelegateCall` - The account was called via delegate call
 - `CallCode` - The account was called via callcode
 - `StaticCall` - The account was called via staticcall
@@ -100,6 +101,7 @@ That is, all balance changes are recorded here, even if reverts occurred.
 - `data` - Input data provided (i.e. `msg.data`) in the case of a `CREATE` or `CALL` type access.
 - `reverted` - If this access reverted in either the current or parent context.
 - `storageAccesses` - An ordered list of storage accesses made while the account access is non-preemptive.
+- `depth` - Call depth traversed during the recording of state differences.
 
 ### `StorageAccess`
 


### PR DESCRIPTION
This pull request updates the AccountAccess struct description in the `vm.stopAndReturnStateDiff()` function documentation to include the recently added `depth` field.

As this is a minor addition to the documentation, it is being submitted directly as a pull request without an associated issue.