### PR TITLE
Add missing --fork-transaction-hash for anvil

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -363,6 +363,9 @@ Gets the transaction hash and the address which created a contract.
 `--fork-retry-backoff <BACKOFF>`
 &nbsp;&nbsp;&nbsp;&nbsp; Initial retry backoff on encountering errors.
 
+`--fork-transaction-hash <TRANSACTION>`
+&nbsp;&nbsp;&nbsp;&nbsp; Fetch state from a specific transaction hash over a remote endpoint (Must pass `--fork-url` in the same command-line).
+
 `--retries <retries>`
 &nbsp;&nbsp;&nbsp;&nbsp; Number of retry requests for spurious networks (timed out requests). [default: 5]
 


### PR DESCRIPTION
When running `anvil help` we see this option:

<img width="712" alt="image" src="https://github.com/user-attachments/assets/eb969ba9-b661-4ef9-81b6-323ca7a2bc30">


But it is not referenced in the docs.

https://book.getfoundry.sh/reference/anvil/#evm-options

Also, it might be nice to maybe re order the reference page so it matches the help menu of anvil (same categories, order etc.). If ok for you I can send another PR. 

But at least this option will now be in the doc and I believe it is an important one :)

(running `anvil 0.2.0 (f2518c9 2024-08-06T00:19:05.446984000Z)`)