### PR TITLE
Fix confusing error in remappings docs.

### DIFF
--- a/src/projects/dependencies.md
+++ b/src/projects/dependencies.md
@@ -46,7 +46,7 @@ You can customize these remappings by creating a `remappings.txt` file in the ro
 Let's create a remapping called `solmate-utils` that points to the `utils` folder in the solmate repository!
 
 ```sh
-solmate-utils/=lib/solmate/src/utils/
+@solmate-utils/=lib/solmate/src/utils/
 ```
 
 You can also set remappings in `foundry.toml`.


### PR DESCRIPTION
When trying to write a `remappings.txt` file for a project I was working on, I encountered a lot of `File not found` errors when running `foundry build`. Following the example in the docs that I intend to edit led me to believe that each remapping in my `remappings.txt` file should not begin with a '@' symbol. Only after trying to build my contracts with that symbol at the start of my remapping lines did `forge` manage to follow the remappings and find the files I intended it to find.

I was using `forge 0.2.0` on WSL (Windows subsystem for Linux).

I would like to spare future developers this headache when they start learning Foundry.

