### PR TITLE
docs: fix typo in writing-tests.md

### DIFF
--- a/src/forge/writing-tests.md
+++ b/src/forge/writing-tests.md
@@ -63,7 +63,7 @@ It is possible to simulate multiple transactions in a single test, with a depend
 ```solidity
 function beforeTestSetup(
     bytes4 testSelector
-public returns (bytes[] memory beforeTestCalldata)
+) public returns (bytes[] memory beforeTestCalldata)
 ```
 
 where


### PR DESCRIPTION
closing parenthesis missing in function