### PR TITLE
Update deploying.md

### DIFF
--- a/src/forge/deploying.md
+++ b/src/forge/deploying.md
@@ -116,9 +116,9 @@ Contract successfully verified.
 
 ### Troubleshooting
 
-##### `Invalid character 'x' at position 1`
+##### `missing hex prefix ("0x") for hex string`
 
-Make sure the private key string does not begin with `0x`.
+Make sure the private key string begins with `0x`.
 
 ##### `EIP-1559 not activated`
 EIP-1559 is not supported or not activated on the RPC server. Pass the `--legacy` flag to use legacy transactions instead of the EIP-1559 ones. If you do development in a local environment, you can use Hardhat instead of Ganache.


### PR DESCRIPTION
I had this error, I think 0x prefix is needed when providing private key:

```sh
Error: 
Failed to deploy script:
execution reverted: failed parsing "privatekeywithout0xprefix" as type `uint256`: missing hex prefix ("0x") for hex string (gas: 375776)
```