### PR TITLE
comma-separated -> semicolon-separated

### DIFF
--- a/src/reference/forge/compiler-options.md
+++ b/src/reference/forge/compiler-options.md
@@ -24,7 +24,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;Do not auto-detect solc.
 
 `--ignored-error-codes` *error_codes*  
-&nbsp;&nbsp;&nbsp;&nbsp;Ignore solc warnings by error code. The parameter is a comma-separated list of error codes.
+&nbsp;&nbsp;&nbsp;&nbsp;Ignore solc warnings by error code. The parameter is a semicolon-separated list of error codes.
 
 `--extra-output` *selector*  
 &nbsp;&nbsp;&nbsp;&nbsp;Extra output to include in the contract's artifact.


### PR DESCRIPTION
This does not work with a comma-separated list, only semicolon-separated, at least on macos using

```sh
$ forge -V
forge 0.2.0 (9058812 2024-07-01T00:25:00.180987000Z)
```