### PR TITLE
Missing dependencies section in Soldeer

### DIFF
--- a/src/projects/soldeer.md
+++ b/src/projects/soldeer.md
@@ -87,7 +87,8 @@ For example, having this Foundry config file in a git repository, one can pull t
 auto_detect_solc = false 
 bytecode_hash = "none" 
 fuzz = { runs = 1_000 } 
-gas_reports = ["*"] # <= This is important to be added
+libs = ["dependencies"] # <= This is important to be added
+gas_reports = ["*"]
 
 [dependencies] # <= Dependencies will be added under this config
 "@openzeppelin-contracts" = { version = "5.0.2" }


### PR DESCRIPTION
Added the following line to the `toml` block for `Updating Dependencies`

```bash
libs = ["dependencies"] # <= This is important to be added
```

Closes #1252 
