### PR TITLE
chore: start defaulting to stable

### DIFF
--- a/src/ci-cd/github-actions.md
+++ b/src/ci-cd/github-actions.md
@@ -4,7 +4,7 @@
 
 ### Example workflow
 
-```
+```yml
 on: [push]
 
 name: test
@@ -14,7 +14,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -30,12 +30,14 @@ jobs:
 
 ### Inputs
 
-| Name | Required | Default | Description | Type |
-|---|---|---|---|---|
-| cache | No | true | Whether to cache RPC responses or not. | bool |
-| version | No | nightly | Version to install, e.g. nightly or 1.8.8. Note: Foundry only has nightly builds for the time being. | string |
-| cache-key | No | `${{ github.job }}` | The cache key to use for caching. | string |
-| cache-restore-keys | No | `[${{ github.job }}]` | The cache keys to use for restoring the cache. | string[] |
+### Inputs
+
+| **Name**             | **Required** | **Default**                           | **Description**                                          | **Type** |
+| -------------------- | ------------ | ------------------------------------- | -------------------------------------------------------- | -------- |
+| `cache`              | No           | `true`                                | Whether to cache RPC responses or not.                   | bool     |
+| `version`            | No           | `stable`                              | Version to install, e.g. `stable`, `nightly` or `0.3.0`. | string   |
+| `cache-key`          | No           | `${{ github.job }}-${{ github.sha }}` | The cache key to use for caching.                        | string   |
+| `cache-restore-keys` | No           | `[${{ github.job }}-]`                | The cache keys to use for restoring the cache.           | string[] |
 
 ### RPC Caching
 
@@ -49,7 +51,7 @@ The logic of the caching is as follows:
 
 If you would like to disable the caching (e.g. because you want to implement your own caching mechanism), you can set the `cache` input to `false`, like this:
 
-```
+```yml
 - name: Install Foundry
   uses: foundry-rs/foundry-toolchain@v1
   with:
@@ -62,7 +64,7 @@ You have the ability to define custom cache keys by utilizing the `cache-key` an
 
 For instance, if you wish to utilize a shared cache between two distinct jobs, the following configuration can be applied:
 
-```
+```yml
 - name: Install Foundry
   uses: foundry-rs/foundry-toolchain@v1
   with:

--- a/src/config/continuous-integration.md
+++ b/src/config/continuous-integration.md
@@ -14,14 +14,14 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run tests
         run: forge test -vvv

--- a/src/getting-started/installation.md
+++ b/src/getting-started/installation.md
@@ -18,7 +18,7 @@ curl -L https://foundry.paradigm.xyz | bash
 
 This will install Foundryup. Simply follow the on-screen instructions, and the `foundryup` command will become available in your CLI.
 
-Running `foundryup` will automatically install the latest (nightly) versions of the [precompiled binaries](#precompiled-binaries): `forge`, `cast`, `anvil`, and `chisel`. For additional options, such as installing a specific version or commit, run `foundryup --help`.
+Running `foundryup` will automatically install the latest stable version of the [precompiled binaries](#precompiled-binaries): `forge`, `cast`, `anvil`, and `chisel`. If you wish to use the latest `nightly` build run `foundryup --install nightly`. For additional options, such as installing a specific version or commit, run `foundryup --help`.
 
 > ℹ️ **Note**  
 > If you're using Windows, you'll need to install and use [Git BASH](https://gitforwindows.org/) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) as your terminal, since Foundryup currently doesn't support Powershell or Command Prompt (Cmd).


### PR DESCRIPTION
Related: https://github.com/foundry-rs/foundry-toolchain/pull/60

For our stable release, update the Foundry toolchain documentation in the book to point to the latest stable version by default.