### PR TITLE
fix: typo in openzeppelin version

### DIFF
--- a/src/projects/soldeer.md
+++ b/src/projects/soldeer.md
@@ -10,7 +10,7 @@ A new approach has been in the making, [soldeer.xyz](https://soldeer.xyz), which
 
 #### Add a Dependency Stored in the Central Repository
 
-To add a dependency, you can visit [soldeer.xyz](https://soldeer.xyz) and search for the dependency you want to add (e.g., openzeppelin 0.5.2).
+To add a dependency, you can visit [soldeer.xyz](https://soldeer.xyz) and search for the dependency you want to add (e.g., openzeppelin 5.0.2).
 
 ![image](https://i.postimg.cc/Hm6R8MTs/Unknown-413.png)
 


### PR DESCRIPTION
Make openzeppelin version consistent to avoid confusion