### PR TITLE
Update test configs

### DIFF
--- a/src/reference/cli/forge/coverage.md
+++ b/src/reference/cli/forge/coverage.md
@@ -76,6 +76,9 @@ Test options:
       --fuzz-input-file <FUZZ_INPUT_FILE>
           File to rerun fuzz failures from
 
+      --max-threads <MAX_THREADS>
+          Max concurrent threads to use. Default value is the number of available CPUs
+
 Display options:
   -j, --json
           Output test results in JSON format

--- a/src/reference/cli/forge/snapshot.md
+++ b/src/reference/cli/forge/snapshot.md
@@ -74,6 +74,9 @@ Test options:
       --fuzz-input-file <FUZZ_INPUT_FILE>
           File to rerun fuzz failures from
 
+      --max-threads <MAX_THREADS>
+          Max concurrent threads to use. Default value is the number of available CPUs
+
 Display options:
   -j, --json
           Output test results in JSON format

--- a/src/reference/cli/forge/test.md
+++ b/src/reference/cli/forge/test.md
@@ -54,6 +54,9 @@ Test options:
       --fuzz-input-file <FUZZ_INPUT_FILE>
           File to rerun fuzz failures from
 
+      --max-threads <MAX_THREADS>
+          Max concurrent threads to use. Default value is the number of available CPUs
+
 Display options:
   -j, --json
           Output test results in JSON format

--- a/src/reference/config/testing.md
+++ b/src/reference/config/testing.md
@@ -395,7 +395,7 @@ The number of runs that must execute for each invariant test group. See also [fu
 ##### `depth`
 
 - Type: integer
-- Default: 15
+- Default: 500
 - Environment: `FOUNDRY_INVARIANT_DEPTH`
 
 The number of calls executed to attempt to break invariants in one run.
@@ -439,3 +439,11 @@ The flag indicating whether to include values from storage. See also [fuzz.inclu
 - Environment: `FOUNDRY_FUZZ_INCLUDE_PUSH_BYTES`
 
 The flag indicating whether to include push bytes values. See also [fuzz.include_push_bytes](#include_push_bytes)
+
+##### `shrink_run_limit`
+
+- Type: integer
+- Default: 5000
+- Environment: `FOUNDRY_INVARIANT_SHRINK_RUN_LIMIT`
+
+The maximum number of attempts to shrink a failed the sequence. Shrink process is disabled if set to 0.


### PR DESCRIPTION
Invariant related:
- depth default value is now 500
- add missing `shrink_run_limit`

Tests, coverage and snapshot:
- add new `max_threads` config