### PR TITLE
fix: incompatible `-L` flag in `tree lib -L 1` on Windows

### DIFF
--- a/src/output/deps/tree
+++ b/src/output/deps/tree
@@ -1,6 +1,6 @@
 // ANCHOR: all
 // ANCHOR: command
-$ tree lib -L 1
+$ tree lib
 // ANCHOR_END: command
 // ANCHOR: output
 lib


### PR DESCRIPTION
Closes: https://github.com/foundry-rs/book/issues/1149

The output isn't fully accurate now but good enough to get the point across