### PR TITLE
Document cast wallet sign default behavior: EIP-191

### DIFF
--- a/src/reference/cast/cast-wallet-sign.md
+++ b/src/reference/cast/cast-wallet-sign.md
@@ -10,7 +10,7 @@ cast-wallet-sign - Sign a message.
 
 ### DESCRIPTION
 
-Sign a message.
+Sign a message suitable for [`eth_sign`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sign). Note that signing prefixes the message with the Ethereum Signed Message header [in accordance with EIP-191](https://eips.ethereum.org/EIPS/eip-191) unless `--no-hash` is provided.
 
 ### OPTIONS
 


### PR DESCRIPTION
Add a snippet documenting the `cast wallet sign` default behavior using EIP-191 in case readers want to know how to sign unprefixed messages using `--no-hash`