### PR TITLE
Fix: clarify how to decode nested structs + abi.decode for TOML and JSON

### DIFF
--- a/src/cheatcodes/parse-json.md
+++ b/src/cheatcodes/parse-json.md
@@ -108,6 +108,74 @@ struct Json {
 
 The reason is that it would try to decode the string `"sigma"` as a uint. To be exact, it would be decoded, but it would result to a wrong number, since it would interpret the bytes incorrectly.
 
+Another example, given the following JSON:
+
+```json
+{
+    "apples": [
+        {
+            "sweetness": 7,
+            "sourness": 3,
+            "color": "Red"
+        },
+        {
+            "sweetness": 5,
+            "sourness": 5,
+            "color": "Green"
+        },
+        {
+            "sweetness": 9,
+            "sourness": 1,
+            "color": "Yellow"
+        }
+    ],
+    "name": "Fresh Fruit"
+}
+```
+
+And Solidity structs defined as follows:
+
+```solidity
+struct Apple {
+    string color;
+    uint8 sourness;
+    uint8 sweetness;
+}
+
+struct FruitStall {
+    Apple[] apples;
+    string name;
+}
+```
+
+One would decode the JSON as follows:
+
+```solidity
+string memory root = vm.projectRoot();
+string memory path = string.concat(root, "/src/test/fixtures/fruitstall.json");
+string memory json = vm.readFile(path);
+bytes memory data = vm.parseJson(json);
+FruitStall memory fruitstall = abi.decode(data, (FruitStall));
+
+// Logs: Welcome to Fresh Fruit
+console2.log("Welcome to", fruitstall.name);
+
+for (uint256 i = 0; i < fruitstall.apples.length; i++) {
+    Apple memory apple = fruitstall.apples[i];
+
+    // Logs:
+    // Color: Red, Sourness: 3, Sweetness: 7
+    // Color: Green, Sourness: 5, Sweetness: 5
+    // Color: Yellow, Sourness: 1, Sweetness: 9
+    console2.log(
+        "Color: %s, Sourness: %d, Sweetness: %d",
+        apple.color,
+        apple.sourness,
+        apple.sweetness
+    );
+}
+```
+
 ### Decoding JSON Objects, a tip
 
 If your JSON object has `hex numbers`, they will be encoded as bytes. The way to decode them as `uint` for better UX, is to define two `struct`, one intermediary with the definition of these values as `bytes` and then a final `struct` that will be consumed by the user.


### PR DESCRIPTION
From conversations it became clear that the current documentation of TOML and JSON misses a practical example of decoding complex nested structs. This addition aims to address this concern.