### PR TITLE
Fix: document `ignored_warnings_from` setting

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -121,6 +121,15 @@ Each entry in the array should be a path to a directory or a specific file. For 
 
 This configuration will cause the compiler to ignore any warnings that originate from the specified paths.
 
+Purpose:
+This setting helps maintain compatibility across different Solidity versions while avoiding unnecessary warnings from older compilers.
+
+Best Practices:
+
+- Only ignore warnings from versions that are absolutely necessary for your project's compatibility requirements.
+- Regularly review ignored warnings to ensure you're not overlooking important security or functionality improvements.
+- Document why certain warnings are being ignored in your project's README or documentation.
+
 ##### `ignored_error_codes`
 
 - Type: array of integers/strings

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -113,7 +113,7 @@ If both `offline` and `auto-detect-solc` are set to `true`, the required version
 - Environment: `FOUNDRY_IGNORED_WARNINGS_FROM` OR `DAPP_IGNORED_WARNINGS_FROM`
 
 An array of file paths from which warnings should be ignored during the compulation process. This is useful when you have a specific
-directories of files that produce known warning and you wish to suppress these warnings without affecting others.
+directories of files that produce known warnings and you wish to suppress these warnings without affecting others.
 
 Each entry in the array should be a path to a directory or a specific file. For Example:
 

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -129,7 +129,6 @@ Best Practices:
 - Only ignore warnings from versions that are absolutely necessary for your project's compatibility requirements.
 - Regularly review ignored warnings to ensure you're not overlooking important security or functionality improvements.
 - Document why certain warnings are being ignored in your project's README or documentation.
-  [Learn more about Solidity compatibility](https://docs.soliditylang.org/en/latest/how-to-use-solidity.html#compatibility)
 
 ##### `ignored_error_codes`
 

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -121,15 +121,6 @@ Each entry in the array should be a path to a directory or a specific file. For 
 
 This configuration will cause the compiler to ignore any warnings that originate from the specified paths.
 
-Purpose:
-This setting helps maintain compatibility across different Solidity versions while avoiding unnecessary warnings from older compilers.
-
-Best Practices:
-
-- Only ignore warnings from versions that are absolutely necessary for your project's compatibility requirements.
-- Regularly review ignored warnings to ensure you're not overlooking important security or functionality improvements.
-- Document why certain warnings are being ignored in your project's README or documentation.
-
 ##### `ignored_error_codes`
 
 - Type: array of integers/strings

--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -129,6 +129,7 @@ Best Practices:
 - Only ignore warnings from versions that are absolutely necessary for your project's compatibility requirements.
 - Regularly review ignored warnings to ensure you're not overlooking important security or functionality improvements.
 - Document why certain warnings are being ignored in your project's README or documentation.
+  [Learn more about Solidity compatibility](https://docs.soliditylang.org/en/latest/how-to-use-solidity.html#compatibility)
 
 ##### `ignored_error_codes`
 


### PR DESCRIPTION
documented the 'ignored_warning_from' section in references of solidity-compiler doc

Closes: https://github.com/foundry-rs/book/issues/1114