### PR TITLE
Fix: Correct errors in cast logs example

### DIFF
--- a/src/reference/cast/cast-logs.md
+++ b/src/reference/cast/cast-logs.md
@@ -44,11 +44,11 @@ If using a signature, remaining arguments must be in their ordinary form. If usi
 
 1. Get logs using a signature:
     ```sh
-    cast logs --from-block 15537393 --to-block latest 'Transfer (address indexed from, address indexed to, uint256 value)' 0x2e8ABfE042886E4938201101A63730D04F160A82
+    cast logs --from-block 15537393 --to-block latest 'Transfer (address indexed from, address indexed to, uint256 value)' --address 0x2e8ABfE042886E4938201101A63730D04F160A82
     ```
 2. Get logs using a topic:
     ```sh
-    cast logs --from-block 15537393 --to-block latest 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef 0x0000000000000000000000002e8abfe042886e4938201101a63730d04f160a82
+    cast logs --from-block 15537393 --to-block latest 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef --address 0x0000000000000000000000002e8abfe042886e4938201101a63730d04f160a82
     ```
 
 ### SEE ALSO


### PR DESCRIPTION
According to my understanding and verification, 

`cast logs --from-block 15537393 --to-block latest 'Transfer (address indexed from, address indexed to, uint256 value)' 0x2e8ABfE042886E4938201101A63730D04F160A82` 

has the same effect as 

`cast logs --from-block 15537393 --to-block latest 'Transfer (address indexed from, address indexed to, uint256 value)'`. 

Therefore, the address in the original example does not take effect. The `--address` option should be added if this is the original intention of the example.