### PR TITLE
Updated docs(`cheatcodes`): `vm.parseJsonKeys` behaviour is documented incorrectly mentioning

### DIFF
--- a/src/cheatcodes/parse-json-keys.md
+++ b/src/cheatcodes/parse-json-keys.md
@@ -25,5 +25,5 @@ string[] memory keys = vm.parseJsonKeys(json, "$"); // ["key"]
 
 ```solidity
 string memory json = '{"root_key": [{"a": 1, "b": 2}]}';
-string[] memory keys = vm.parseJsonKeys(json, ".root_key.0"); // ["a", "b"]
+string[] memory keys = vm.parseJsonKeys(json, ".root_key[0]"); // ["a", "b"]
 ```


### PR DESCRIPTION
This solves https://github.com/foundry-rs/foundry/issues/8672

### Previous behaviour 
```solidity
string memory json = '{"root_key": [{"a": 1, "b": 2}]}';
string[] memory keys = vm.parseJsonKeys(json, ".root_key.0"); // ["a", "b"] 
```

### Updated/required bheaviour
```solidity
string memory json = '{"root_key": [{"a": 1, "b": 2}]}';
string[] memory keys = vm.parseJsonKeys(json, ".root_key[0]"); // ["a", "b"] 
```