### PR TITLE
cargo installation command throws an error for 'cast'

### DIFF
--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -49,7 +49,7 @@ foundryup --path path/to/foundry
 Alternatively, you can install via Cargo with the following command:
 
 ```sh
-cargo install --git https://github.com/foundry-rs/foundry --profile release --locked forge cast chisel anvil
+cargo install --git https://github.com/foundry-rs/foundry --profile release --locked forge foundry-cast chisel anvil
 ```
 
 You can also manually build from a local copy of the [Foundry repository](https://github.com/foundry-rs/foundry):


### PR DESCRIPTION

On Windows, the modified installation command worked.

![image](https://github.com/user-attachments/assets/21f79bc6-9032-4895-ae8e-2b340c8f8a17)
