### PR TITLE
docs: fix `optimizer_runs` documentation

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -255,7 +255,9 @@ Whether or not to enable the Solidity optimizer.
 - Default: 200
 - Environment: `FOUNDRY_OPTIMIZER_RUNS` or `DAPP_OPTIMIZER_RUNS`
 
-The amount of optimizer runs to perform.
+The number of runs specifies roughly how often each opcode of the deployed code will be executed across the life-time of the contract. This means it is a trade-off parameter between code size (deploy cost) and code execution cost (cost after deployment). A `optimizer_runs` parameter of `1` will produce short but expensive code. In contrast, a larger `optimizer_runs` parameter will produce longer but more gas efficient code. The maximum value of the parameter is `2**32-1`.
+
+A common misconception is that this parameter specifies the number of iterations of the optimizer. This is not true: The optimizer will always run as many times as it can still improve the code.
 
 ##### `via_ir`
 


### PR DESCRIPTION
https://docs.soliditylang.org/en/v0.8.17/internals/optimizer.html#optimizer-parameter-runs

Closes: #789