### PR TITLE
chore: tweak help.rs

### DIFF
--- a/scripts/gen_output/help.rs
+++ b/scripts/gen_output/help.rs
@@ -171,7 +171,7 @@ fn get_entry(cmd: &Cmd) -> io::Result<(Vec<String>, String)> {
         .args(&cmd.subcommands)
         .arg("--help")
         .env("NO_COLOR", "1")
-        .env("COLUMNS", "100")
+        .env("COLUMNS", "80")
         .env("LINES", "10000")
         .stdout(Stdio::piped())
         .output()?;

--- a/src/reference/cli/anvil.md
+++ b/src/reference/cli/anvil.md
@@ -4,6 +4,9 @@ A fast local Ethereum development node
 
 ```bash
 $ anvil --help
+```
+
+```txt
 Usage: anvil [OPTIONS] [COMMAND]
 
 Commands:

--- a/src/reference/cli/anvil.md
+++ b/src/reference/cli/anvil.md
@@ -39,9 +39,11 @@ Options:
           [default: m/44'/60'/0'/0/]
 
       --dump-state <PATH>
-          Dump the state and block environment of chain on exit to the given file.
+          Dump the state and block environment of chain on exit to the given
+          file.
           
-          If the value is a directory, the state will be written to `<VALUE>/state.json`.
+          If the value is a directory, the state will be written to
+          `<VALUE>/state.json`.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -49,13 +51,15 @@ Options:
       --hardfork <HARDFORK>
           The EVM hardfork to use.
           
-          Choose the hardfork by name, e.g. `shanghai`, `paris`, `london`, etc... [default: latest]
+          Choose the hardfork by name, e.g. `shanghai`, `paris`, `london`,
+          etc... [default: latest]
 
       --init <PATH>
           Initialize the genesis block with the given `genesis.json` file
 
       --ipc [<PATH>]
-          Launch an ipc server at the given path or default path = `/tmp/anvil.ipc`
+          Launch an ipc server at the given path or default path =
+          `/tmp/anvil.ipc`
           
           [aliases: ipcpath]
 
@@ -63,8 +67,8 @@ Options:
           Initialize the chain from a previously saved state snapshot
 
   -m, --mnemonic <MNEMONIC>
-          BIP39 mnemonic phrase used for generating accounts. Cannot be used if `mnemonic_random` or
-          `mnemonic_seed` are used
+          BIP39 mnemonic phrase used for generating accounts. Cannot be used if
+          `mnemonic_random` or `mnemonic_seed` are used
 
       --max-persisted-states <MAX_PERSISTED_STATES>
           Max number of states to persist on disk.
@@ -75,16 +79,16 @@ Options:
           [aliases: mixed-mining]
 
       --mnemonic-random [<MNEMONIC_RANDOM>]
-          Automatically generates a BIP39 mnemonic phrase, and derives accounts from it. Cannot be
-          used with other `mnemonic` options. You can specify the number of words you want in the
-          mnemonic. [default: 12]
+          Automatically generates a BIP39 mnemonic phrase, and derives accounts
+          from it. Cannot be used with other `mnemonic` options. You can specify
+          the number of words you want in the mnemonic. [default: 12]
 
       --mnemonic-seed-unsafe <MNEMONIC_SEED>
-          Generates a BIP39 mnemonic phrase from a given seed Cannot be used with other `mnemonic`
-          options.
+          Generates a BIP39 mnemonic phrase from a given seed Cannot be used
+          with other `mnemonic` options.
           
-          CAREFUL: This is NOT SAFE and should only be used for testing. Never use the private keys
-          generated in production.
+          CAREFUL: This is NOT SAFE and should only be used for testing. Never
+          use the private keys generated in production.
 
       --no-mining
           Disable auto and interval mining, and mine on demand instead
@@ -102,13 +106,15 @@ Options:
           [default: 8545]
 
       --prune-history [<PRUNE_HISTORY>]
-          Don't keep full chain history. If a number argument is specified, at most this number of
-          states is kept in memory.
+          Don't keep full chain history. If a number argument is specified, at
+          most this number of states is kept in memory.
           
-          If enabled, no state will be persisted on disk, so `max_persisted_states` will be 0.
+          If enabled, no state will be persisted on disk, so
+          `max_persisted_states` will be 0.
 
   -s, --state-interval <SECONDS>
-          Interval in seconds at which the state and block environment is to be dumped to disk.
+          Interval in seconds at which the state and block environment is to be
+          dumped to disk.
           
           See --state and --dump-state
 
@@ -123,8 +129,8 @@ Options:
       --state <PATH>
           This is an alias for both --load-state and --dump-state.
           
-          It initializes the chain with the state and block environment stored at the file, if it
-          exists, and dumps the chain's state on exit.
+          It initializes the chain with the state and block environment stored
+          at the file, if it exists, and dumps the chain's state on exit.
 
       --timestamp <NUM>
           The timestamp of the genesis block
@@ -151,11 +157,13 @@ Server options:
           Disable CORS
 
       --no-request-size-limit
-          Disable the default request body size limit. At time of writing the default limit is 2MB
+          Disable the default request body size limit. At time of writing the
+          default limit is 2MB
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -163,10 +171,12 @@ Fork config:
           <https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second>
 
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, add a block number like
-          `http://localhost:8545@1400000` or use the `--fork-block-number` argument.
+          If you want to fetch state from a specific block number, add a block
+          number like `http://localhost:8545@1400000` or use the
+          `--fork-block-number` argument.
           
           [aliases: rpc-url]
 
@@ -176,11 +186,12 @@ Fork config:
           See --fork-url.
 
       --fork-chain-id <CHAIN>
-          Specify chain id to skip fetching it from remote endpoint. This enables offline-start
-          mode.
+          Specify chain id to skip fetching it from remote endpoint. This
+          enables offline-start mode.
           
-          You still must pass both `--fork-url` and `--fork-block-number`, and already have your
-          required state cached on disk, anything missing locally would be fetched from the remote.
+          You still must pass both `--fork-url` and `--fork-block-number`, and
+          already have your required state cached on disk, anything missing
+          locally would be fetched from the remote.
 
       --fork-header <HEADERS>
           Headers to use for the rpc client, e.g. "User-Agent: test-agent"
@@ -222,7 +233,8 @@ Fork config:
           Default value 5
 
       --timeout <timeout>
-          Timeout in ms for requests sent to remote JSON-RPC server in forking mode.
+          Timeout in ms for requests sent to remote JSON-RPC server in forking
+          mode.
           
           Default value 45000
 
@@ -236,8 +248,9 @@ Environment config:
           The chain ID
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. To
-          disable entirely, use `--disable-code-size-limit`. By default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. To disable entirely, use
+          `--disable-code-size-limit`. By default, it is 0x6000 (~25kb)
 
       --disable-block-gas-limit
           Disable the `call.gas_limit <= block.gas_limit` constraint

--- a/src/reference/cli/anvil/completions.md
+++ b/src/reference/cli/anvil/completions.md
@@ -4,6 +4,9 @@ Generate shell completions script
 
 ```bash
 $ anvil completions --help
+```
+
+```txt
 Usage: anvil completions <SHELL>
 
 Arguments:

--- a/src/reference/cli/anvil/generate-fig-spec.md
+++ b/src/reference/cli/anvil/generate-fig-spec.md
@@ -4,6 +4,9 @@ Generate Fig autocompletion spec
 
 ```bash
 $ anvil generate-fig-spec --help
+```
+
+```txt
 Usage: anvil generate-fig-spec
 
 Options:

--- a/src/reference/cli/cast.md
+++ b/src/reference/cli/cast.md
@@ -12,13 +12,17 @@ Usage: cast <COMMAND>
 Commands:
   4byte                  Get the function signatures for the given selector from
                          https://openchain.xyz [aliases: 4, 4b]
-  4byte-decode           Decode ABI-encoded calldata using https://openchain.xyz [aliases: 4d, 4bd]
-  4byte-event            Get the event signature for a given topic 0 from https://openchain.xyz
-                         [aliases: 4e, 4be, topic0-event, t0e]
-  abi-decode             Decode ABI-encoded input or output data [aliases: ad, --abi-decode]
-  abi-encode             ABI encode the given function argument, excluding the selector [aliases:
-                         ae]
-  access-list            Create an access list for a transaction [aliases: ac, acl]
+  4byte-decode           Decode ABI-encoded calldata using https://openchain.xyz
+                         [aliases: 4d, 4bd]
+  4byte-event            Get the event signature for a given topic 0 from
+                         https://openchain.xyz [aliases: 4e, 4be, topic0-event,
+                         t0e]
+  abi-decode             Decode ABI-encoded input or output data [aliases: ad,
+                         --abi-decode]
+  abi-encode             ABI encode the given function argument, excluding the
+                         selector [aliases: ae]
+  access-list            Create an access list for a transaction [aliases: ac,
+                         acl]
   address-zero           Prints the zero address [aliases: --address-zero, az]
   admin                  Fetch the EIP-1967 admin account [aliases: adm]
   age                    Get the timestamp of a block [aliases: a]
@@ -27,100 +31,136 @@ Commands:
   bind                   Generate a rust binding from a given ABI [aliases: bi]
   block                  Get information about a block [aliases: bl]
   block-number           Get the latest block number [aliases: bn]
-  call                   Perform a call on an account without publishing a transaction [aliases: c]
+  call                   Perform a call on an account without publishing a
+                         transaction [aliases: c]
   calldata               ABI-encode a function with arguments [aliases: cd]
-  calldata-decode        Decode ABI-encoded input data [aliases: --calldata-decode, cdd]
+  calldata-decode        Decode ABI-encoded input data [aliases:
+                         --calldata-decode, cdd]
   chain                  Get the symbolic name of the current chain
   chain-id               Get the Ethereum chain ID [aliases: ci, cid]
   client                 Get the current client version [aliases: cl]
   code                   Get the runtime bytecode of a contract [aliases: co]
   codehash               Get the codehash for an account
-  codesize               Get the runtime bytecode size of a contract [aliases: cs]
+  codesize               Get the runtime bytecode size of a contract [aliases:
+                         cs]
   completions            Generate shell completions script [aliases: com]
-  compute-address        Compute the contract address from a given nonce and deployer address
-                         [aliases: ca]
+  compute-address        Compute the contract address from a given nonce and
+                         deployer address [aliases: ca]
   concat-hex             Concatenate hex strings [aliases: --concat-hex, ch]
-  create2                Generate a deterministic contract address using CREATE2 [aliases: c2]
+  create2                Generate a deterministic contract address using CREATE2
+                         [aliases: c2]
   decode-eof             Decodes EOF container bytes
-  decode-transaction     Decodes a raw signed EIP 2718 typed transaction [aliases: dt, decode-tx]
-  disassemble            Disassembles hex encoded bytecode into individual / human readable opcodes
-                         [aliases: da]
+  decode-transaction     Decodes a raw signed EIP 2718 typed transaction
+                         [aliases: dt, decode-tx]
+  disassemble            Disassembles hex encoded bytecode into individual /
+                         human readable opcodes [aliases: da]
   estimate               Estimate the gas cost of a transaction [aliases: e]
-  etherscan-source       Get the source code of a contract from Etherscan [aliases: et, src]
-  find-block             Get the block number closest to the provided timestamp [aliases: f]
-  format-bytes32-string  Formats a string into bytes32 encoding [aliases: --format-bytes32-string]
-  from-bin               Convert binary data into hex data [aliases: --from-bin, from-binx, fb]
-  from-fixed-point       Convert a fixed point number into an integer [aliases: --from-fix, ff]
+  etherscan-source       Get the source code of a contract from Etherscan
+                         [aliases: et, src]
+  find-block             Get the block number closest to the provided timestamp
+                         [aliases: f]
+  format-bytes32-string  Formats a string into bytes32 encoding [aliases:
+                         --format-bytes32-string]
+  from-bin               Convert binary data into hex data [aliases: --from-bin,
+                         from-binx, fb]
+  from-fixed-point       Convert a fixed point number into an integer [aliases:
+                         --from-fix, ff]
   from-rlp               Decodes RLP hex-encoded data [aliases: --from-rlp]
-  from-utf8              Convert UTF8 text to hex [aliases: --from-ascii, --from-utf8, from-ascii,
-                         fu, fa]
-  from-wei               Convert wei into an ETH amount [aliases: --from-wei, fw]
+  from-utf8              Convert UTF8 text to hex [aliases: --from-ascii,
+                         --from-utf8, from-ascii, fu, fa]
+  from-wei               Convert wei into an ETH amount [aliases: --from-wei,
+                         fw]
   gas-price              Get the current gas price [aliases: g]
   generate-fig-spec      Generate Fig autocompletion spec [aliases: fig]
-  hash-message           Hash a message according to EIP-191 [aliases: --hash-message, hm]
+  hash-message           Hash a message according to EIP-191 [aliases:
+                         --hash-message, hm]
   hash-zero              Prints the zero hash [aliases: --hash-zero, hz]
-  help                   Print this message or the help of the given subcommand(s)
-  implementation         Fetch the EIP-1967 implementation account [aliases: impl]
-  index                  Compute the storage slot for an entry in a mapping [aliases: in]
-  index-erc7201          Compute storage slots as specified by `ERC-7201: Namespaced Storage Layout`
-                         [aliases: index7201, in7201]
-  interface              Generate a Solidity interface from a given ABI [aliases: i]
-  keccak                 Hash arbitrary data using Keccak-256 [aliases: k, keccak256]
+  help                   Print this message or the help of the given
+                         subcommand(s)
+  implementation         Fetch the EIP-1967 implementation account [aliases:
+                         impl]
+  index                  Compute the storage slot for an entry in a mapping
+                         [aliases: in]
+  index-erc7201          Compute storage slots as specified by `ERC-7201:
+                         Namespaced Storage Layout` [aliases: index7201, in7201]
+  interface              Generate a Solidity interface from a given ABI
+                         [aliases: i]
+  keccak                 Hash arbitrary data using Keccak-256 [aliases: k,
+                         keccak256]
   logs                   Get logs by signature or topic [aliases: l]
   lookup-address         Perform an ENS reverse lookup [aliases: la]
-  max-int                Prints the maximum value of the given integer type [aliases: --max-int,
-                         maxi]
-  max-uint               Prints the maximum value of the given integer type [aliases: --max-uint,
-                         maxu]
-  min-int                Prints the minimum value of the given integer type [aliases: --min-int,
-                         mini]
+  max-int                Prints the maximum value of the given integer type
+                         [aliases: --max-int, maxi]
+  max-uint               Prints the maximum value of the given integer type
+                         [aliases: --max-uint, maxu]
+  min-int                Prints the minimum value of the given integer type
+                         [aliases: --min-int, mini]
   mktx                   Build and sign a transaction [aliases: m]
   namehash               Calculate the ENS namehash of a name [aliases: na, nh]
   nonce                  Get the nonce for an account [aliases: n]
-  parse-bytes32-address  Parses a checksummed address from bytes32 encoding. [aliases:
-                         --parse-bytes32-address]
-  parse-bytes32-string   Parses a string from bytes32 encoding [aliases: --parse-bytes32-string]
+  parse-bytes32-address  Parses a checksummed address from bytes32 encoding.
+                         [aliases: --parse-bytes32-address]
+  parse-bytes32-string   Parses a string from bytes32 encoding [aliases:
+                         --parse-bytes32-string]
   pretty-calldata        Pretty print calldata [aliases: pc]
-  proof                  Generate a storage proof for a given storage slot [aliases: pr]
+  proof                  Generate a storage proof for a given storage slot
+                         [aliases: pr]
   publish                Publish a raw transaction to the network [aliases: p]
-  receipt                Get the transaction receipt for a transaction [aliases: re]
+  receipt                Get the transaction receipt for a transaction [aliases:
+                         re]
   resolve-name           Perform an ENS lookup [aliases: rn]
   rpc                    Perform a raw JSON-RPC request [aliases: rp]
-  run                    Runs a published transaction in a local environment and prints the trace
-                         [aliases: r]
-  selectors              Extracts function selectors and arguments from bytecode [aliases: sel]
+  run                    Runs a published transaction in a local environment and
+                         prints the trace [aliases: r]
+  selectors              Extracts function selectors and arguments from bytecode
+                         [aliases: sel]
   send                   Sign and publish a transaction [aliases: s]
   shl                    Perform a left shifting operation
   shr                    Perform a right shifting operation
   sig                    Get the selector for a function [aliases: si]
-  sig-event              Generate event signatures from event string [aliases: se]
-  storage                Get the raw value of a contract's storage slot [aliases: st]
+  sig-event              Generate event signatures from event string [aliases:
+                         se]
+  storage                Get the raw value of a contract's storage slot
+                         [aliases: st]
   storage-root           Get the storage root for an account [aliases: sr]
-  to-ascii               Convert hex data to an ASCII string [aliases: --to-ascii, tas, 2as]
-  to-base                Converts a number of one base to another [aliases: --to-base, --to-radix,
-                         to-radix, tr, 2r]
-  to-bytes32             Right-pads hex data to 32 bytes [aliases: --to-bytes32, tb, 2b]
-  to-check-sum-address   Convert an address to a checksummed format (EIP-55) [aliases:
-                         --to-checksum-address, --to-checksum, to-checksum, ta, 2a]
-  to-dec                 Converts a number of one base to decimal [aliases: --to-dec, td, 2d]
-  to-fixed-point         Convert an integer into a fixed point number [aliases: --to-fix, tf, 2f]
-  to-hex                 Converts a number of one base to another [aliases: --to-hex, th, 2h]
-  to-hexdata             Normalize the input to lowercase, 0x-prefixed hex [aliases: --to-hexdata,
-                         thd, 2hd]
-  to-int256              Convert a number to a hex-encoded int256 [aliases: --to-int256, ti, 2i]
-  to-rlp                 RLP encodes hex data, or an array of hex data [aliases: --to-rlp]
-  to-uint256             Convert a number to a hex-encoded uint256 [aliases: --to-uint256, tu, 2u]
-  to-unit                Convert an ETH amount into another unit (ether, gwei or wei) [aliases:
-                         --to-unit, tun, 2un]
-  to-utf8                Convert hex data to a utf-8 string [aliases: --to-utf8, tu8, 2u8]
-  to-wei                 Convert an ETH amount to wei [aliases: --to-wei, tw, 2w]
+  to-ascii               Convert hex data to an ASCII string [aliases:
+                         --to-ascii, tas, 2as]
+  to-base                Converts a number of one base to another [aliases:
+                         --to-base, --to-radix, to-radix, tr, 2r]
+  to-bytes32             Right-pads hex data to 32 bytes [aliases: --to-bytes32,
+                         tb, 2b]
+  to-check-sum-address   Convert an address to a checksummed format (EIP-55)
+                         [aliases: --to-checksum-address, --to-checksum,
+                         to-checksum, ta, 2a]
+  to-dec                 Converts a number of one base to decimal [aliases:
+                         --to-dec, td, 2d]
+  to-fixed-point         Convert an integer into a fixed point number [aliases:
+                         --to-fix, tf, 2f]
+  to-hex                 Converts a number of one base to another [aliases:
+                         --to-hex, th, 2h]
+  to-hexdata             Normalize the input to lowercase, 0x-prefixed hex
+                         [aliases: --to-hexdata, thd, 2hd]
+  to-int256              Convert a number to a hex-encoded int256 [aliases:
+                         --to-int256, ti, 2i]
+  to-rlp                 RLP encodes hex data, or an array of hex data [aliases:
+                         --to-rlp]
+  to-uint256             Convert a number to a hex-encoded uint256 [aliases:
+                         --to-uint256, tu, 2u]
+  to-unit                Convert an ETH amount into another unit (ether, gwei or
+                         wei) [aliases: --to-unit, tun, 2un]
+  to-utf8                Convert hex data to a utf-8 string [aliases: --to-utf8,
+                         tu8, 2u8]
+  to-wei                 Convert an ETH amount to wei [aliases: --to-wei, tw,
+                         2w]
   tx                     Get information about a transaction [aliases: t]
-  upload-signature       Upload the given signatures to https://openchain.xyz [aliases: ups]
+  upload-signature       Upload the given signatures to https://openchain.xyz
+                         [aliases: ups]
   wallet                 Wallet management utilities [aliases: w]
 
 Options:
   -h, --help     Print help
   -V, --version  Print version
 
-Find more information in the book: http://book.getfoundry.sh/reference/cast/cast.html
+Find more information in the book:
+http://book.getfoundry.sh/reference/cast/cast.html
 ```

--- a/src/reference/cli/cast.md
+++ b/src/reference/cli/cast.md
@@ -4,6 +4,9 @@ Perform Ethereum RPC calls from the comfort of your command line
 
 ```bash
 $ cast --help
+```
+
+```txt
 Usage: cast <COMMAND>
 
 Commands:

--- a/src/reference/cli/cast/4byte-decode.md
+++ b/src/reference/cli/cast/4byte-decode.md
@@ -4,6 +4,9 @@ Decode ABI-encoded calldata using https://openchain.xyz
 
 ```bash
 $ cast 4byte-decode --help
+```
+
+```txt
 Usage: cast 4byte-decode [OPTIONS] [CALLDATA]
 
 Arguments:

--- a/src/reference/cli/cast/4byte-event.md
+++ b/src/reference/cli/cast/4byte-event.md
@@ -4,6 +4,9 @@ Get the event signature for a given topic 0 from https://openchain.xyz
 
 ```bash
 $ cast 4byte-event --help
+```
+
+```txt
 Usage: cast 4byte-event [TOPIC_0]
 
 Arguments:

--- a/src/reference/cli/cast/4byte.md
+++ b/src/reference/cli/cast/4byte.md
@@ -4,6 +4,9 @@ Get the function signatures for the given selector from https://openchain.xyz
 
 ```bash
 $ cast 4byte --help
+```
+
+```txt
 Usage: cast 4byte [SELECTOR]
 
 Arguments:

--- a/src/reference/cli/cast/abi-decode.md
+++ b/src/reference/cli/cast/abi-decode.md
@@ -4,6 +4,9 @@ Decode ABI-encoded input or output data.
 
 ```bash
 $ cast abi-decode --help
+```
+
+```txt
 Usage: cast abi-decode [OPTIONS] <SIG> <CALLDATA>
 
 Arguments:

--- a/src/reference/cli/cast/abi-encode.md
+++ b/src/reference/cli/cast/abi-encode.md
@@ -4,6 +4,9 @@ ABI encode the given function argument, excluding the selector
 
 ```bash
 $ cast abi-encode --help
+```
+
+```txt
 Usage: cast abi-encode [OPTIONS] <SIG> [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/access-list.md
+++ b/src/reference/cli/cast/access-list.md
@@ -4,6 +4,9 @@ Create an access list for a transaction
 
 ```bash
 $ cast access-list --help
+```
+
+```txt
 Usage: cast access-list [OPTIONS] [TO] [SIG] [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/access-list.md
+++ b/src/reference/cli/cast/access-list.md
@@ -39,8 +39,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -52,8 +53,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -85,17 +86,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -151,7 +155,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/address-zero.md
+++ b/src/reference/cli/cast/address-zero.md
@@ -4,6 +4,9 @@ Prints the zero address
 
 ```bash
 $ cast address-zero --help
+```
+
+```txt
 Usage: cast address-zero
 
 Options:

--- a/src/reference/cli/cast/admin.md
+++ b/src/reference/cli/cast/admin.md
@@ -25,17 +25,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/admin.md
+++ b/src/reference/cli/cast/admin.md
@@ -4,6 +4,9 @@ Fetch the EIP-1967 admin account
 
 ```bash
 $ cast admin --help
+```
+
+```txt
 Usage: cast admin [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/age.md
+++ b/src/reference/cli/cast/age.md
@@ -22,17 +22,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/age.md
+++ b/src/reference/cli/cast/age.md
@@ -4,6 +4,9 @@ Get the timestamp of a block
 
 ```bash
 $ cast age --help
+```
+
+```txt
 Usage: cast age [OPTIONS] [BLOCK]
 
 Arguments:

--- a/src/reference/cli/cast/balance.md
+++ b/src/reference/cli/cast/balance.md
@@ -4,6 +4,9 @@ Get the balance of an account in wei
 
 ```bash
 $ cast balance --help
+```
+
+```txt
 Usage: cast balance [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/balance.md
+++ b/src/reference/cli/cast/balance.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -48,8 +51,8 @@ Options:
           [env: ETH_RPC_JWT_SECRET=]
 
       --erc20 <ERC20>
-          erc20 address to query, with the method `balanceOf(address) return (uint256)`, alias with
-          '--erc721'
+          erc20 address to query, with the method `balanceOf(address) return
+          (uint256)`, alias with '--erc721'
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/cast/base-fee.md
+++ b/src/reference/cli/cast/base-fee.md
@@ -4,6 +4,9 @@ Get the basefee of a block
 
 ```bash
 $ cast base-fee --help
+```
+
+```txt
 Usage: cast base-fee [OPTIONS] [BLOCK]
 
 Arguments:

--- a/src/reference/cli/cast/base-fee.md
+++ b/src/reference/cli/cast/base-fee.md
@@ -22,17 +22,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/bind.md
+++ b/src/reference/cli/cast/bind.md
@@ -22,16 +22,16 @@ Options:
       --crate-name <NAME>
           The name of the Rust crate to generate.
           
-          This should be a valid crates.io crate name. However, this is currently not validated by
-          this command.
+          This should be a valid crates.io crate name. However, this is
+          currently not validated by this command.
           
           [default: foundry-contracts]
 
       --crate-version <VERSION>
           The version of the Rust crate to generate.
           
-          This should be a standard semver version string. However, it is not currently validated by
-          this command.
+          This should be a standard semver version string. However, it is not
+          currently validated by this command.
           
           [default: 0.0.1]
 

--- a/src/reference/cli/cast/bind.md
+++ b/src/reference/cli/cast/bind.md
@@ -4,6 +4,9 @@ Generate a rust binding from a given ABI
 
 ```bash
 $ cast bind --help
+```
+
+```txt
 Usage: cast bind [OPTIONS] <PATH_OR_ADDRESS>
 
 Arguments:

--- a/src/reference/cli/cast/block-number.md
+++ b/src/reference/cli/cast/block-number.md
@@ -4,6 +4,9 @@ Get the latest block number
 
 ```bash
 $ cast block-number --help
+```
+
+```txt
 Usage: cast block-number [OPTIONS] [BLOCK]
 
 Arguments:

--- a/src/reference/cli/cast/block-number.md
+++ b/src/reference/cli/cast/block-number.md
@@ -11,7 +11,8 @@ Usage: cast block-number [OPTIONS] [BLOCK]
 
 Arguments:
   [BLOCK]
-          The hash or tag to query. If not specified, the latest number is returned
+          The hash or tag to query. If not specified, the latest number is
+          returned
 
 Options:
   -r, --rpc-url <URL>
@@ -20,17 +21,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/block.md
+++ b/src/reference/cli/cast/block.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/block.md
+++ b/src/reference/cli/cast/block.md
@@ -4,6 +4,9 @@ Get information about a block
 
 ```bash
 $ cast block --help
+```
+
+```txt
 Usage: cast block [OPTIONS] [BLOCK]
 
 Arguments:

--- a/src/reference/cli/cast/call.md
+++ b/src/reference/cli/cast/call.md
@@ -4,6 +4,9 @@ Perform a call on an account without publishing a transaction
 
 ```bash
 $ cast call --help
+```
+
+```txt
 Usage: cast call [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]
 
 Commands:

--- a/src/reference/cli/cast/call.md
+++ b/src/reference/cli/cast/call.md
@@ -28,7 +28,8 @@ Options:
           Data for the transaction
 
       --trace
-          Forks the remote rpc, executes the transaction locally and prints a trace
+          Forks the remote rpc, executes the transaction locally and prints a
+          trace
 
       --debug
           Opens an interactive debugger. Can only be used with `--trace`
@@ -37,7 +38,8 @@ Options:
           
 
       --labels <LABELS>
-          Labels to apply to the traces; format: `address:label`. Can only be used with `--trace`
+          Labels to apply to the traces; format: `address:label`. Can only be
+          used with `--trace`
 
       --evm-version <EVM_VERSION>
           The EVM Version to use. Can only be used with `--trace`
@@ -64,8 +66,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -77,8 +80,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -110,17 +113,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -176,7 +182,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/call/--create.md
+++ b/src/reference/cli/cast/call/--create.md
@@ -4,6 +4,9 @@ ignores the address field and simulates creating a contract
 
 ```bash
 $ cast call --create --help
+```
+
+```txt
 Usage: cast call --create [OPTIONS] <CODE> [SIG] [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/calldata-decode.md
+++ b/src/reference/cli/cast/calldata-decode.md
@@ -4,6 +4,9 @@ Decode ABI-encoded input data.
 
 ```bash
 $ cast calldata-decode --help
+```
+
+```txt
 Usage: cast calldata-decode [OPTIONS] <SIG> <CALLDATA>
 
 Arguments:

--- a/src/reference/cli/cast/calldata.md
+++ b/src/reference/cli/cast/calldata.md
@@ -10,7 +10,8 @@ $ cast calldata --help
 Usage: cast calldata <SIG> [ARGS]...
 
 Arguments:
-  <SIG>      The function signature in the format `<name>(<in-types>)(<out-types>)`
+  <SIG>      The function signature in the format
+             `<name>(<in-types>)(<out-types>)`
   [ARGS]...  The arguments to encode
 
 Options:

--- a/src/reference/cli/cast/calldata.md
+++ b/src/reference/cli/cast/calldata.md
@@ -4,6 +4,9 @@ ABI-encode a function with arguments
 
 ```bash
 $ cast calldata --help
+```
+
+```txt
 Usage: cast calldata <SIG> [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/chain-id.md
+++ b/src/reference/cli/cast/chain-id.md
@@ -16,17 +16,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/chain-id.md
+++ b/src/reference/cli/cast/chain-id.md
@@ -4,6 +4,9 @@ Get the Ethereum chain ID
 
 ```bash
 $ cast chain-id --help
+```
+
+```txt
 Usage: cast chain-id [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/chain.md
+++ b/src/reference/cli/cast/chain.md
@@ -16,17 +16,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/chain.md
+++ b/src/reference/cli/cast/chain.md
@@ -4,6 +4,9 @@ Get the symbolic name of the current chain
 
 ```bash
 $ cast chain --help
+```
+
+```txt
 Usage: cast chain [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/client.md
+++ b/src/reference/cli/cast/client.md
@@ -16,17 +16,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/client.md
+++ b/src/reference/cli/cast/client.md
@@ -4,6 +4,9 @@ Get the current client version
 
 ```bash
 $ cast client --help
+```
+
+```txt
 Usage: cast client [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/code.md
+++ b/src/reference/cli/cast/code.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/code.md
+++ b/src/reference/cli/cast/code.md
@@ -4,6 +4,9 @@ Get the runtime bytecode of a contract
 
 ```bash
 $ cast code --help
+```
+
+```txt
 Usage: cast code [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/codehash.md
+++ b/src/reference/cli/cast/codehash.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/codehash.md
+++ b/src/reference/cli/cast/codehash.md
@@ -4,6 +4,9 @@ Get the codehash for an account
 
 ```bash
 $ cast codehash --help
+```
+
+```txt
 Usage: cast codehash [OPTIONS] <WHO> [SLOTS]...
 
 Arguments:

--- a/src/reference/cli/cast/codesize.md
+++ b/src/reference/cli/cast/codesize.md
@@ -25,17 +25,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/codesize.md
+++ b/src/reference/cli/cast/codesize.md
@@ -4,6 +4,9 @@ Get the runtime bytecode size of a contract
 
 ```bash
 $ cast codesize --help
+```
+
+```txt
 Usage: cast codesize [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/completions.md
+++ b/src/reference/cli/cast/completions.md
@@ -4,6 +4,9 @@ Generate shell completions script
 
 ```bash
 $ cast completions --help
+```
+
+```txt
 Usage: cast completions <SHELL>
 
 Arguments:

--- a/src/reference/cli/cast/compute-address.md
+++ b/src/reference/cli/cast/compute-address.md
@@ -4,6 +4,9 @@ Compute the contract address from a given nonce and deployer address
 
 ```bash
 $ cast compute-address --help
+```
+
+```txt
 Usage: cast compute-address [OPTIONS] [ADDRESS]
 
 Arguments:

--- a/src/reference/cli/cast/compute-address.md
+++ b/src/reference/cli/cast/compute-address.md
@@ -23,17 +23,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/concat-hex.md
+++ b/src/reference/cli/cast/concat-hex.md
@@ -4,6 +4,9 @@ Concatenate hex strings
 
 ```bash
 $ cast concat-hex --help
+```
+
+```txt
 Usage: cast concat-hex [DATA]...
 
 Arguments:

--- a/src/reference/cli/cast/create2.md
+++ b/src/reference/cli/cast/create2.md
@@ -4,6 +4,9 @@ Generate a deterministic contract address using CREATE2
 
 ```bash
 $ cast create2 --help
+```
+
+```txt
 Usage: cast create2 [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/create2.md
+++ b/src/reference/cli/cast/create2.md
@@ -16,15 +16,18 @@ Options:
   -c, --case-sensitive         Case sensitive matching
   -d, --deployer <ADDRESS>     Address of the contract deployer [default:
                                0x4e59b44847b379578588920ca78fbf26c0b4956c]
-      --salt <HEX>             Salt to be used for the contract deployment. This option separate
-                               from the default salt mining with filters
+      --salt <HEX>             Salt to be used for the contract deployment. This
+                               option separate from the default salt mining with
+                               filters
   -i, --init-code <HEX>        Init code of the contract to be deployed
       --init-code-hash <HASH>  Init code hash of the contract to be deployed
-  -j, --jobs <JOBS>            Number of threads to use. Defaults to and caps at the number of
-                               logical cores
-      --caller <ADDRESS>       Address of the caller. Used for the first 20 bytes of the salt
-      --seed <HEX>             The random number generator's seed, used to initialize the salt
-      --no-random              Don't initialize the salt with a random value, and instead use the
-                               default value of 0
+  -j, --jobs <JOBS>            Number of threads to use. Defaults to and caps at
+                               the number of logical cores
+      --caller <ADDRESS>       Address of the caller. Used for the first 20
+                               bytes of the salt
+      --seed <HEX>             The random number generator's seed, used to
+                               initialize the salt
+      --no-random              Don't initialize the salt with a random value,
+                               and instead use the default value of 0
   -h, --help                   Print help
 ```

--- a/src/reference/cli/cast/decode-eof.md
+++ b/src/reference/cli/cast/decode-eof.md
@@ -4,6 +4,9 @@ Decodes EOF container bytes
 
 ```bash
 $ cast decode-eof --help
+```
+
+```txt
 Usage: cast decode-eof [EOF]
 
 Arguments:

--- a/src/reference/cli/cast/decode-transaction.md
+++ b/src/reference/cli/cast/decode-transaction.md
@@ -4,6 +4,9 @@ Decodes a raw signed EIP 2718 typed transaction
 
 ```bash
 $ cast decode-transaction --help
+```
+
+```txt
 Usage: cast decode-transaction [TX]
 
 Arguments:

--- a/src/reference/cli/cast/disassemble.md
+++ b/src/reference/cli/cast/disassemble.md
@@ -4,6 +4,9 @@ Disassembles hex encoded bytecode into individual / human readable opcodes
 
 ```bash
 $ cast disassemble --help
+```
+
+```txt
 Usage: cast disassemble <BYTECODE>
 
 Arguments:

--- a/src/reference/cli/cast/estimate.md
+++ b/src/reference/cli/cast/estimate.md
@@ -4,6 +4,9 @@ Estimate the gas cost of a transaction
 
 ```bash
 $ cast estimate --help
+```
+
+```txt
 Usage: cast estimate [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]
 
 Commands:

--- a/src/reference/cli/cast/estimate.md
+++ b/src/reference/cli/cast/estimate.md
@@ -39,8 +39,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -52,8 +53,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -85,17 +86,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -151,7 +155,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/estimate/--create.md
+++ b/src/reference/cli/cast/estimate/--create.md
@@ -4,6 +4,9 @@ Estimate gas cost to deploy a smart contract
 
 ```bash
 $ cast estimate --create --help
+```
+
+```txt
 Usage: cast estimate --create [OPTIONS] <CODE> [SIG] [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/etherscan-source.md
+++ b/src/reference/cli/cast/etherscan-source.md
@@ -13,9 +13,14 @@ Arguments:
   <ADDRESS>  The contract's address
 
 Options:
-  -f, --flatten                  Whether to flatten the source code
-  -d <DIRECTORY>                 The output directory/file to expand source tree into
-  -e, --etherscan-api-key <KEY>  The Etherscan (or equivalent) API key [env: ETHERSCAN_API_KEY=]
-  -c, --chain <CHAIN>            The chain name or EIP-155 chain ID [env: CHAIN=]
-  -h, --help                     Print help
+  -f, --flatten
+          Whether to flatten the source code
+  -d <DIRECTORY>
+          The output directory/file to expand source tree into
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key [env: ETHERSCAN_API_KEY=]
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID [env: CHAIN=]
+  -h, --help
+          Print help
 ```

--- a/src/reference/cli/cast/etherscan-source.md
+++ b/src/reference/cli/cast/etherscan-source.md
@@ -4,6 +4,9 @@ Get the source code of a contract from Etherscan
 
 ```bash
 $ cast etherscan-source --help
+```
+
+```txt
 Usage: cast etherscan-source [OPTIONS] <ADDRESS>
 
 Arguments:

--- a/src/reference/cli/cast/find-block.md
+++ b/src/reference/cli/cast/find-block.md
@@ -4,6 +4,9 @@ Get the block number closest to the provided timestamp
 
 ```bash
 $ cast find-block --help
+```
+
+```txt
 Usage: cast find-block [OPTIONS] <TIMESTAMP>
 
 Arguments:

--- a/src/reference/cli/cast/find-block.md
+++ b/src/reference/cli/cast/find-block.md
@@ -20,17 +20,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/format-bytes32-string.md
+++ b/src/reference/cli/cast/format-bytes32-string.md
@@ -4,6 +4,9 @@ Formats a string into bytes32 encoding
 
 ```bash
 $ cast format-bytes32-string --help
+```
+
+```txt
 Usage: cast format-bytes32-string [STRING]
 
 Arguments:

--- a/src/reference/cli/cast/from-bin.md
+++ b/src/reference/cli/cast/from-bin.md
@@ -4,6 +4,9 @@ Convert binary data into hex data
 
 ```bash
 $ cast from-bin --help
+```
+
+```txt
 Usage: cast from-bin
 
 Options:

--- a/src/reference/cli/cast/from-fixed-point.md
+++ b/src/reference/cli/cast/from-fixed-point.md
@@ -4,6 +4,9 @@ Convert a fixed point number into an integer
 
 ```bash
 $ cast from-fixed-point --help
+```
+
+```txt
 Usage: cast from-fixed-point [DECIMALS] [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/from-rlp.md
+++ b/src/reference/cli/cast/from-rlp.md
@@ -4,6 +4,9 @@ Decodes RLP hex-encoded data
 
 ```bash
 $ cast from-rlp --help
+```
+
+```txt
 Usage: cast from-rlp [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/from-utf8.md
+++ b/src/reference/cli/cast/from-utf8.md
@@ -4,6 +4,9 @@ Convert UTF8 text to hex
 
 ```bash
 $ cast from-utf8 --help
+```
+
+```txt
 Usage: cast from-utf8 [TEXT]
 
 Arguments:

--- a/src/reference/cli/cast/from-wei.md
+++ b/src/reference/cli/cast/from-wei.md
@@ -4,6 +4,9 @@ Convert wei into an ETH amount.
 
 ```bash
 $ cast from-wei --help
+```
+
+```txt
 Usage: cast from-wei [VALUE] [UNIT]
 
 Arguments:

--- a/src/reference/cli/cast/gas-price.md
+++ b/src/reference/cli/cast/gas-price.md
@@ -16,17 +16,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/gas-price.md
+++ b/src/reference/cli/cast/gas-price.md
@@ -4,6 +4,9 @@ Get the current gas price
 
 ```bash
 $ cast gas-price --help
+```
+
+```txt
 Usage: cast gas-price [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/generate-fig-spec.md
+++ b/src/reference/cli/cast/generate-fig-spec.md
@@ -4,6 +4,9 @@ Generate Fig autocompletion spec
 
 ```bash
 $ cast generate-fig-spec --help
+```
+
+```txt
 Usage: cast generate-fig-spec
 
 Options:

--- a/src/reference/cli/cast/hash-message.md
+++ b/src/reference/cli/cast/hash-message.md
@@ -4,6 +4,9 @@ Hash a message according to EIP-191
 
 ```bash
 $ cast hash-message --help
+```
+
+```txt
 Usage: cast hash-message [MESSAGE]
 
 Arguments:

--- a/src/reference/cli/cast/hash-zero.md
+++ b/src/reference/cli/cast/hash-zero.md
@@ -4,6 +4,9 @@ Prints the zero hash
 
 ```bash
 $ cast hash-zero --help
+```
+
+```txt
 Usage: cast hash-zero
 
 Options:

--- a/src/reference/cli/cast/implementation.md
+++ b/src/reference/cli/cast/implementation.md
@@ -25,17 +25,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/implementation.md
+++ b/src/reference/cli/cast/implementation.md
@@ -4,6 +4,9 @@ Fetch the EIP-1967 implementation account
 
 ```bash
 $ cast implementation --help
+```
+
+```txt
 Usage: cast implementation [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/index-erc7201.md
+++ b/src/reference/cli/cast/index-erc7201.md
@@ -13,7 +13,9 @@ Arguments:
   [ID]  The arbitrary identifier
 
 Options:
-      --formula-id <FORMULA_ID>  The formula ID. Currently the only supported formula is `erc7201`
-                                 [default: erc7201]
-  -h, --help                     Print help
+      --formula-id <FORMULA_ID>
+          The formula ID. Currently the only supported formula is `erc7201`
+          [default: erc7201]
+  -h, --help
+          Print help
 ```

--- a/src/reference/cli/cast/index-erc7201.md
+++ b/src/reference/cli/cast/index-erc7201.md
@@ -4,6 +4,9 @@ Compute storage slots as specified by `ERC-7201: Namespaced Storage Layout`
 
 ```bash
 $ cast index-erc7201 --help
+```
+
+```txt
 Usage: cast index-erc7201 [OPTIONS] [ID]
 
 Arguments:

--- a/src/reference/cli/cast/index.md
+++ b/src/reference/cli/cast/index.md
@@ -4,6 +4,9 @@ Compute the storage slot for an entry in a mapping
 
 ```bash
 $ cast index --help
+```
+
+```txt
 Usage: cast index <KEY_TYPE> <KEY> <SLOT_NUMBER>
 
 Arguments:

--- a/src/reference/cli/cast/interface.md
+++ b/src/reference/cli/cast/interface.md
@@ -11,9 +11,10 @@ Usage: cast interface [OPTIONS] <CONTRACT>
 
 Arguments:
   <CONTRACT>
-          The target contract, which can be one of: - A file path to an ABI JSON file. - A contract
-          identifier in the form `<path>:<contractname>` or just `<contractname>`. - An Ethereum
-          address, for which the ABI will be fetched from Etherscan
+          The target contract, which can be one of: - A file path to an ABI JSON
+          file. - A contract identifier in the form `<path>:<contractname>` or
+          just `<contractname>`. - An Ethereum address, for which the ABI will
+          be fetched from Etherscan
 
 Options:
   -n, --name <NAME>
@@ -32,7 +33,8 @@ Options:
           If not specified, the interface will be output to stdout.
 
   -j, --json
-          If specified, the interface will be output as JSON rather than Solidity
+          If specified, the interface will be output as JSON rather than
+          Solidity
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key

--- a/src/reference/cli/cast/interface.md
+++ b/src/reference/cli/cast/interface.md
@@ -4,6 +4,9 @@ Generate a Solidity interface from a given ABI.
 
 ```bash
 $ cast interface --help
+```
+
+```txt
 Usage: cast interface [OPTIONS] <CONTRACT>
 
 Arguments:

--- a/src/reference/cli/cast/keccak.md
+++ b/src/reference/cli/cast/keccak.md
@@ -4,6 +4,9 @@ Hash arbitrary data using Keccak-256
 
 ```bash
 $ cast keccak --help
+```
+
+```txt
 Usage: cast keccak [DATA]
 
 Arguments:

--- a/src/reference/cli/cast/logs.md
+++ b/src/reference/cli/cast/logs.md
@@ -4,6 +4,9 @@ Get logs by signature or topic
 
 ```bash
 $ cast logs --help
+```
+
+```txt
 Usage: cast logs [OPTIONS] [SIG_OR_TOPIC] [TOPICS_OR_ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/logs.md
+++ b/src/reference/cli/cast/logs.md
@@ -11,12 +11,12 @@ Usage: cast logs [OPTIONS] [SIG_OR_TOPIC] [TOPICS_OR_ARGS]...
 
 Arguments:
   [SIG_OR_TOPIC]
-          The signature of the event to filter logs by which will be converted to the first topic or
-          a topic to filter on
+          The signature of the event to filter logs by which will be converted
+          to the first topic or a topic to filter on
 
   [TOPICS_OR_ARGS]...
-          If used with a signature, the indexed fields of the event to filter by. Otherwise, the
-          remaining topics of the filter
+          If used with a signature, the indexed fields of the event to filter
+          by. Otherwise, the remaining topics of the filter
 
 Options:
       --from-block <FROM_BLOCK>
@@ -33,8 +33,9 @@ Options:
           The contract address to filter on
 
       --subscribe
-          If the RPC type and endpoints supports `eth_subscribe` stream logs instead of printing and
-          exiting. Will continue until interrupted or TO_BLOCK is reached
+          If the RPC type and endpoints supports `eth_subscribe` stream logs
+          instead of printing and exiting. Will continue until interrupted or
+          TO_BLOCK is reached
 
   -h, --help
           Print help (see a summary with '-h')
@@ -50,17 +51,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -116,7 +120,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/lookup-address.md
+++ b/src/reference/cli/cast/lookup-address.md
@@ -4,6 +4,9 @@ Perform an ENS reverse lookup
 
 ```bash
 $ cast lookup-address --help
+```
+
+```txt
 Usage: cast lookup-address [OPTIONS] [WHO]
 
 Arguments:

--- a/src/reference/cli/cast/lookup-address.md
+++ b/src/reference/cli/cast/lookup-address.md
@@ -23,17 +23,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/max-int.md
+++ b/src/reference/cli/cast/max-int.md
@@ -4,6 +4,9 @@ Prints the maximum value of the given integer type
 
 ```bash
 $ cast max-int --help
+```
+
+```txt
 Usage: cast max-int [TYPE]
 
 Arguments:

--- a/src/reference/cli/cast/max-uint.md
+++ b/src/reference/cli/cast/max-uint.md
@@ -4,6 +4,9 @@ Prints the maximum value of the given integer type
 
 ```bash
 $ cast max-uint --help
+```
+
+```txt
 Usage: cast max-uint [TYPE]
 
 Arguments:

--- a/src/reference/cli/cast/max-uint.md
+++ b/src/reference/cli/cast/max-uint.md
@@ -10,7 +10,8 @@ $ cast max-uint --help
 Usage: cast max-uint [TYPE]
 
 Arguments:
-  [TYPE]  The unsigned integer type to get the maximum value of [default: uint256]
+  [TYPE]  The unsigned integer type to get the maximum value of [default:
+          uint256]
 
 Options:
   -h, --help  Print help

--- a/src/reference/cli/cast/min-int.md
+++ b/src/reference/cli/cast/min-int.md
@@ -4,6 +4,9 @@ Prints the minimum value of the given integer type
 
 ```bash
 $ cast min-int --help
+```
+
+```txt
 Usage: cast min-int [TYPE]
 
 Arguments:

--- a/src/reference/cli/cast/mktx.md
+++ b/src/reference/cli/cast/mktx.md
@@ -36,8 +36,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -49,8 +50,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -85,17 +86,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -151,7 +155,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/mktx.md
+++ b/src/reference/cli/cast/mktx.md
@@ -4,6 +4,9 @@ Build and sign a transaction
 
 ```bash
 $ cast mktx --help
+```
+
+```txt
 Usage: cast mktx [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]
 
 Commands:

--- a/src/reference/cli/cast/mktx/--create.md
+++ b/src/reference/cli/cast/mktx/--create.md
@@ -4,6 +4,9 @@ Use to deploy raw contract bytecode
 
 ```bash
 $ cast mktx --create --help
+```
+
+```txt
 Usage: cast mktx --create <CODE> [SIG] [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/namehash.md
+++ b/src/reference/cli/cast/namehash.md
@@ -4,6 +4,9 @@ Calculate the ENS namehash of a name
 
 ```bash
 $ cast namehash --help
+```
+
+```txt
 Usage: cast namehash [NAME]
 
 Arguments:

--- a/src/reference/cli/cast/nonce.md
+++ b/src/reference/cli/cast/nonce.md
@@ -4,6 +4,9 @@ Get the nonce for an account
 
 ```bash
 $ cast nonce --help
+```
+
+```txt
 Usage: cast nonce [OPTIONS] <WHO>
 
 Arguments:

--- a/src/reference/cli/cast/nonce.md
+++ b/src/reference/cli/cast/nonce.md
@@ -25,17 +25,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/parse-bytes32-address.md
+++ b/src/reference/cli/cast/parse-bytes32-address.md
@@ -4,6 +4,9 @@ Parses a checksummed address from bytes32 encoding.
 
 ```bash
 $ cast parse-bytes32-address --help
+```
+
+```txt
 Usage: cast parse-bytes32-address [BYTES]
 
 Arguments:

--- a/src/reference/cli/cast/parse-bytes32-string.md
+++ b/src/reference/cli/cast/parse-bytes32-string.md
@@ -4,6 +4,9 @@ Parses a string from bytes32 encoding
 
 ```bash
 $ cast parse-bytes32-string --help
+```
+
+```txt
 Usage: cast parse-bytes32-string [BYTES]
 
 Arguments:

--- a/src/reference/cli/cast/pretty-calldata.md
+++ b/src/reference/cli/cast/pretty-calldata.md
@@ -4,6 +4,9 @@ Pretty print calldata.
 
 ```bash
 $ cast pretty-calldata --help
+```
+
+```txt
 Usage: cast pretty-calldata [OPTIONS] [CALLDATA]
 
 Arguments:

--- a/src/reference/cli/cast/proof.md
+++ b/src/reference/cli/cast/proof.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/proof.md
+++ b/src/reference/cli/cast/proof.md
@@ -4,6 +4,9 @@ Generate a storage proof for a given storage slot
 
 ```bash
 $ cast proof --help
+```
+
+```txt
 Usage: cast proof [OPTIONS] <ADDRESS> [SLOTS]...
 
 Arguments:

--- a/src/reference/cli/cast/publish.md
+++ b/src/reference/cli/cast/publish.md
@@ -4,6 +4,9 @@ Publish a raw transaction to the network
 
 ```bash
 $ cast publish --help
+```
+
+```txt
 Usage: cast publish [OPTIONS] <RAW_TX>
 
 Arguments:

--- a/src/reference/cli/cast/publish.md
+++ b/src/reference/cli/cast/publish.md
@@ -25,17 +25,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/receipt.md
+++ b/src/reference/cli/cast/receipt.md
@@ -4,6 +4,9 @@ Get the transaction receipt for a transaction
 
 ```bash
 $ cast receipt --help
+```
+
+```txt
 Usage: cast receipt [OPTIONS] <TX_HASH> [FIELD]
 
 Arguments:

--- a/src/reference/cli/cast/receipt.md
+++ b/src/reference/cli/cast/receipt.md
@@ -33,17 +33,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/resolve-name.md
+++ b/src/reference/cli/cast/resolve-name.md
@@ -23,17 +23,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/resolve-name.md
+++ b/src/reference/cli/cast/resolve-name.md
@@ -4,6 +4,9 @@ Perform an ENS lookup
 
 ```bash
 $ cast resolve-name --help
+```
+
+```txt
 Usage: cast resolve-name [OPTIONS] [WHO]
 
 Arguments:

--- a/src/reference/cli/cast/rpc.md
+++ b/src/reference/cli/cast/rpc.md
@@ -18,15 +18,15 @@ Arguments:
           
           Interpreted as JSON:
           
-          cast rpc eth_getBlockByNumber 0x123 false => {"method": "eth_getBlockByNumber", "params":
-          ["0x123", false] ... }
+          cast rpc eth_getBlockByNumber 0x123 false => {"method":
+          "eth_getBlockByNumber", "params": ["0x123", false] ... }
 
 Options:
   -w, --raw
           Send raw JSON parameters
           
-          The first param will be interpreted as a raw JSON array of params. If no params are given,
-          stdin will be used. For example:
+          The first param will be interpreted as a raw JSON array of params. If
+          no params are given, stdin will be used. For example:
           
           cast rpc eth_getBlockByNumber '["0x123", false]' --raw => {"method":
           "eth_getBlockByNumber", "params": ["0x123", false] ... }
@@ -37,17 +37,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/rpc.md
+++ b/src/reference/cli/cast/rpc.md
@@ -4,6 +4,9 @@ Perform a raw JSON-RPC request
 
 ```bash
 $ cast rpc --help
+```
+
+```txt
 Usage: cast rpc [OPTIONS] <METHOD> [PARAMS]...
 
 Arguments:

--- a/src/reference/cli/cast/run.md
+++ b/src/reference/cli/cast/run.md
@@ -4,6 +4,9 @@ Runs a published transaction in a local environment and prints the trace
 
 ```bash
 $ cast run --help
+```
+
+```txt
 Usage: cast run [OPTIONS] <TX_HASH>
 
 Arguments:

--- a/src/reference/cli/cast/run.md
+++ b/src/reference/cli/cast/run.md
@@ -42,17 +42,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -67,7 +70,8 @@ Options:
           Overrides the version specified in the config.
 
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           

--- a/src/reference/cli/cast/selectors.md
+++ b/src/reference/cli/cast/selectors.md
@@ -4,6 +4,9 @@ Extracts function selectors and arguments from bytecode
 
 ```bash
 $ cast selectors --help
+```
+
+```txt
 Usage: cast selectors [OPTIONS] <BYTECODE>
 
 Arguments:

--- a/src/reference/cli/cast/selectors.md
+++ b/src/reference/cli/cast/selectors.md
@@ -13,7 +13,7 @@ Arguments:
   <BYTECODE>  The hex encoded bytecode
 
 Options:
-  -r, --resolve  Resolve the function signatures for the extracted selectors using
-                 https://openchain.xyz
+  -r, --resolve  Resolve the function signatures for the extracted selectors
+                 using https://openchain.xyz
   -h, --help     Print help
 ```

--- a/src/reference/cli/cast/send.md
+++ b/src/reference/cli/cast/send.md
@@ -37,7 +37,8 @@ Options:
           [default: 1]
 
       --unlocked
-          Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM as sender
+          Send via `eth_sendTransaction using the `--from` argument or $ETH_FROM
+          as sender
 
       --timeout <TIMEOUT>
           Timeout for sending the transaction
@@ -58,8 +59,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -71,8 +73,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -107,17 +109,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -173,7 +178,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/send.md
+++ b/src/reference/cli/cast/send.md
@@ -4,6 +4,9 @@ Sign and publish a transaction
 
 ```bash
 $ cast send --help
+```
+
+```txt
 Usage: cast send [OPTIONS] [TO] [SIG] [ARGS]... [COMMAND]
 
 Commands:

--- a/src/reference/cli/cast/send/--create.md
+++ b/src/reference/cli/cast/send/--create.md
@@ -4,6 +4,9 @@ Use to deploy raw contract bytecode
 
 ```bash
 $ cast send --create --help
+```
+
+```txt
 Usage: cast send --create <CODE> [SIG] [ARGS]...
 
 Arguments:

--- a/src/reference/cli/cast/shl.md
+++ b/src/reference/cli/cast/shl.md
@@ -4,6 +4,9 @@ Perform a left shifting operation
 
 ```bash
 $ cast shl --help
+```
+
+```txt
 Usage: cast shl [OPTIONS] <VALUE> <BITS>
 
 Arguments:

--- a/src/reference/cli/cast/shr.md
+++ b/src/reference/cli/cast/shr.md
@@ -4,6 +4,9 @@ Perform a right shifting operation
 
 ```bash
 $ cast shr --help
+```
+
+```txt
 Usage: cast shr [OPTIONS] <VALUE> <BITS>
 
 Arguments:

--- a/src/reference/cli/cast/sig-event.md
+++ b/src/reference/cli/cast/sig-event.md
@@ -4,6 +4,9 @@ Generate event signatures from event string
 
 ```bash
 $ cast sig-event --help
+```
+
+```txt
 Usage: cast sig-event [EVENT_STRING]
 
 Arguments:

--- a/src/reference/cli/cast/sig.md
+++ b/src/reference/cli/cast/sig.md
@@ -11,7 +11,8 @@ Usage: cast sig [SIG] [OPTIMIZE]
 
 Arguments:
   [SIG]       The function signature, e.g. transfer(address,uint256)
-  [OPTIMIZE]  Optimize signature to contain provided amount of leading zeroes in selector
+  [OPTIMIZE]  Optimize signature to contain provided amount of leading zeroes in
+              selector
 
 Options:
   -h, --help  Print help

--- a/src/reference/cli/cast/sig.md
+++ b/src/reference/cli/cast/sig.md
@@ -4,6 +4,9 @@ Get the selector for a function
 
 ```bash
 $ cast sig --help
+```
+
+```txt
 Usage: cast sig [SIG] [OPTIMIZE]
 
 Arguments:

--- a/src/reference/cli/cast/storage-root.md
+++ b/src/reference/cli/cast/storage-root.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/storage-root.md
+++ b/src/reference/cli/cast/storage-root.md
@@ -4,6 +4,9 @@ Get the storage root for an account
 
 ```bash
 $ cast storage-root --help
+```
+
+```txt
 Usage: cast storage-root [OPTIONS] <WHO> [SLOTS]...
 
 Arguments:

--- a/src/reference/cli/cast/storage.md
+++ b/src/reference/cli/cast/storage.md
@@ -28,17 +28,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -92,7 +95,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -105,7 +109,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -142,8 +147,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -154,7 +159,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -174,7 +180,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/cast/storage.md
+++ b/src/reference/cli/cast/storage.md
@@ -4,6 +4,9 @@ Get the raw value of a contract's storage slot
 
 ```bash
 $ cast storage --help
+```
+
+```txt
 Usage: cast storage [OPTIONS] <ADDRESS> [SLOT]
 
 Arguments:

--- a/src/reference/cli/cast/to-ascii.md
+++ b/src/reference/cli/cast/to-ascii.md
@@ -4,6 +4,9 @@ Convert hex data to an ASCII string
 
 ```bash
 $ cast to-ascii --help
+```
+
+```txt
 Usage: cast to-ascii [HEXDATA]
 
 Arguments:

--- a/src/reference/cli/cast/to-base.md
+++ b/src/reference/cli/cast/to-base.md
@@ -4,6 +4,9 @@ Converts a number of one base to another
 
 ```bash
 $ cast to-base --help
+```
+
+```txt
 Usage: cast to-base [OPTIONS] [VALUE] [BASE]
 
 Arguments:

--- a/src/reference/cli/cast/to-bytes32.md
+++ b/src/reference/cli/cast/to-bytes32.md
@@ -4,6 +4,9 @@ Right-pads hex data to 32 bytes
 
 ```bash
 $ cast to-bytes32 --help
+```
+
+```txt
 Usage: cast to-bytes32 [BYTES]
 
 Arguments:

--- a/src/reference/cli/cast/to-check-sum-address.md
+++ b/src/reference/cli/cast/to-check-sum-address.md
@@ -4,6 +4,9 @@ Convert an address to a checksummed format (EIP-55)
 
 ```bash
 $ cast to-check-sum-address --help
+```
+
+```txt
 Usage: cast to-check-sum-address [ADDRESS]
 
 Arguments:

--- a/src/reference/cli/cast/to-dec.md
+++ b/src/reference/cli/cast/to-dec.md
@@ -4,6 +4,9 @@ Converts a number of one base to decimal
 
 ```bash
 $ cast to-dec --help
+```
+
+```txt
 Usage: cast to-dec [OPTIONS] [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-fixed-point.md
+++ b/src/reference/cli/cast/to-fixed-point.md
@@ -4,6 +4,9 @@ Convert an integer into a fixed point number
 
 ```bash
 $ cast to-fixed-point --help
+```
+
+```txt
 Usage: cast to-fixed-point [DECIMALS] [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-hex.md
+++ b/src/reference/cli/cast/to-hex.md
@@ -4,6 +4,9 @@ Converts a number of one base to another
 
 ```bash
 $ cast to-hex --help
+```
+
+```txt
 Usage: cast to-hex [OPTIONS] [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-hexdata.md
+++ b/src/reference/cli/cast/to-hexdata.md
@@ -4,6 +4,9 @@ Normalize the input to lowercase, 0x-prefixed hex.
 
 ```bash
 $ cast to-hexdata --help
+```
+
+```txt
 Usage: cast to-hexdata [INPUT]
 
 Arguments:

--- a/src/reference/cli/cast/to-int256.md
+++ b/src/reference/cli/cast/to-int256.md
@@ -4,6 +4,9 @@ Convert a number to a hex-encoded int256
 
 ```bash
 $ cast to-int256 --help
+```
+
+```txt
 Usage: cast to-int256 [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-rlp.md
+++ b/src/reference/cli/cast/to-rlp.md
@@ -13,8 +13,8 @@ Arguments:
   [VALUE]
           The value to convert.
           
-          This is a hex-encoded string, or an array of hex-encoded strings. Can be arbitrarily
-          recursive.
+          This is a hex-encoded string, or an array of hex-encoded strings. Can
+          be arbitrarily recursive.
 
 Options:
   -h, --help

--- a/src/reference/cli/cast/to-rlp.md
+++ b/src/reference/cli/cast/to-rlp.md
@@ -4,6 +4,9 @@ RLP encodes hex data, or an array of hex data.
 
 ```bash
 $ cast to-rlp --help
+```
+
+```txt
 Usage: cast to-rlp [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-uint256.md
+++ b/src/reference/cli/cast/to-uint256.md
@@ -4,6 +4,9 @@ Convert a number to a hex-encoded uint256
 
 ```bash
 $ cast to-uint256 --help
+```
+
+```txt
 Usage: cast to-uint256 [VALUE]
 
 Arguments:

--- a/src/reference/cli/cast/to-unit.md
+++ b/src/reference/cli/cast/to-unit.md
@@ -4,6 +4,9 @@ Convert an ETH amount into another unit (ether, gwei or wei).
 
 ```bash
 $ cast to-unit --help
+```
+
+```txt
 Usage: cast to-unit [VALUE] [UNIT]
 
 Arguments:

--- a/src/reference/cli/cast/to-utf8.md
+++ b/src/reference/cli/cast/to-utf8.md
@@ -4,6 +4,9 @@ Convert hex data to a utf-8 string
 
 ```bash
 $ cast to-utf8 --help
+```
+
+```txt
 Usage: cast to-utf8 [HEXDATA]
 
 Arguments:

--- a/src/reference/cli/cast/to-wei.md
+++ b/src/reference/cli/cast/to-wei.md
@@ -4,6 +4,9 @@ Convert an ETH amount to wei.
 
 ```bash
 $ cast to-wei --help
+```
+
+```txt
 Usage: cast to-wei [VALUE] [UNIT]
 
 Arguments:

--- a/src/reference/cli/cast/tx.md
+++ b/src/reference/cli/cast/tx.md
@@ -14,8 +14,8 @@ Arguments:
           The transaction hash
 
   [FIELD]
-          If specified, only get the given field of the transaction. If "raw", the RLP encoded
-          transaction will be printed
+          If specified, only get the given field of the transaction. If "raw",
+          the RLP encoded transaction will be printed
 
 Options:
       --raw
@@ -27,17 +27,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/cast/tx.md
+++ b/src/reference/cli/cast/tx.md
@@ -4,6 +4,9 @@ Get information about a transaction
 
 ```bash
 $ cast tx --help
+```
+
+```txt
 Usage: cast tx [OPTIONS] <TX_HASH> [FIELD]
 
 Arguments:

--- a/src/reference/cli/cast/upload-signature.md
+++ b/src/reference/cli/cast/upload-signature.md
@@ -4,6 +4,9 @@ Upload the given signatures to https://openchain.xyz.
 
 ```bash
 $ cast upload-signature --help
+```
+
+```txt
 Usage: cast upload-signature [SIGNATURES]...
 
 Arguments:

--- a/src/reference/cli/cast/upload-signature.md
+++ b/src/reference/cli/cast/upload-signature.md
@@ -13,8 +13,8 @@ Arguments:
   [SIGNATURES]...
           The signatures to upload.
           
-          Prefix with 'function', 'event', or 'error'. Defaults to function if no prefix given. Can
-          also take paths to contract artifact JSON.
+          Prefix with 'function', 'event', or 'error'. Defaults to function if
+          no prefix given. Can also take paths to contract artifact JSON.
 
 Options:
   -h, --help

--- a/src/reference/cli/cast/wallet.md
+++ b/src/reference/cli/cast/wallet.md
@@ -4,6 +4,9 @@ Wallet management utilities
 
 ```bash
 $ cast wallet --help
+```
+
+```txt
 Usage: cast wallet <COMMAND>
 
 Commands:

--- a/src/reference/cli/cast/wallet.md
+++ b/src/reference/cli/cast/wallet.md
@@ -18,7 +18,8 @@ Commands:
   sign-auth         EIP-7702 sign authorization [aliases: sa]
   verify            Verify the signature of a message [aliases: v]
   import            Import a private key into an encrypted keystore [aliases: i]
-  list              List all the accounts in the keystore default directory [aliases: ls]
+  list              List all the accounts in the keystore default directory
+                    [aliases: ls]
   private-key       Derives private key from mnemonic [aliases: pk]
   decrypt-keystore  Decrypt a keystore file to get the private key [aliases: dk]
   help              Print this message or the help of the given subcommand(s)

--- a/src/reference/cli/cast/wallet/address.md
+++ b/src/reference/cli/cast/wallet/address.md
@@ -4,6 +4,9 @@ Convert a private key to an address
 
 ```bash
 $ cast wallet address --help
+```
+
+```txt
 Usage: cast wallet address [OPTIONS] [PRIVATE_KEY]
 
 Arguments:

--- a/src/reference/cli/cast/wallet/address.md
+++ b/src/reference/cli/cast/wallet/address.md
@@ -11,7 +11,8 @@ Usage: cast wallet address [OPTIONS] [PRIVATE_KEY]
 
 Arguments:
   [PRIVATE_KEY]
-          If provided, the address will be derived from the specified private key
+          If provided, the address will be derived from the specified private
+          key
 
 Options:
   -h, --help
@@ -54,7 +55,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/wallet/decrypt-keystore.md
+++ b/src/reference/cli/cast/wallet/decrypt-keystore.md
@@ -13,10 +13,13 @@ Arguments:
   <ACCOUNT_NAME>  The name for the account in the keystore
 
 Options:
-  -k, --keystore-dir <KEYSTORE_DIR>  If not provided, keystore will try to be located at the default
-                                     keystores directory (~/.foundry/keystores)
-      --unsafe-password <PASSWORD>   Password for the JSON keystore in cleartext This is unsafe, we
-                                     recommend using the default hidden password prompt [env:
-                                     CAST_UNSAFE_PASSWORD=]
-  -h, --help                         Print help
+  -k, --keystore-dir <KEYSTORE_DIR>
+          If not provided, keystore will try to be located at the default
+          keystores directory (~/.foundry/keystores)
+      --unsafe-password <PASSWORD>
+          Password for the JSON keystore in cleartext This is unsafe, we
+          recommend using the default hidden password prompt [env:
+          CAST_UNSAFE_PASSWORD=]
+  -h, --help
+          Print help
 ```

--- a/src/reference/cli/cast/wallet/decrypt-keystore.md
+++ b/src/reference/cli/cast/wallet/decrypt-keystore.md
@@ -4,6 +4,9 @@ Decrypt a keystore file to get the private key
 
 ```bash
 $ cast wallet decrypt-keystore --help
+```
+
+```txt
 Usage: cast wallet decrypt-keystore [OPTIONS] <ACCOUNT_NAME>
 
 Arguments:

--- a/src/reference/cli/cast/wallet/import.md
+++ b/src/reference/cli/cast/wallet/import.md
@@ -4,6 +4,9 @@ Import a private key into an encrypted keystore
 
 ```bash
 $ cast wallet import --help
+```
+
+```txt
 Usage: cast wallet import [OPTIONS] <ACCOUNT_NAME>
 
 Arguments:

--- a/src/reference/cli/cast/wallet/import.md
+++ b/src/reference/cli/cast/wallet/import.md
@@ -15,12 +15,12 @@ Arguments:
 
 Options:
   -k, --keystore-dir <KEYSTORE_DIR>
-          If provided, keystore will be saved here instead of the default keystores directory
-          (~/.foundry/keystores)
+          If provided, keystore will be saved here instead of the default
+          keystores directory (~/.foundry/keystores)
 
       --unsafe-password <PASSWORD>
-          Password for the JSON keystore in cleartext This is unsafe, we recommend using the default
-          hidden password prompt
+          Password for the JSON keystore in cleartext This is unsafe, we
+          recommend using the default hidden password prompt
           
           [env: CAST_UNSAFE_PASSWORD=]
 

--- a/src/reference/cli/cast/wallet/list.md
+++ b/src/reference/cli/cast/wallet/list.md
@@ -4,6 +4,9 @@ List all the accounts in the keystore default directory
 
 ```bash
 $ cast wallet list --help
+```
+
+```txt
 Usage: cast wallet list [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/wallet/list.md
+++ b/src/reference/cli/cast/wallet/list.md
@@ -10,13 +10,19 @@ $ cast wallet list --help
 Usage: cast wallet list [OPTIONS]
 
 Options:
-      --dir [<DIR>]                List all the accounts in the keystore directory. Default keystore
-                                   directory is used if no path provided
-  -l, --ledger                     List accounts from a Ledger hardware wallet
-  -t, --trezor                     List accounts from a Trezor hardware wallet
-      --aws                        List accounts from AWS KMS
-      --all                        List all configured accounts
-  -m, --max-senders <MAX_SENDERS>  Max number of addresses to display from hardware wallets
-                                   [default: 3]
-  -h, --help                       Print help
+      --dir [<DIR>]
+          List all the accounts in the keystore directory. Default keystore
+          directory is used if no path provided
+  -l, --ledger
+          List accounts from a Ledger hardware wallet
+  -t, --trezor
+          List accounts from a Trezor hardware wallet
+      --aws
+          List accounts from AWS KMS
+      --all
+          List all configured accounts
+  -m, --max-senders <MAX_SENDERS>
+          Max number of addresses to display from hardware wallets [default: 3]
+  -h, --help
+          Print help
 ```

--- a/src/reference/cli/cast/wallet/new-mnemonic.md
+++ b/src/reference/cli/cast/wallet/new-mnemonic.md
@@ -4,6 +4,9 @@ Generates a random BIP39 mnemonic phrase
 
 ```bash
 $ cast wallet new-mnemonic --help
+```
+
+```txt
 Usage: cast wallet new-mnemonic [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/wallet/new.md
+++ b/src/reference/cli/cast/wallet/new.md
@@ -4,6 +4,9 @@ Create a new random keypair
 
 ```bash
 $ cast wallet new --help
+```
+
+```txt
 Usage: cast wallet new [OPTIONS] [PATH]
 
 Arguments:

--- a/src/reference/cli/cast/wallet/new.md
+++ b/src/reference/cli/cast/wallet/new.md
@@ -11,7 +11,8 @@ Usage: cast wallet new [OPTIONS] [PATH]
 
 Arguments:
   [PATH]
-          If provided, then keypair will be written to an encrypted JSON keystore
+          If provided, then keypair will be written to an encrypted JSON
+          keystore
 
 Options:
   -p, --password

--- a/src/reference/cli/cast/wallet/private-key.md
+++ b/src/reference/cli/cast/wallet/private-key.md
@@ -11,11 +11,12 @@ Usage: cast wallet private-key [OPTIONS] [MNEMONIC] [MNEMONIC_INDEX_OR_DERIVATIO
 
 Arguments:
   [MNEMONIC]
-          If provided, the private key will be derived from the specified menomonic phrase
+          If provided, the private key will be derived from the specified
+          menomonic phrase
 
   [MNEMONIC_INDEX_OR_DERIVATION_PATH]
-          If provided, the private key will be derived using the specified mnemonic index (if
-          integer) or derivation path
+          If provided, the private key will be derived using the specified
+          mnemonic index (if integer) or derivation path
 
 Options:
   -v, --verbose
@@ -61,7 +62,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/wallet/private-key.md
+++ b/src/reference/cli/cast/wallet/private-key.md
@@ -4,6 +4,9 @@ Derives private key from mnemonic
 
 ```bash
 $ cast wallet private-key --help
+```
+
+```txt
 Usage: cast wallet private-key [OPTIONS] [MNEMONIC] [MNEMONIC_INDEX_OR_DERIVATION_PATH]
 
 Arguments:

--- a/src/reference/cli/cast/wallet/sign-auth.md
+++ b/src/reference/cli/cast/wallet/sign-auth.md
@@ -4,6 +4,9 @@ EIP-7702 sign authorization
 
 ```bash
 $ cast wallet sign-auth --help
+```
+
+```txt
 Usage: cast wallet sign-auth [OPTIONS] <ADDRESS>
 
 Arguments:

--- a/src/reference/cli/cast/wallet/sign-auth.md
+++ b/src/reference/cli/cast/wallet/sign-auth.md
@@ -20,17 +20,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -85,7 +88,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/wallet/sign.md
+++ b/src/reference/cli/cast/wallet/sign.md
@@ -13,15 +13,16 @@ Arguments:
   <MESSAGE>
           The message, typed data, or hash to sign.
           
-          Messages starting with 0x are expected to be hex encoded, which get decoded before being
-          signed.
+          Messages starting with 0x are expected to be hex encoded, which get
+          decoded before being signed.
           
-          The message will be prefixed with the Ethereum Signed Message header and hashed before
-          signing, unless `--no-hash` is provided.
+          The message will be prefixed with the Ethereum Signed Message header
+          and hashed before signing, unless `--no-hash` is provided.
           
-          Typed data can be provided as a json string or a file name. Use --data flag to denote the
-          message is a string of typed data. Use --data --from-file to denote the message is a file
-          name containing typed data. The data will be combined and hashed using the EIP712
+          Typed data can be provided as a json string or a file name. Use --data
+          flag to denote the message is a string of typed data. Use --data
+          --from-file to denote the message is a file name containing typed
+          data. The data will be combined and hashed using the EIP712
           specification before signing. The data should be formatted as JSON.
 
 Options:
@@ -29,10 +30,12 @@ Options:
           Treat the message as JSON typed data
 
       --from-file
-          Treat the message as a file containing JSON typed data. Requires `--data`
+          Treat the message as a file containing JSON typed data. Requires
+          `--data`
 
       --no-hash
-          Treat the message as a raw 32-byte hash and sign it directly without hashing it again
+          Treat the message as a raw 32-byte hash and sign it directly without
+          hashing it again
 
   -h, --help
           Print help (see a summary with '-h')
@@ -74,7 +77,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/cast/wallet/sign.md
+++ b/src/reference/cli/cast/wallet/sign.md
@@ -4,6 +4,9 @@ Sign a message or typed data
 
 ```bash
 $ cast wallet sign --help
+```
+
+```txt
 Usage: cast wallet sign [OPTIONS] <MESSAGE>
 
 Arguments:

--- a/src/reference/cli/cast/wallet/vanity.md
+++ b/src/reference/cli/cast/wallet/vanity.md
@@ -4,6 +4,9 @@ Generate a vanity address
 
 ```bash
 $ cast wallet vanity --help
+```
+
+```txt
 Usage: cast wallet vanity [OPTIONS]
 
 Options:

--- a/src/reference/cli/cast/wallet/vanity.md
+++ b/src/reference/cli/cast/wallet/vanity.md
@@ -17,14 +17,14 @@ Options:
           Suffix regex pattern or hex string
 
       --nonce <NONCE>
-          Generate a vanity contract address created by the generated keypair with the specified
-          nonce
+          Generate a vanity contract address created by the generated keypair
+          with the specified nonce
 
       --save-path <PATH>
           Path to save the generated vanity contract address to.
           
-          If provided, the generated vanity addresses will appended to a JSON array in the specified
-          file.
+          If provided, the generated vanity addresses will appended to a JSON
+          array in the specified file.
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/cast/wallet/verify.md
+++ b/src/reference/cli/cast/wallet/verify.md
@@ -4,6 +4,9 @@ Verify the signature of a message
 
 ```bash
 $ cast wallet verify --help
+```
+
+```txt
 Usage: cast wallet verify --address <ADDRESS> <MESSAGE> <SIGNATURE>
 
 Arguments:

--- a/src/reference/cli/chisel.md
+++ b/src/reference/cli/chisel.md
@@ -4,6 +4,9 @@ Fast, utilitarian, and verbose Solidity REPL
 
 ```bash
 $ chisel --help
+```
+
+```txt
 Usage: chisel [OPTIONS] [COMMAND]
 
 Commands:

--- a/src/reference/cli/chisel.md
+++ b/src/reference/cli/chisel.md
@@ -25,16 +25,17 @@ Options:
 
 REPL options:
       --prelude <PRELUDE>
-          Path to a directory containing Solidity files to import, or path to a single Solidity
-          file.
+          Path to a directory containing Solidity files to import, or path to a
+          single Solidity file.
           
-          These files will be evaluated before the top-level of the REPL, therefore functioning as a
-          prelude
+          These files will be evaluated before the top-level of the REPL,
+          therefore functioning as a prelude
 
       --no-vm
           Disable the default `Vm` import.
           
-          The import is disabled by default if the Solc version is less than 0.6.2.
+          The import is disabled by default if the Solc version is less than
+          0.6.2.
 
 Cache options:
       --force
@@ -68,7 +69,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -81,7 +83,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -118,8 +121,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -130,7 +133,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -150,7 +154,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -159,9 +164,11 @@ Project options:
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -199,7 +206,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -209,12 +217,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -234,8 +244,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -272,8 +282,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -283,9 +293,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features

--- a/src/reference/cli/chisel/clear-cache.md
+++ b/src/reference/cli/chisel/clear-cache.md
@@ -4,6 +4,9 @@ Clear all cached chisel sessions from the cache directory
 
 ```bash
 $ chisel clear-cache --help
+```
+
+```txt
 Usage: chisel clear-cache
 
 Options:

--- a/src/reference/cli/chisel/list.md
+++ b/src/reference/cli/chisel/list.md
@@ -4,6 +4,9 @@ List all cached sessions
 
 ```bash
 $ chisel list --help
+```
+
+```txt
 Usage: chisel list
 
 Options:

--- a/src/reference/cli/chisel/load.md
+++ b/src/reference/cli/chisel/load.md
@@ -4,6 +4,9 @@ Load a cached session
 
 ```bash
 $ chisel load --help
+```
+
+```txt
 Usage: chisel load <ID>
 
 Arguments:

--- a/src/reference/cli/chisel/view.md
+++ b/src/reference/cli/chisel/view.md
@@ -4,6 +4,9 @@ View the source of a cached session
 
 ```bash
 $ chisel view --help
+```
+
+```txt
 Usage: chisel view <ID>
 
 Arguments:

--- a/src/reference/cli/forge.md
+++ b/src/reference/cli/forge.md
@@ -11,11 +11,12 @@ Usage: forge <COMMAND>
 
 Commands:
   bind               Generate Rust bindings for smart contracts
-  bind-json          Generate bindings for serialization/deserialization of project structs via JSON
-                     cheatcodes
+  bind-json          Generate bindings for serialization/deserialization of
+                     project structs via JSON cheatcodes
   build              Build the project's smart contracts [aliases: b, compile]
   cache              Manage the Foundry cache
-  clean              Remove the build artifacts and cache directories [aliases: cl]
+  clean              Remove the build artifacts and cache directories [aliases:
+                     cl]
   clone              Clone a contract from Etherscan
   completions        Generate shell completions script [aliases: com]
   config             Display the current config [aliases: co]
@@ -23,27 +24,34 @@ Commands:
   create             Deploy a smart contract [aliases: c]
   debug              Debugs a single smart contract as a script [aliases: d]
   doc                Generate documentation for the project
-  eip712             Generate EIP-712 struct encodings for structs from a given file
-  flatten            Flatten a source file and all of its imports into one file [aliases: f]
+  eip712             Generate EIP-712 struct encodings for structs from a given
+                     file
+  flatten            Flatten a source file and all of its imports into one file
+                     [aliases: f]
   fmt                Format Solidity source files
-  geiger             Detects usage of unsafe cheat codes in a project and its dependencies
+  geiger             Detects usage of unsafe cheat codes in a project and its
+                     dependencies
   generate           Generate scaffold files
   generate-fig-spec  Generate Fig autocompletion spec [aliases: fig]
   help               Print this message or the help of the given subcommand(s)
   init               Create a new Forge project
-  inspect            Get specialized information about a smart contract [aliases: in]
+  inspect            Get specialized information about a smart contract
+                     [aliases: in]
   install            Install one or multiple dependencies [aliases: i]
-  remappings         Get the automatically inferred remappings for the project [aliases: re]
+  remappings         Get the automatically inferred remappings for the project
+                     [aliases: re]
   remove             Remove one or multiple dependencies [aliases: rm]
-  script             Run a smart contract as a script, building transactions that can be sent
-                     onchain
+  script             Run a smart contract as a script, building transactions
+                     that can be sent onchain
   selectors          Function selector utilities [aliases: se]
   snapshot           Create a snapshot of each test's gas usage [aliases: s]
   soldeer            Soldeer dependency manager
   test               Run the project's tests [aliases: t]
-  tree               Display a tree visualization of the project's dependency graph [aliases: tr]
+  tree               Display a tree visualization of the project's dependency
+                     graph [aliases: tr]
   update             Update one or multiple dependencies [aliases: u]
-  verify-bytecode    Verify the deployed bytecode against its source on Etherscan [aliases: vb]
+  verify-bytecode    Verify the deployed bytecode against its source on
+                     Etherscan [aliases: vb]
   verify-check       Check verification status on Etherscan [aliases: vc]
   verify-contract    Verify smart contracts on Etherscan [aliases: v]
 
@@ -51,5 +59,6 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 
-Find more information in the book: http://book.getfoundry.sh/reference/forge/forge.html
+Find more information in the book:
+http://book.getfoundry.sh/reference/forge/forge.html
 ```

--- a/src/reference/cli/forge.md
+++ b/src/reference/cli/forge.md
@@ -4,6 +4,9 @@ Build, test, fuzz, debug and deploy Solidity contracts
 
 ```bash
 $ forge --help
+```
+
+```txt
 Usage: forge <COMMAND>
 
 Commands:

--- a/src/reference/cli/forge/bind-json.md
+++ b/src/reference/cli/forge/bind-json.md
@@ -4,6 +4,9 @@ Generate bindings for serialization/deserialization of project structs via JSON 
 
 ```bash
 $ forge bind-json --help
+```
+
+```txt
 Usage: forge bind-json [OPTIONS] [PATH]
 
 Arguments:

--- a/src/reference/cli/forge/bind-json.md
+++ b/src/reference/cli/forge/bind-json.md
@@ -1,6 +1,6 @@
 # forge bind-json
 
-Generate bindings for serialization/deserialization of project structs via JSON cheatcodes
+Generate bindings for serialization/deserialization of project structs via JSON
 
 ```bash
 $ forge bind-json --help
@@ -49,7 +49,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -62,7 +63,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -99,8 +101,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -111,7 +113,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -131,7 +134,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/bind.md
+++ b/src/reference/cli/forge/bind.md
@@ -14,7 +14,8 @@ Options:
           Path to where the contract artifacts are stored
 
       --select <SELECT>
-          Create bindings only for contracts whose names match the specified filter(s)
+          Create bindings only for contracts whose names match the specified
+          filter(s)
 
       --select-all
           Explicitly generate bindings for all contracts
@@ -24,16 +25,16 @@ Options:
       --crate-name <NAME>
           The name of the Rust crate to generate.
           
-          This should be a valid crates.io crate name, however, this is not currently validated by
-          this command.
+          This should be a valid crates.io crate name, however, this is not
+          currently validated by this command.
           
           [default: foundry-contracts]
 
       --crate-version <VERSION>
           The version of the Rust crate to generate.
           
-          This should be a standard semver version string, however, this is not currently validated
-          by this command.
+          This should be a standard semver version string, however, this is not
+          currently validated by this command.
           
           [default: 0.1.0]
 
@@ -43,8 +44,9 @@ Options:
       --overwrite
           Overwrite existing generated bindings.
           
-          By default, the command will check that the bindings are correct, and then exit. If
-          --overwrite is passed, it will instead delete and overwrite the bindings.
+          By default, the command will check that the bindings are correct, and
+          then exit. If --overwrite is passed, it will instead delete and
+          overwrite the bindings.
 
       --single-file
           Generate bindings as a single file
@@ -65,7 +67,8 @@ Options:
           Specify the alloy version
 
       --ethers
-          Generate bindings for the `ethers` library, instead of `alloy` (default, deprecated)
+          Generate bindings for the `ethers` library, instead of `alloy`
+          (default, deprecated)
 
   -h, --help
           Print help (see a summary with '-h')
@@ -102,7 +105,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -115,7 +119,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -152,8 +157,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -164,7 +169,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -184,7 +190,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/bind.md
+++ b/src/reference/cli/forge/bind.md
@@ -4,6 +4,9 @@ Generate Rust bindings for smart contracts
 
 ```bash
 $ forge bind --help
+```
+
+```txt
 Usage: forge bind [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/build.md
+++ b/src/reference/cli/forge/build.md
@@ -54,7 +54,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -67,7 +68,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -104,8 +106,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -116,7 +118,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -136,7 +139,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -147,7 +151,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -155,22 +160,24 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 
       --format-json
-          Output the compilation errors in the json format. This is useful when you want to use the
-          output in other tools
+          Output the compilation errors in the json format. This is useful when
+          you want to use the output in other tools
 ```

--- a/src/reference/cli/forge/build.md
+++ b/src/reference/cli/forge/build.md
@@ -4,6 +4,9 @@ Build the project's smart contracts
 
 ```bash
 $ forge build --help
+```
+
+```txt
 Usage: forge build [OPTIONS] [PATHS]...
 
 Options:

--- a/src/reference/cli/forge/cache.md
+++ b/src/reference/cli/forge/cache.md
@@ -4,6 +4,9 @@ Manage the Foundry cache
 
 ```bash
 $ forge cache --help
+```
+
+```txt
 Usage: forge cache <COMMAND>
 
 Commands:

--- a/src/reference/cli/forge/cache/clean.md
+++ b/src/reference/cli/forge/cache/clean.md
@@ -4,6 +4,9 @@ Cleans cached data from the global foundry directory
 
 ```bash
 $ forge cache clean --help
+```
+
+```txt
 Usage: forge cache clean [OPTIONS] [CHAINS]...
 
 Arguments:

--- a/src/reference/cli/forge/cache/ls.md
+++ b/src/reference/cli/forge/cache/ls.md
@@ -4,6 +4,9 @@ Shows cached data from the global foundry directory
 
 ```bash
 $ forge cache ls --help
+```
+
+```txt
 Usage: forge cache ls [CHAINS]...
 
 Arguments:

--- a/src/reference/cli/forge/clean.md
+++ b/src/reference/cli/forge/clean.md
@@ -13,7 +13,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/forge/clean.md
+++ b/src/reference/cli/forge/clean.md
@@ -4,6 +4,9 @@ Remove the build artifacts and cache directories
 
 ```bash
 $ forge clean --help
+```
+
+```txt
 Usage: forge clean [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/clone.md
+++ b/src/reference/cli/forge/clone.md
@@ -4,6 +4,9 @@ Clone a contract from Etherscan
 
 ```bash
 $ forge clone --help
+```
+
+```txt
 Usage: forge clone [OPTIONS] <ADDRESS> [PATH]
 
 Arguments:

--- a/src/reference/cli/forge/clone.md
+++ b/src/reference/cli/forge/clone.md
@@ -20,14 +20,15 @@ Arguments:
 
 Options:
       --no-remappings-txt
-          Do not generate the remappings.txt file. Instead, keep the remappings in the configuration
+          Do not generate the remappings.txt file. Instead, keep the remappings
+          in the configuration
 
       --keep-directory-structure
           Keep the original directory structure collected from Etherscan.
           
-          If this flag is set, the directory structure of the cloned project will be kept as is. By
-          default, the directory structure is re-orgnized to increase the readability, but may risk
-          some compilation failures.
+          If this flag is set, the directory structure of the cloned project
+          will be kept as is. By default, the directory structure is re-orgnized
+          to increase the readability, but may risk some compilation failures.
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key
@@ -42,7 +43,8 @@ Options:
       --shallow
           Perform shallow clones instead of deep ones.
           
-          Improves performance and reduces disk usage, but prevents switching branches or tags.
+          Improves performance and reduces disk usage, but prevents switching
+          branches or tags.
 
       --no-git
           Install without adding the dependency as a submodule

--- a/src/reference/cli/forge/completions.md
+++ b/src/reference/cli/forge/completions.md
@@ -4,6 +4,9 @@ Generate shell completions script
 
 ```bash
 $ forge completions --help
+```
+
+```txt
 Usage: forge completions <SHELL>
 
 Arguments:

--- a/src/reference/cli/forge/config.md
+++ b/src/reference/cli/forge/config.md
@@ -4,6 +4,9 @@ Display the current config
 
 ```bash
 $ forge config --help
+```
+
+```txt
 Usage: forge config [OPTIONS] [PATHS]...
 
 Options:

--- a/src/reference/cli/forge/config.md
+++ b/src/reference/cli/forge/config.md
@@ -63,7 +63,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -76,7 +77,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -113,8 +115,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -125,7 +127,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -145,7 +148,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -156,7 +160,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -164,30 +169,34 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 
       --format-json
-          Output the compilation errors in the json format. This is useful when you want to use the
-          output in other tools
+          Output the compilation errors in the json format. This is useful when
+          you want to use the output in other tools
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -225,7 +234,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -235,12 +245,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -260,8 +272,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -298,8 +310,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -309,9 +321,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features

--- a/src/reference/cli/forge/coverage.md
+++ b/src/reference/cli/forge/coverage.md
@@ -21,13 +21,14 @@ Options:
       --ir-minimum
           Enable viaIR with minimum optimization
           
-          This can fix most of the "stack too deep" errors while resulting a relatively accurate
-          source map.
+          This can fix most of the "stack too deep" errors while resulting a
+          relatively accurate source map.
 
   -r, --report-file <PATH>
           The path to output the report.
           
-          If not specified, the report will be stored in the root of the project.
+          If not specified, the report will be stored in the root of the
+          project.
 
       --include-libs
           Whether to include libraries in the coverage report
@@ -39,18 +40,22 @@ Test options:
       --debug <TEST_FUNCTION>
           Run a test in the debugger.
           
-          The argument passed to this flag is the name of the test function you want to run, and it
-          works the same as --match-test.
+          The argument passed to this flag is the name of the test function you
+          want to run, and it works the same as --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
           
-          The matching test will be opened in the debugger regardless of the outcome of the test.
+          The matching test will be opened in the debugger regardless of the
+          outcome of the test.
           
-          If the matching test is a fuzz test, then it will open the debugger on the first failure
-          case. If the fuzz test does not fail, it will open the debugger on the last fuzz case.
+          If the matching test is a fuzz test, then it will open the debugger on
+          the first failure case. If the fuzz test does not fail, it will open
+          the debugger on the last fuzz case.
           
-          For more fine-grained control of which fuzz case is run, see forge run.
+          For more fine-grained control of which fuzz case is run, see forge
+          run.
 
       --flamegraph
           Generate a flamegraph for a single test. Implies `--decode-internal`
@@ -61,15 +66,16 @@ Test options:
       --decode-internal [<TEST_FUNCTION>]
           Whether to identify internal functions in traces.
           
-          If no argument is passed to this flag, it will trace internal functions scope and decode
-          stack parameters, but parameters stored in memory (such as bytes or arrays) will not be
-          decoded.
+          If no argument is passed to this flag, it will trace internal
+          functions scope and decode stack parameters, but parameters stored in
+          memory (such as bytes or arrays) will not be decoded.
           
-          To decode memory parameters, you should pass an argument with a test function name,
-          similarly to --debug and --match-test.
+          To decode memory parameters, you should pass an argument with a test
+          function name, similarly to --debug and --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
 
       --gas-report
           Print a gas report
@@ -99,7 +105,8 @@ Test options:
           File to rerun fuzz failures from
 
   -j, --threads <THREADS>
-          Max concurrent threads to use. Default value is the number of available CPUs
+          Max concurrent threads to use. Default value is the number of
+          available CPUs
           
           [aliases: jobs]
 
@@ -142,7 +149,8 @@ Test filtering:
           [aliases: mc]
 
       --no-match-contract <REGEX>
-          Only run tests in contracts that do not match the specified regex pattern
+          Only run tests in contracts that do not match the specified regex
+          pattern
           
           [aliases: nmc]
 
@@ -152,24 +160,28 @@ Test filtering:
           [aliases: mp]
 
       --no-match-path <GLOB>
-          Only run tests in source files that do not match the specified glob pattern
+          Only run tests in source files that do not match the specified glob
+          pattern
           
           [aliases: nmp]
 
       --no-match-coverage <REGEX>
-          Only show coverage for files that do not match the specified regex pattern
+          Only show coverage for files that do not match the specified regex
+          pattern
           
           [aliases: nmco]
 
       --rerun
-          Re-run recorded test failures from last run. If no failure recorded then regular test run
-          is performed
+          Re-run recorded test failures from last run. If no failure recorded
+          then regular test run is performed
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -207,7 +219,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -217,12 +230,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -242,8 +257,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -280,8 +295,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -291,9 +306,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features
@@ -330,7 +346,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -343,7 +360,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -380,8 +398,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -392,7 +410,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -412,7 +431,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -423,7 +443,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -431,18 +452,20 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 ```

--- a/src/reference/cli/forge/coverage.md
+++ b/src/reference/cli/forge/coverage.md
@@ -4,6 +4,9 @@ Generate coverage reports
 
 ```bash
 $ forge coverage --help
+```
+
+```txt
 Usage: forge coverage [OPTIONS] [PATH]
 
 Options:

--- a/src/reference/cli/forge/create.md
+++ b/src/reference/cli/forge/create.md
@@ -24,13 +24,14 @@ Options:
           Verify contract after creation
 
       --unlocked
-          Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
+          Send via `eth_sendTransaction` using the `--from` argument or
+          `$ETH_FROM` as sender
 
       --show-standard-json-input
           Prints the standard json compiler input if `--verify` is provided.
           
-          The standard json compiler input can be used to manually submit contract verification in
-          the browser.
+          The standard json compiler input can be used to manually submit
+          contract verification in the browser.
 
       --timeout <TIMEOUT>
           Timeout to use for broadcasting transactions
@@ -76,7 +77,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -89,7 +91,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -126,8 +129,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -138,7 +141,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -158,7 +162,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -172,8 +177,9 @@ Transaction options:
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -185,8 +191,8 @@ Transaction options:
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --value <VALUE>
-          Ether to send in the transaction, either specified in wei, or as a string with a unit
-          type.
+          Ether to send in the transaction, either specified in wei, or as a
+          string with a unit type.
           
           Examples: 1ether, 10gwei, 0.01ether
 
@@ -218,17 +224,20 @@ Ethereum options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
@@ -294,7 +303,8 @@ Wallet options - keystore:
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
 

--- a/src/reference/cli/forge/create.md
+++ b/src/reference/cli/forge/create.md
@@ -4,6 +4,9 @@ Deploy a smart contract
 
 ```bash
 $ forge create --help
+```
+
+```txt
 Usage: forge create [OPTIONS] <CONTRACT>
 
 Arguments:

--- a/src/reference/cli/forge/debug.md
+++ b/src/reference/cli/forge/debug.md
@@ -13,8 +13,8 @@ Arguments:
   <PATH>
           The contract you want to run. Either the file path or contract name.
           
-          If multiple contracts exist in the same file you must specify the target contract with
-          --target-contract.
+          If multiple contracts exist in the same file you must specify the
+          target contract with --target-contract.
 
   [ARGS]...
           Arguments to pass to the script function
@@ -26,7 +26,8 @@ Options:
           [aliases: tc]
 
   -s, --sig <SIGNATURE>
-          The signature of the function you want to call in the contract, or raw calldata
+          The signature of the function you want to call in the contract, or raw
+          calldata
           
           [default: run()]
 
@@ -68,7 +69,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -81,7 +83,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -118,8 +121,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -130,7 +133,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -150,7 +154,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -159,9 +164,11 @@ Project options:
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -199,7 +206,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -209,12 +217,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -234,8 +244,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -272,8 +282,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -283,9 +293,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features

--- a/src/reference/cli/forge/debug.md
+++ b/src/reference/cli/forge/debug.md
@@ -4,6 +4,9 @@ Debugs a single smart contract as a script
 
 ```bash
 $ forge debug --help
+```
+
+```txt
 Usage: forge debug [OPTIONS] <PATH> [ARGS]...
 
 Arguments:

--- a/src/reference/cli/forge/doc.md
+++ b/src/reference/cli/forge/doc.md
@@ -4,6 +4,9 @@ Generate documentation for the project
 
 ```bash
 $ forge doc --help
+```
+
+```txt
 Usage: forge doc [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/doc.md
+++ b/src/reference/cli/forge/doc.md
@@ -13,7 +13,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -o, --out <PATH>
           The doc's output path.
@@ -39,7 +40,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -47,27 +49,29 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 
   -p, --port <PORT>
           Port for serving documentation
 
       --deployments [<DEPLOYMENTS>]
-          The relative path to the `hardhat-deploy` or `forge-deploy` artifact directory. Leave
-          blank for default
+          The relative path to the `hardhat-deploy` or `forge-deploy` artifact
+          directory. Leave blank for default
 
   -i, --include-libraries
           Whether to create docs for external libraries

--- a/src/reference/cli/forge/eip712.md
+++ b/src/reference/cli/forge/eip712.md
@@ -4,6 +4,9 @@ Generate EIP-712 struct encodings for structs from a given file
 
 ```bash
 $ forge eip712 --help
+```
+
+```txt
 Usage: forge eip712 [OPTIONS] <PATH>
 
 Arguments:

--- a/src/reference/cli/forge/eip712.md
+++ b/src/reference/cli/forge/eip712.md
@@ -49,7 +49,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -62,7 +63,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -99,8 +101,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -111,7 +113,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -131,7 +134,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/flatten.md
+++ b/src/reference/cli/forge/flatten.md
@@ -26,7 +26,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -46,7 +47,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/flatten.md
+++ b/src/reference/cli/forge/flatten.md
@@ -4,6 +4,9 @@ Flatten a source file and all of its imports into one file
 
 ```bash
 $ forge flatten --help
+```
+
+```txt
 Usage: forge flatten [OPTIONS] <PATH>
 
 Arguments:

--- a/src/reference/cli/forge/fmt.md
+++ b/src/reference/cli/forge/fmt.md
@@ -17,15 +17,18 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --check
           Run in 'check' mode.
           
-          Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required.
+          Exits with 0 if input is formatted correctly. Exits with 1 if
+          formatting is required.
 
   -r, --raw
-          In 'check' and stdin modes, outputs raw formatted code instead of the diff
+          In 'check' and stdin modes, outputs raw formatted code instead of the
+          diff
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/forge/fmt.md
+++ b/src/reference/cli/forge/fmt.md
@@ -4,6 +4,9 @@ Format Solidity source files
 
 ```bash
 $ forge fmt --help
+```
+
+```txt
 Usage: forge fmt [OPTIONS] [PATH]...
 
 Arguments:

--- a/src/reference/cli/forge/geiger.md
+++ b/src/reference/cli/forge/geiger.md
@@ -17,12 +17,14 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --check
           Run in "check" mode.
           
-          The exit code of the program will be the number of unsafe cheatcodes found.
+          The exit code of the program will be the number of unsafe cheatcodes
+          found.
 
       --ignore <PATH>...
           Globs to ignore

--- a/src/reference/cli/forge/geiger.md
+++ b/src/reference/cli/forge/geiger.md
@@ -4,6 +4,9 @@ Detects usage of unsafe cheat codes in a project and its dependencies
 
 ```bash
 $ forge geiger --help
+```
+
+```txt
 Usage: forge geiger [OPTIONS] [PATH]...
 
 Arguments:

--- a/src/reference/cli/forge/generate-fig-spec.md
+++ b/src/reference/cli/forge/generate-fig-spec.md
@@ -4,6 +4,9 @@ Generate Fig autocompletion spec
 
 ```bash
 $ forge generate-fig-spec --help
+```
+
+```txt
 Usage: forge generate-fig-spec
 
 Options:

--- a/src/reference/cli/forge/generate.md
+++ b/src/reference/cli/forge/generate.md
@@ -4,6 +4,9 @@ Generate scaffold files
 
 ```bash
 $ forge generate --help
+```
+
+```txt
 Usage: forge generate <COMMAND>
 
 Commands:

--- a/src/reference/cli/forge/generate/test.md
+++ b/src/reference/cli/forge/generate/test.md
@@ -4,6 +4,9 @@ Scaffolds test file for given contract
 
 ```bash
 $ forge generate test --help
+```
+
+```txt
 Usage: forge generate test --contract-name <CONTRACT_NAME>
 
 Options:

--- a/src/reference/cli/forge/init.md
+++ b/src/reference/cli/forge/init.md
@@ -20,8 +20,8 @@ Options:
           The template to start from
 
   -b, --branch <BRANCH>
-          Branch argument that can only be used with template option. If not specified, the default
-          branch is used
+          Branch argument that can only be used with template option. If not
+          specified, the default branch is used
 
       --offline
           Do not install dependencies from the network
@@ -32,13 +32,14 @@ Options:
           Create the project even if the specified root directory is not empty
 
       --vscode
-          Create a .vscode/settings.json file with Solidity settings, and generate a remappings.txt
-          file
+          Create a .vscode/settings.json file with Solidity settings, and
+          generate a remappings.txt file
 
       --shallow
           Perform shallow clones instead of deep ones.
           
-          Improves performance and reduces disk usage, but prevents switching branches or tags.
+          Improves performance and reduces disk usage, but prevents switching
+          branches or tags.
 
       --no-git
           Install without adding the dependency as a submodule

--- a/src/reference/cli/forge/init.md
+++ b/src/reference/cli/forge/init.md
@@ -4,6 +4,9 @@ Create a new Forge project
 
 ```bash
 $ forge init --help
+```
+
+```txt
 Usage: forge init [OPTIONS] [PATH]
 
 Arguments:

--- a/src/reference/cli/forge/inspect.md
+++ b/src/reference/cli/forge/inspect.md
@@ -11,14 +11,16 @@ Usage: forge inspect [OPTIONS] <CONTRACT> <FIELD>
 
 Arguments:
   <CONTRACT>
-          The identifier of the contract to inspect in the form `(<path>:)?<contractname>`
+          The identifier of the contract to inspect in the form
+          `(<path>:)?<contractname>`
 
   <FIELD>
           The contract artifact field to inspect
           
-          [possible values: abi, bytecode, deployedBytecode, assembly, assemblyOptimized,
-          methodIdentifiers, gasEstimates, storageLayout, devdoc, ir, irOptimized, metadata,
-          userdoc, ewasm, errors, events, eof, eof-init]
+          [possible values: abi, bytecode, deployedBytecode, assembly,
+          assemblyOptimized, methodIdentifiers, gasEstimates, storageLayout,
+          devdoc, ir, irOptimized, metadata, userdoc, ewasm, errors, events,
+          eof, eof-init]
 
 Options:
       --pretty
@@ -59,7 +61,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -72,7 +75,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -109,8 +113,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -121,7 +125,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -141,7 +146,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/inspect.md
+++ b/src/reference/cli/forge/inspect.md
@@ -4,6 +4,9 @@ Get specialized information about a smart contract
 
 ```bash
 $ forge inspect --help
+```
+
+```txt
 Usage: forge inspect [OPTIONS] <CONTRACT> <FIELD>
 
 Arguments:

--- a/src/reference/cli/forge/install.md
+++ b/src/reference/cli/forge/install.md
@@ -18,23 +18,26 @@ Arguments:
           
           A dependency can be a raw URL, or the path to a GitHub repository.
           
-          Additionally, a ref can be provided by adding @ to the dependency path.
+          Additionally, a ref can be provided by adding @ to the dependency
+          path.
           
           A ref can be: - A branch: master - A tag: v1.2.3 - A commit: 8e8128
           
-          Target installation directory can be added via `<alias>=` suffix. The dependency will
-          installed to `lib/<alias>`.
+          Target installation directory can be added via `<alias>=` suffix. The
+          dependency will installed to `lib/<alias>`.
 
 Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --shallow
           Perform shallow clones instead of deep ones.
           
-          Improves performance and reduces disk usage, but prevents switching branches or tags.
+          Improves performance and reduces disk usage, but prevents switching
+          branches or tags.
 
       --no-git
           Install without adding the dependency as a submodule

--- a/src/reference/cli/forge/install.md
+++ b/src/reference/cli/forge/install.md
@@ -4,6 +4,9 @@ Install one or multiple dependencies.
 
 ```bash
 $ forge install --help
+```
+
+```txt
 Usage: forge install [OPTIONS] [DEPENDENCIES]...
     forge install [OPTIONS] <github username>/<github project>@<tag>...
     forge install [OPTIONS] <alias>=<github username>/<github project>@<tag>...

--- a/src/reference/cli/forge/remappings.md
+++ b/src/reference/cli/forge/remappings.md
@@ -4,6 +4,9 @@ Get the automatically inferred remappings for the project
 
 ```bash
 $ forge remappings --help
+```
+
+```txt
 Usage: forge remappings [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/remappings.md
+++ b/src/reference/cli/forge/remappings.md
@@ -13,7 +13,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --pretty
           Pretty-print the remappings, grouping each of them by context

--- a/src/reference/cli/forge/remove.md
+++ b/src/reference/cli/forge/remove.md
@@ -4,6 +4,9 @@ Remove one or multiple dependencies
 
 ```bash
 $ forge remove --help
+```
+
+```txt
 Usage: forge remove [OPTIONS] <DEPENDENCIES>...
 
 Arguments:

--- a/src/reference/cli/forge/remove.md
+++ b/src/reference/cli/forge/remove.md
@@ -17,7 +17,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -f, --force
           Override the up-to-date check

--- a/src/reference/cli/forge/script.md
+++ b/src/reference/cli/forge/script.md
@@ -13,8 +13,8 @@ Arguments:
   <PATH>
           The contract you want to run. Either the file path or contract name.
           
-          If multiple contracts exist in the same file you must specify the target contract with
-          --target-contract.
+          If multiple contracts exist in the same file you must specify the
+          target contract with --target-contract.
 
   [ARGS]...
           Arguments to pass to the script function
@@ -26,7 +26,8 @@ Options:
           [aliases: tc]
 
   -s, --sig <SIG>
-          The signature of the function you want to call in the contract, or raw calldata
+          The signature of the function you want to call in the contract, or raw
+          calldata
           
           [default: run()]
 
@@ -46,7 +47,8 @@ Options:
       --batch-size <BATCH_SIZE>
           Batch size of transactions.
           
-          This is ignored and set to 1 if batching is not available or `--slow` is enabled.
+          This is ignored and set to 1 if batching is not available or `--slow`
+          is enabled.
           
           [default: 100]
 
@@ -59,18 +61,21 @@ Options:
           [default: 130]
 
       --unlocked
-          Send via `eth_sendTransaction` using the `--from` argument or `$ETH_FROM` as sender
+          Send via `eth_sendTransaction` using the `--from` argument or
+          `$ETH_FROM` as sender
 
       --resume
           Resumes submitting transactions that failed or timed-out previously.
           
-          It DOES NOT simulate the script again and it expects nonces to have remained the same.
+          It DOES NOT simulate the script again and it expects nonces to have
+          remained the same.
           
-          Example: If transaction N has a nonce of 22, then the account should have a nonce of 22,
-          otherwise it fails.
+          Example: If transaction N has a nonce of 22, then the account should
+          have a nonce of 22, otherwise it fails.
 
       --multi
-          If present, --resume or --verify will be assumed to be a multi chain deployment
+          If present, --resume or --verify will be assumed to be a multi chain
+          deployment
 
       --debug
           Open the script in the debugger.
@@ -78,11 +83,12 @@ Options:
           Takes precedence over broadcast.
 
       --slow
-          Makes sure a transaction is sent, only after its previous one has been confirmed and
-          succeeded
+          Makes sure a transaction is sent, only after its previous one has been
+          confirmed and succeeded
 
       --non-interactive
-          Disables interactive prompts that might appear when deploying big contracts.
+          Disables interactive prompts that might appear when deploying big
+          contracts.
           
           For more info on the contract size limit, see EIP-170:
           <https://eips.ethereum.org/EIPS/eip-170>
@@ -99,8 +105,9 @@ Options:
           Output results in JSON format
 
       --with-gas-price <PRICE>
-          Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
-          specified in wei, or as a string with a unit type.
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions, either specified in wei, or as a string with a unit
+          type.
           
           Examples: 1ether, 10gwei, 0.01ether
           
@@ -146,7 +153,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -159,7 +167,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -196,8 +205,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -208,7 +217,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -228,7 +238,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -280,7 +291,8 @@ Wallet options - keystore:
           [aliases: keystores]
 
       --account <ACCOUNT_NAMES>
-          Use a keystore from the default keystores folder (~/.foundry/keystores) by its filename
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
           
           [env: ETH_KEYSTORE_ACCOUNT=]
           [aliases: accounts]
@@ -310,9 +322,11 @@ Wallet options - remote:
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -350,7 +364,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -360,12 +375,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -385,8 +402,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -423,8 +440,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -434,9 +451,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features

--- a/src/reference/cli/forge/script.md
+++ b/src/reference/cli/forge/script.md
@@ -4,6 +4,9 @@ Run a smart contract as a script, building transactions that can be sent onchain
 
 ```bash
 $ forge script --help
+```
+
+```txt
 Usage: forge script [OPTIONS] <PATH> [ARGS]...
 
 Arguments:

--- a/src/reference/cli/forge/selectors.md
+++ b/src/reference/cli/forge/selectors.md
@@ -4,6 +4,9 @@ Function selector utilities
 
 ```bash
 $ forge selectors --help
+```
+
+```txt
 Usage: forge selectors <COMMAND>
 
 Commands:

--- a/src/reference/cli/forge/selectors/collision.md
+++ b/src/reference/cli/forge/selectors/collision.md
@@ -4,6 +4,9 @@ Check for selector collisions between contracts
 
 ```bash
 $ forge selectors collision --help
+```
+
+```txt
 Usage: forge selectors collision [OPTIONS] <FIRST_CONTRACT> <SECOND_CONTRACT>
 
 Arguments:

--- a/src/reference/cli/forge/selectors/collision.md
+++ b/src/reference/cli/forge/selectors/collision.md
@@ -11,12 +11,12 @@ Usage: forge selectors collision [OPTIONS] <FIRST_CONTRACT> <SECOND_CONTRACT>
 
 Arguments:
   <FIRST_CONTRACT>
-          The first of the two contracts for which to look selector collisions for, in the form
-          `(<path>:)?<contractname>`
+          The first of the two contracts for which to look selector collisions
+          for, in the form `(<path>:)?<contractname>`
 
   <SECOND_CONTRACT>
-          The second of the two contracts for which to look selector collisions for, in the form
-          `(<path>:)?<contractname>`
+          The second of the two contracts for which to look selector collisions
+          for, in the form `(<path>:)?<contractname>`
 
 Options:
   -h, --help
@@ -54,7 +54,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -67,7 +68,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -104,8 +106,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -116,7 +118,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -136,7 +139,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/selectors/find.md
+++ b/src/reference/cli/forge/selectors/find.md
@@ -21,7 +21,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -41,7 +42,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/selectors/find.md
+++ b/src/reference/cli/forge/selectors/find.md
@@ -4,6 +4,9 @@ Find if a selector is present in the project
 
 ```bash
 $ forge selectors find --help
+```
+
+```txt
 Usage: forge selectors find [OPTIONS] <SELECTOR>
 
 Arguments:

--- a/src/reference/cli/forge/selectors/list.md
+++ b/src/reference/cli/forge/selectors/list.md
@@ -4,6 +4,9 @@ List selectors from current workspace
 
 ```bash
 $ forge selectors list --help
+```
+
+```txt
 Usage: forge selectors list [OPTIONS] [CONTRACT]
 
 Arguments:

--- a/src/reference/cli/forge/selectors/list.md
+++ b/src/reference/cli/forge/selectors/list.md
@@ -21,7 +21,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -41,7 +42,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/selectors/upload.md
+++ b/src/reference/cli/forge/selectors/upload.md
@@ -24,7 +24,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -44,7 +45,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/selectors/upload.md
+++ b/src/reference/cli/forge/selectors/upload.md
@@ -4,6 +4,9 @@ Upload selectors to registry
 
 ```bash
 $ forge selectors upload --help
+```
+
+```txt
 Usage: forge selectors upload [OPTIONS] [CONTRACT]
 
 Arguments:

--- a/src/reference/cli/forge/snapshot.md
+++ b/src/reference/cli/forge/snapshot.md
@@ -4,6 +4,9 @@ Create a snapshot of each test's gas usage
 
 ```bash
 $ forge snapshot --help
+```
+
+```txt
 Usage: forge snapshot [OPTIONS] [PATH]
 
 Options:

--- a/src/reference/cli/forge/snapshot.md
+++ b/src/reference/cli/forge/snapshot.md
@@ -16,7 +16,8 @@ Options:
           By default, the comparison is done with .gas-snapshot.
 
       --check [<SNAPSHOT_FILE>]
-          Compare against a pre-existing snapshot, exiting with code 1 if they do not match.
+          Compare against a pre-existing snapshot, exiting with code 1 if they
+          do not match.
           
           Outputs a diff if the snapshots do not match.
           
@@ -37,18 +38,22 @@ Test options:
       --debug <TEST_FUNCTION>
           Run a test in the debugger.
           
-          The argument passed to this flag is the name of the test function you want to run, and it
-          works the same as --match-test.
+          The argument passed to this flag is the name of the test function you
+          want to run, and it works the same as --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
           
-          The matching test will be opened in the debugger regardless of the outcome of the test.
+          The matching test will be opened in the debugger regardless of the
+          outcome of the test.
           
-          If the matching test is a fuzz test, then it will open the debugger on the first failure
-          case. If the fuzz test does not fail, it will open the debugger on the last fuzz case.
+          If the matching test is a fuzz test, then it will open the debugger on
+          the first failure case. If the fuzz test does not fail, it will open
+          the debugger on the last fuzz case.
           
-          For more fine-grained control of which fuzz case is run, see forge run.
+          For more fine-grained control of which fuzz case is run, see forge
+          run.
 
       --flamegraph
           Generate a flamegraph for a single test. Implies `--decode-internal`
@@ -59,15 +64,16 @@ Test options:
       --decode-internal [<TEST_FUNCTION>]
           Whether to identify internal functions in traces.
           
-          If no argument is passed to this flag, it will trace internal functions scope and decode
-          stack parameters, but parameters stored in memory (such as bytes or arrays) will not be
-          decoded.
+          If no argument is passed to this flag, it will trace internal
+          functions scope and decode stack parameters, but parameters stored in
+          memory (such as bytes or arrays) will not be decoded.
           
-          To decode memory parameters, you should pass an argument with a test function name,
-          similarly to --debug and --match-test.
+          To decode memory parameters, you should pass an argument with a test
+          function name, similarly to --debug and --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
 
       --gas-report
           Print a gas report
@@ -97,7 +103,8 @@ Test options:
           File to rerun fuzz failures from
 
   -j, --threads <THREADS>
-          Max concurrent threads to use. Default value is the number of available CPUs
+          Max concurrent threads to use. Default value is the number of
+          available CPUs
           
           [aliases: jobs]
 
@@ -140,7 +147,8 @@ Test filtering:
           [aliases: mc]
 
       --no-match-contract <REGEX>
-          Only run tests in contracts that do not match the specified regex pattern
+          Only run tests in contracts that do not match the specified regex
+          pattern
           
           [aliases: nmc]
 
@@ -150,24 +158,28 @@ Test filtering:
           [aliases: mp]
 
       --no-match-path <GLOB>
-          Only run tests in source files that do not match the specified glob pattern
+          Only run tests in source files that do not match the specified glob
+          pattern
           
           [aliases: nmp]
 
       --no-match-coverage <REGEX>
-          Only show coverage for files that do not match the specified regex pattern
+          Only show coverage for files that do not match the specified regex
+          pattern
           
           [aliases: nmco]
 
       --rerun
-          Re-run recorded test failures from last run. If no failure recorded then regular test run
-          is performed
+          Re-run recorded test failures from last run. If no failure recorded
+          then regular test run is performed
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -205,7 +217,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -215,12 +228,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -240,8 +255,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -278,8 +293,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -289,9 +304,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features
@@ -328,7 +344,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -341,7 +358,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -378,8 +396,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -390,7 +408,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -410,7 +429,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -421,7 +441,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -429,20 +450,22 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 
       --asc
           Sort results by gas used (ascending)

--- a/src/reference/cli/forge/soldeer.md
+++ b/src/reference/cli/forge/soldeer.md
@@ -4,6 +4,9 @@ Soldeer dependency manager
 
 ```bash
 $ forge soldeer --help
+```
+
+```txt
 Usage: Native Solidity Package Manager, `run forge soldeer [COMMAND] --help` for more details
 
 Commands:

--- a/src/reference/cli/forge/soldeer/init.md
+++ b/src/reference/cli/forge/soldeer/init.md
@@ -10,7 +10,8 @@ $ forge soldeer init --help
 Usage: forge soldeer init [OPTIONS]
 
 Options:
-      --clean  Clean the Foundry project by removing .gitmodules and the lib directory
+      --clean  Clean the Foundry project by removing .gitmodules and the lib
+               directory
   -h, --help   Print help
 
 For more information, read the README.md

--- a/src/reference/cli/forge/soldeer/init.md
+++ b/src/reference/cli/forge/soldeer/init.md
@@ -4,6 +4,9 @@ Initialize a new Soldeer project for use with Foundry
 
 ```bash
 $ forge soldeer init --help
+```
+
+```txt
 Usage: forge soldeer init [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/soldeer/install.md
+++ b/src/reference/cli/forge/soldeer/install.md
@@ -31,11 +31,12 @@ Options:
           A Git branch
 
   -g, --regenerate-remappings
-          If set, this command will delete the existing remappings and re-create them
+          If set, this command will delete the existing remappings and re-create
+          them
 
   -d, --recursive-deps
-          If set, this command will install the recursive dependencies (via submodules or via
-          soldeer)
+          If set, this command will install the recursive dependencies (via
+          submodules or via soldeer)
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/forge/soldeer/install.md
+++ b/src/reference/cli/forge/soldeer/install.md
@@ -4,6 +4,9 @@ Install a dependency
 
 ```bash
 $ forge soldeer install --help
+```
+
+```txt
 Usage: forge soldeer install [OPTIONS] [DEPENDENCY~VERSION] [URL]
 
 Arguments:

--- a/src/reference/cli/forge/soldeer/login.md
+++ b/src/reference/cli/forge/soldeer/login.md
@@ -4,6 +4,9 @@ Log into the central repository to push the dependencies
 
 ```bash
 $ forge soldeer login --help
+```
+
+```txt
 Usage: forge soldeer login
 
 Options:

--- a/src/reference/cli/forge/soldeer/push.md
+++ b/src/reference/cli/forge/soldeer/push.md
@@ -13,22 +13,23 @@ Arguments:
   <DEPENDENCY>~<VERSION>
           The dependency name and version, separated by a tilde.
           
-          This should always be used when you want to push a dependency to the central repository:
-          `<https://soldeer.xyz>`.
+          This should always be used when you want to push a dependency to the
+          central repository: `<https://soldeer.xyz>`.
 
   [PATH]
-          Use this if the dependency you want to push is not in the current directory.
+          Use this if the dependency you want to push is not in the current
+          directory.
           
           Example: `soldeer push mypkg~0.1.0 /path/to/dep`.
 
 Options:
   -d, --dry-run
-          Use this if you want to run a dry run. If set, this will generate a zip file that you can
-          inspect to see what will be pushed
+          Use this if you want to run a dry run. If set, this will generate a
+          zip file that you can inspect to see what will be pushed
 
       --skip-warnings
-          Use this if you want to skip the warnings that can be triggered when trying to push
-          dotfiles like .env
+          Use this if you want to skip the warnings that can be triggered when
+          trying to push dotfiles like .env
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/reference/cli/forge/soldeer/push.md
+++ b/src/reference/cli/forge/soldeer/push.md
@@ -4,6 +4,9 @@ Push a Dependency to the Repository
 
 ```bash
 $ forge soldeer push --help
+```
+
+```txt
 Usage: forge soldeer push [OPTIONS] <DEPENDENCY>~<VERSION> [PATH]
 
 Arguments:

--- a/src/reference/cli/forge/soldeer/uninstall.md
+++ b/src/reference/cli/forge/soldeer/uninstall.md
@@ -4,6 +4,9 @@ Uninstall a dependency
 
 ```bash
 $ forge soldeer uninstall --help
+```
+
+```txt
 Usage: forge soldeer uninstall <DEPENDENCY>
 
 Arguments:

--- a/src/reference/cli/forge/soldeer/update.md
+++ b/src/reference/cli/forge/soldeer/update.md
@@ -10,10 +10,10 @@ $ forge soldeer update --help
 Usage: forge soldeer update [OPTIONS]
 
 Options:
-  -g, --regenerate-remappings  If set, this command will delete the existing remappings and
-                               re-create them
-  -d, --recursive-deps         If set, this command will install the recursive dependencies (via
-                               submodules or via soldeer)
+  -g, --regenerate-remappings  If set, this command will delete the existing
+                               remappings and re-create them
+  -d, --recursive-deps         If set, this command will install the recursive
+                               dependencies (via submodules or via soldeer)
   -h, --help                   Print help
 
 For more information, read the README.md

--- a/src/reference/cli/forge/soldeer/update.md
+++ b/src/reference/cli/forge/soldeer/update.md
@@ -4,6 +4,9 @@ Update dependencies by reading the config file
 
 ```bash
 $ forge soldeer update --help
+```
+
+```txt
 Usage: forge soldeer update [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/soldeer/version.md
+++ b/src/reference/cli/forge/soldeer/version.md
@@ -4,6 +4,9 @@ Display the version of Soldeer
 
 ```bash
 $ forge soldeer version --help
+```
+
+```txt
 Usage: forge soldeer version
 
 Options:

--- a/src/reference/cli/forge/test.md
+++ b/src/reference/cli/forge/test.md
@@ -17,18 +17,22 @@ Test options:
       --debug <TEST_FUNCTION>
           Run a test in the debugger.
           
-          The argument passed to this flag is the name of the test function you want to run, and it
-          works the same as --match-test.
+          The argument passed to this flag is the name of the test function you
+          want to run, and it works the same as --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
           
-          The matching test will be opened in the debugger regardless of the outcome of the test.
+          The matching test will be opened in the debugger regardless of the
+          outcome of the test.
           
-          If the matching test is a fuzz test, then it will open the debugger on the first failure
-          case. If the fuzz test does not fail, it will open the debugger on the last fuzz case.
+          If the matching test is a fuzz test, then it will open the debugger on
+          the first failure case. If the fuzz test does not fail, it will open
+          the debugger on the last fuzz case.
           
-          For more fine-grained control of which fuzz case is run, see forge run.
+          For more fine-grained control of which fuzz case is run, see forge
+          run.
 
       --flamegraph
           Generate a flamegraph for a single test. Implies `--decode-internal`
@@ -39,15 +43,16 @@ Test options:
       --decode-internal [<TEST_FUNCTION>]
           Whether to identify internal functions in traces.
           
-          If no argument is passed to this flag, it will trace internal functions scope and decode
-          stack parameters, but parameters stored in memory (such as bytes or arrays) will not be
-          decoded.
+          If no argument is passed to this flag, it will trace internal
+          functions scope and decode stack parameters, but parameters stored in
+          memory (such as bytes or arrays) will not be decoded.
           
-          To decode memory parameters, you should pass an argument with a test function name,
-          similarly to --debug and --match-test.
+          To decode memory parameters, you should pass an argument with a test
+          function name, similarly to --debug and --match-test.
           
-          If more than one test matches your specified criteria, you must add additional filters
-          until only one test is found (see --match-contract and --match-path).
+          If more than one test matches your specified criteria, you must add
+          additional filters until only one test is found (see --match-contract
+          and --match-path).
 
       --gas-report
           Print a gas report
@@ -77,7 +82,8 @@ Test options:
           File to rerun fuzz failures from
 
   -j, --threads <THREADS>
-          Max concurrent threads to use. Default value is the number of available CPUs
+          Max concurrent threads to use. Default value is the number of
+          available CPUs
           
           [aliases: jobs]
 
@@ -120,7 +126,8 @@ Test filtering:
           [aliases: mc]
 
       --no-match-contract <REGEX>
-          Only run tests in contracts that do not match the specified regex pattern
+          Only run tests in contracts that do not match the specified regex
+          pattern
           
           [aliases: nmc]
 
@@ -130,24 +137,28 @@ Test filtering:
           [aliases: mp]
 
       --no-match-path <GLOB>
-          Only run tests in source files that do not match the specified glob pattern
+          Only run tests in source files that do not match the specified glob
+          pattern
           
           [aliases: nmp]
 
       --no-match-coverage <REGEX>
-          Only show coverage for files that do not match the specified regex pattern
+          Only show coverage for files that do not match the specified regex
+          pattern
           
           [aliases: nmco]
 
       --rerun
-          Re-run recorded test failures from last run. If no failure recorded then regular test run
-          is performed
+          Re-run recorded test failures from last run. If no failure recorded
+          then regular test run is performed
 
 EVM options:
   -f, --fork-url <URL>
-          Fetch state over a remote endpoint instead of starting from an empty state.
+          Fetch state over a remote endpoint instead of starting from an empty
+          state.
           
-          If you want to fetch state from a specific block number, see --fork-block-number.
+          If you want to fetch state from a specific block number, see
+          --fork-block-number.
           
           [aliases: rpc-url]
 
@@ -185,7 +196,8 @@ EVM options:
           Enable the FFI cheatcode
 
       --always-use-create-2-factory
-          Use the create 2 factory in all cases including tests and non-broadcasting scripts
+          Use the create 2 factory in all cases including tests and
+          non-broadcasting scripts
 
   -v, --verbosity...
           Verbosity of the EVM.
@@ -195,12 +207,14 @@ EVM options:
           Verbosity levels:
           - 2: Print logs for all tests
           - 3: Print execution traces for failing tests
-          - 4: Print execution traces for all tests, and setup traces for failing tests
+          - 4: Print execution traces for all tests, and setup traces for
+          failing tests
           - 5: Print execution and setup traces for all tests
 
 Fork config:
       --compute-units-per-second <CUPS>
-          Sets the number of assumed available compute units per second for this provider
+          Sets the number of assumed available compute units per second for this
+          provider
           
           default value: 330
           
@@ -220,8 +234,8 @@ Executor environment config:
           The block gas limit
 
       --code-size-limit <CODE_SIZE>
-          EIP-170: Contract code size limit in bytes. Useful to increase this because of tests. By
-          default, it is 0x6000 (~25kb)
+          EIP-170: Contract code size limit in bytes. Useful to increase this
+          because of tests. By default, it is 0x6000 (~25kb)
 
       --chain <CHAIN>
           The chain name or EIP-155 chain ID
@@ -258,8 +272,8 @@ Executor environment config:
           The block gas limit
 
       --memory-limit <MEMORY_LIMIT>
-          The memory limit per EVM execution in bytes. If this limit is exceeded, a `MemoryLimitOOG`
-          result is thrown.
+          The memory limit per EVM execution in bytes. If this limit is
+          exceeded, a `MemoryLimitOOG` result is thrown.
           
           The default is 128MiB.
 
@@ -269,9 +283,10 @@ Executor environment config:
           [aliases: no-gas-limit]
 
       --isolate
-          Whether to enable isolation of calls. In isolation mode all top-level calls are executed
-          as a separate transaction in a separate EVM context, enabling more precise gas accounting
-          and transaction state changes
+          Whether to enable isolation of calls. In isolation mode all top-level
+          calls are executed as a separate transaction in a separate EVM
+          context, enabling more precise gas accounting and transaction state
+          changes
 
       --alphanet
           Whether to enable Alphanet features
@@ -308,7 +323,8 @@ Compiler options:
       --use <SOLC_VERSION>
           Specify the solc version, or a path to a local solc, to build with.
           
-          Valid values are in the format `x.y.z`, `solc:x.y.z` or `path/to/solc`.
+          Valid values are in the format `x.y.z`, `solc:x.y.z` or
+          `path/to/solc`.
 
       --offline
           Do not access the network.
@@ -321,7 +337,8 @@ Compiler options:
       --no-metadata
           Do not append any metadata to the bytecode.
           
-          This is equivalent to setting `bytecode_hash` to `none` and `cbor_metadata` to `false`.
+          This is equivalent to setting `bytecode_hash` to `none` and
+          `cbor_metadata` to `false`.
 
       --silent
           Don't print anything on startup
@@ -358,8 +375,8 @@ Project options:
       --revert-strings <REVERT>
           Revert string configuration.
           
-          Possible values are "default", "strip" (remove), "debug" (Solidity-generated revert
-          strings) and "verboseDebug"
+          Possible values are "default", "strip" (remove), "debug"
+          (Solidity-generated revert strings) and "verboseDebug"
 
       --build-info
           Generate build info files
@@ -370,7 +387,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -390,7 +408,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 
@@ -401,7 +420,8 @@ Watch options:
   -w, --watch [<PATH>...]
           Watch the given files or directories for changes.
           
-          If no paths are provided, the source and test directories of the project are watched.
+          If no paths are provided, the source and test directories of the
+          project are watched.
 
       --no-restart
           Do not restart the command while it's still running
@@ -409,18 +429,20 @@ Watch options:
       --run-all
           Explicitly re-run all tests when a change is made.
           
-          By default, only the tests of the last modified test file are executed.
+          By default, only the tests of the last modified test file are
+          executed.
 
       --watch-delay <DELAY>
           File update debounce delay.
           
-          During the delay, incoming change events are accumulated and only once the delay has
-          passed, is an action taken. Note that this does not mean a command will be started: if
-          --no-restart is given and a command is already running, the outcome of the action will be
-          to do nothing.
+          During the delay, incoming change events are accumulated and only once
+          the delay has passed, is an action taken. Note that this does not mean
+          a command will be started: if --no-restart is given and a command is
+          already running, the outcome of the action will be to do nothing.
           
-          Defaults to 50ms. Parses as decimal seconds by default, but using an integer with the `ms`
-          suffix may be more convenient.
+          Defaults to 50ms. Parses as decimal seconds by default, but using an
+          integer with the `ms` suffix may be more convenient.
           
-          When using --poll mode, you'll want a larger duration, or risk overloading disk I/O.
+          When using --poll mode, you'll want a larger duration, or risk
+          overloading disk I/O.
 ```

--- a/src/reference/cli/forge/test.md
+++ b/src/reference/cli/forge/test.md
@@ -4,6 +4,9 @@ Run the project's tests
 
 ```bash
 $ forge test --help
+```
+
+```txt
 Usage: forge test [OPTIONS] [PATH]
 
 Options:

--- a/src/reference/cli/forge/tree.md
+++ b/src/reference/cli/forge/tree.md
@@ -4,6 +4,9 @@ Display a tree visualization of the project's dependency graph
 
 ```bash
 $ forge tree --help
+```
+
+```txt
 Usage: forge tree [OPTIONS]
 
 Options:

--- a/src/reference/cli/forge/tree.md
+++ b/src/reference/cli/forge/tree.md
@@ -27,7 +27,8 @@ Project options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -C, --contracts <PATH>
           The contracts source directory
@@ -47,7 +48,8 @@ Project options:
       --hardhat
           Use the Hardhat-style project layout.
           
-          This is the same as using: `--contracts contracts --lib-paths node_modules`.
+          This is the same as using: `--contracts contracts --lib-paths
+          node_modules`.
           
           [aliases: hh]
 

--- a/src/reference/cli/forge/update.md
+++ b/src/reference/cli/forge/update.md
@@ -4,6 +4,9 @@ Update one or multiple dependencies.
 
 ```bash
 $ forge update --help
+```
+
+```txt
 Usage: forge update [OPTIONS] [DEPENDENCIES]...
 
 Arguments:

--- a/src/reference/cli/forge/update.md
+++ b/src/reference/cli/forge/update.md
@@ -17,7 +17,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
   -f, --force
           Override the up-to-date check

--- a/src/reference/cli/forge/verify-bytecode.md
+++ b/src/reference/cli/forge/verify-bytecode.md
@@ -50,7 +50,8 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --ignore <BYTECODE_TYPE>
           Ignore verification for creation or runtime bytecode

--- a/src/reference/cli/forge/verify-bytecode.md
+++ b/src/reference/cli/forge/verify-bytecode.md
@@ -4,6 +4,9 @@ Verify the deployed bytecode against its source on Etherscan
 
 ```bash
 $ forge verify-bytecode --help
+```
+
+```txt
 Usage: forge verify-bytecode [OPTIONS] <ADDRESS> <CONTRACT>
 
 Arguments:

--- a/src/reference/cli/forge/verify-check.md
+++ b/src/reference/cli/forge/verify-check.md
@@ -4,6 +4,9 @@ Check verification status on Etherscan
 
 ```bash
 $ forge verify-check --help
+```
+
+```txt
 Usage: forge verify-check [OPTIONS] <ID>
 
 Arguments:

--- a/src/reference/cli/forge/verify-contract.md
+++ b/src/reference/cli/forge/verify-contract.md
@@ -40,7 +40,8 @@ Options:
           Flatten the source code before verifying
 
   -f, --force
-          Do not compile the flattened smart contract before verifying (if --flatten is passed)
+          Do not compile the flattened smart contract before verifying (if
+          --flatten is passed)
 
       --skip-is-verified-check
           Do not check if the contract is already verified before verifying
@@ -51,13 +52,14 @@ Options:
       --root <PATH>
           The project's root path.
           
-          By default root of the Git repository, if in one, or the current working directory.
+          By default root of the Git repository, if in one, or the current
+          working directory.
 
       --show-standard-json-input
           Prints the standard json compiler input.
           
-          The standard json compiler input can be used to manually submit contract verification in
-          the browser.
+          The standard json compiler input can be used to manually submit
+          contract verification in the browser.
 
       --via-ir
           Use the Yul intermediate representation compilation pipeline
@@ -83,17 +85,20 @@ Options:
           [env: ETH_RPC_URL=]
 
       --flashbots
-          Use the Flashbots RPC URL with fast mode (<https://rpc.flashbots.net/fast>).
+          Use the Flashbots RPC URL with fast mode
+          (<https://rpc.flashbots.net/fast>).
           
           This shares the transaction privately with all registered builders.
           
-          See: <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
+          See:
+          <https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions>
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
           
-          The JWT secret will be used to create a JWT for a RPC. For example, the following can be
-          used to simulate a CL `engine_forkchoiceUpdated` call:
+          The JWT secret will be used to create a JWT for a RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
           
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",

--- a/src/reference/cli/forge/verify-contract.md
+++ b/src/reference/cli/forge/verify-contract.md
@@ -4,6 +4,9 @@ Verify smart contracts on Etherscan
 
 ```bash
 $ forge verify-contract --help
+```
+
+```txt
 Usage: forge verify-contract [OPTIONS] <ADDRESS> [CONTRACT]
 
 Arguments:


### PR DESCRIPTION
Only functional changes are the split between `$ command --help` and the help output done in reth book too, and setting COLUMNS to 80 because mdbook codeblock is goes up to 88 characters