### PR TITLE
feat: EIP-7702 examples

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -90,7 +90,7 @@ The destination (*to*) can be an ENS name or an address.
     cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
     ```
 
-6. Send an EIP-7702 transaction authorizing `<address>` to act on your behalf:
+6. Send an EIP-7702 transaction delegating to `<address>`:
     ```sh
     cast send $(cast az) --auth <address>
     ```

--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -90,7 +90,7 @@ The destination (*to*) can be an ENS name or an address.
     cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
     ```
 
-6. Send an EIP-7702 transaction delegating to `<address>`:
+6. Send an EIP-7702 transaction delegating the sender to `<address>`:
     ```sh
     cast send $(cast az) --auth <address>
     ```

--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -85,6 +85,17 @@ The destination (*to*) can be an ENS name or an address.
     cast send 0x... 0x68656c6c6f20776f726c64
     ```
 
+5. Sign an EIP-7702 authorization and attach it to a transaction from a different address:
+    ```sh
+    cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
+    ```
+
+6. Send an EIP-7702 transaction authorizing `<address>` to act on your behalf:
+    ```sh
+    cast send $(cast az) --auth <address>
+    ```
+
+
 ### SEE ALSO
 
 [cast](./cast.md), [cast call](./cast-call.md), [cast publish](./cast-publish.md), [cast receipt](./cast-receipt.md), [cast mktx](./cast-mktx.md), [struct encoding](../../misc/struct-encoding.md)

--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -85,7 +85,7 @@ The destination (*to*) can be an ENS name or an address.
     cast send 0x... 0x68656c6c6f20776f726c64
     ```
 
-5. Sign an EIP-7702 authorization and attach it to a transaction from a different address:
+5. Sign an EIP-7702 authorization and attach it to a transaction from a different sender:
     ```sh
     cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
     ```


### PR DESCRIPTION
closes #1272 

For now sets `cast az` as `to`, should be possible to make cleaner after https://github.com/foundry-rs/foundry/pull/8791