### PR TITLE
Followup #1239: add specific pointer for MacOS in regards to default $XDG_DATA_HOME location

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -128,7 +128,7 @@ Forge will sometimes check for newer Solidity versions that fit your project. To
 
 [solc-bin](https://binaries.soliditylang.org/) doesn't offer static builds for Apple silicon. Foundry relies on [svm](https://github.com/alloy-rs/svm-rs) to install native builds for Apple silicon.
 
-All solc versions are installed under `~/.svm/` if the directory already exists, otherwise it uses `$XDG_DATA_HOME/svm`. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
+All solc versions are installed under `~/.svm/` if the directory already exists. If not, it uses `$XDG_DATA_HOME/svm/`, commonly mapped to `$HOME/.local/share/svm/`. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
 
 If you're on Apple silicon, please ensure the [`z3` theorem prover](https://github.com/Z3Prover/z3) is installed: `brew install z3`
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -126,13 +126,13 @@ Forge will sometimes check for newer Solidity versions that fit your project. To
 
 ### I'm getting Solc errors
 
-[solc-bin](https://binaries.soliditylang.org/) doesn't offer static builds for apple silicon. Foundry relies on [svm](https://github.com/roynalnaruto/svm-rs) to install native builds for apple silicon.
+[solc-bin](https://binaries.soliditylang.org/) doesn't offer static builds for Apple silicon. Foundry relies on [svm](https://github.com/alloy-rs/svm-rs) to install native builds for Apple silicon.
 
-All solc versions are installed under `~/.svm/`. If you encounter solc related errors, such as `SolcError: ...` please to nuke `~/.svm/` and try again, this will trigger a fresh install and usually resolves the issue.
+All solc versions are installed under `~/.svm/` if the directory already exists, otherwise it uses `$XDG_DATA_HOME/svm`. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
 
-If you're on apple silicon, please ensure the [`z3` theorem prover](https://github.com/Z3Prover/z3) is installed: `brew install z3`
+If you're on Apple silicon, please ensure the [`z3` theorem prover](https://github.com/Z3Prover/z3) is installed: `brew install z3`
 
-> **Note**: native apple silicon builds are only available from `0.8.5` upwards. If you need older versions, you must enable apple silicon rosetta to run them.
+> **Note**: native Apple silicon builds are only available from `0.8.5` upwards. If you need older versions, you must enable Apple silicon rosetta to run them.
 
 ### Forge fails in JavaScript monorepos (`pnpm`)
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -128,7 +128,7 @@ Forge will sometimes check for newer Solidity versions that fit your project. To
 
 [solc-bin](https://binaries.soliditylang.org/) doesn't offer static builds for Apple silicon. Foundry relies on [svm](https://github.com/alloy-rs/svm-rs) to install native builds for Apple silicon.
 
-All solc versions are installed under `~/.svm/` if the directory already exists. If not, it uses `$XDG_DATA_HOME/svm/`, commonly mapped to `$HOME/.local/share/svm/`. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
+All solc versions are installed under `~/.svm/` if the directory already exists. If not, it uses `$XDG_DATA_HOME/svm/`, commonly mapped to `$HOME/.local/share/svm/` on Linux or `$HOME/Library/Application Support/svm` on MacOS. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
 
 If you're on Apple silicon, please ensure the [`z3` theorem prover](https://github.com/Z3Prover/z3) is installed: `brew install z3`
 

--- a/src/faq.md
+++ b/src/faq.md
@@ -128,7 +128,7 @@ Forge will sometimes check for newer Solidity versions that fit your project. To
 
 [solc-bin](https://binaries.soliditylang.org/) doesn't offer static builds for Apple silicon. Foundry relies on [svm](https://github.com/alloy-rs/svm-rs) to install native builds for Apple silicon.
 
-All solc versions are installed under `~/.svm/` if the directory already exists. If not, it uses `$XDG_DATA_HOME/svm/`, commonly mapped to `$HOME/.local/share/svm/` on Linux or `$HOME/Library/Application Support/svm` on MacOS. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
+All solc versions are installed under `~/.svm/` if the directory already exists. If not, it uses `$XDG_DATA_HOME/svm/`, commonly mapped to `$HOME/.local/share/svm/` on Linux or `$HOME/Library/Application Support/svm/` on MacOS. If you encounter solc related errors, such as `SolcError: ...` please remove the `~/.svm/` directory and try again, this will trigger a fresh install and usually resolves the issue.
 
 If you're on Apple silicon, please ensure the [`z3` theorem prover](https://github.com/Z3Prover/z3) is installed: `brew install z3`
 


### PR DESCRIPTION
Follow up of https://github.com/foundry-rs/book/pull/1239

Aims to address: https://github.com/foundry-rs/foundry/issues/6925#issuecomment-2013497221
