### PR TITLE
Update create-wallet.md

### DIFF
--- a/src/cheatcodes/create-wallet.md
+++ b/src/cheatcodes/create-wallet.md
@@ -36,7 +36,7 @@ Creates a new Wallet struct when given a parameter to derive the private key fro
 #### `uint256`
 
 ```solidity
-Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))));
+Vm.Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))));
 
 emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("1")))
 
@@ -58,7 +58,7 @@ emit log_string(vm.getLabel(wallet.addr)); // ""
 #### `string`
 
 ```solidity
-Wallet memory wallet = vm.createWallet("bob's wallet");
+Vm.Wallet memory wallet = vm.createWallet("bob's wallet");
 
 emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("bob's wallet")))
 
@@ -80,7 +80,7 @@ emit log_string(vm.getLabel(wallet.addr)); // "bob's wallet"
 #### `uint256` and `string`
 
 ```solidity
-Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))), "bob's wallet");
+Vm.Wallet memory wallet = vm.createWallet(uint256(keccak256(bytes("1"))), "bob's wallet");
 
 emit log_uint(wallet.privateKey); // uint256(keccak256(bytes("1")))
 


### PR DESCRIPTION
The guidance provided by the foundry book informs us to setup our tests via
```solidity
contract MyTest is Test {
...
}
```

However, given the inheritance and import structures of `forge-std/Test.sol`, the documentation to create a wallet produces the following error:

```sh
Compiler run failed:
Error (7920): Identifier not found or not unique.
  --> test/MyTest.t.sol:86:5:
   |
86 |     Wallet memory _w = vm.createWallet(100);
   |     ^^^^^^

Error: 
```

Instead, in order to store the result returned by `vm.createWallet`, I had to reference the `Wallet` type through the `Vm` interface, like so:
```solidity
Vm.Wallet memory _w = vm.createWallet(100);
```