### PR TITLE
Fix: Remove Counter.s.sol to resolve forge build error

### DIFF
--- a/src/tutorials/solidity-scripting.md
+++ b/src/tutorials/solidity-scripting.md
@@ -38,7 +38,7 @@ forge install transmissions11/solmate Openzeppelin/openzeppelin-contracts@v5.0.1
 Next, we have to delete the `Counter.sol` file in the `src` folder and create another file called `NFT.sol`. You can do this by running:
 
 ```sh
-rm src/Counter.sol test/Counter.t.sol && touch src/NFT.sol && ls src
+rm src/Counter.sol test/Counter.t.sol script/Counter.s.sol && touch src/NFT.sol && ls src
 ```
 
 ![set up commands](../images/solidity-scripting/set-up-commands.png)


### PR DESCRIPTION
This PR updates the setup instructions to remove the `Counter.s.sol` script file along with other Counter-related files. This change resolves a `forge build` error caused by the presence of the unused Counter script.

Changes made:
- Updated the shell command to remove `script/Counter.s.sol`
- This ensures a clean project setup for the NFT tutorial