### PR TITLE
chore: add announcements page

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,11 +4,17 @@ Foundry is a smart contract development toolchain.
 
 Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line and via Solidity scripts.
 
+> ✨ **Announcements**
+>
+> [Catch up on the latest changes](./announcements.md) to Foundry.
+
 > 📖 **Contributing**
 >
 > You can contribute to this book on [GitHub](https://github.com/foundry-rs/book).
 
 ### Sections
+
+**[Annoucements](./announcements.md)**
 
 **[Getting Started](getting-started/installation.md)**
 

--- a/src/README.md
+++ b/src/README.md
@@ -6,15 +6,13 @@ Foundry manages your dependencies, compiles your project, runs tests, deploys, a
 
 > ✨ **Announcements**
 >
-> [Catch up on the latest changes](./announcements.md) to Foundry.
+> [Stay up to date](./announcements.md) with the latest changes to Foundry.
 
 > 📖 **Contributing**
 >
 > You can contribute to this book on [GitHub](https://github.com/foundry-rs/book).
 
 ### Sections
-
-**[Annoucements](./announcements.md)**
 
 **[Getting Started](getting-started/installation.md)**
 
@@ -72,6 +70,7 @@ Help us improve Foundry: [Contributing](./contributing.md)
 
 References, troubleshooting, and more.
 
+- [Announcements](./announcements.md)
 - [FAQ](./faq.md)
 - [CLI Reference](./reference/cli/)
 - [forge Commands](./reference/forge/)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -79,6 +79,7 @@
 
 # Appendix
 
+- [Announcements](./announcements.md)
 - [FAQ](./faq.md)
 - [Help us improve Foundry](./contributing.md)
 - [References](./reference/README.md)

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -32,13 +32,13 @@ After updating you'll be able to update to the latest version of `foundryup` by 
 
 Easily install different versions using:
 
-```
+```sh
 foundryup --install <version>
 ```
 
 e.g.
 
-```
+```sh
 foundryup --install nightly
 foundryup --install stable
 foundryup --install 0.3.0
@@ -48,13 +48,13 @@ foundryup --install 0.3.0
 
 Run
 
-```
+```sh
 foundryup --list
 ```
 
 This will output a list as follows:
 
-```
+```sh
 foundryup: nightly
 foundryup: - forge 0.3.0 (017c59d 2025-01-14T00:25:28.977200980Z)
 foundryup: - cast 0.3.0 (017c59d 2025-01-14T00:25:28.933986754Z)
@@ -78,13 +78,13 @@ foundryup: - chisel 0.3.0 (5a8bd89 2024-12-19T17:17:10.201917651Z)
 
 Easily manage your installations with:
 
-```
+```sh
 foundryup --use <version>
 ```
 
 e.g.
 
-```
+```sh
 foundryup --use nightly
 foundryup --use stable
 foundryup --use 0.3.0

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -1,0 +1,97 @@
+## Announcements
+
+Stay up to date on the latest changes to Foundry.
+
+## 🚨 Actions required
+
+Upgrade your installation of Foundryup!
+
+Run: `curl -L https://foundry.paradigm.xyz | bash`
+
+Upgrading ensures your installation defaults to updating to the **latest stable release** instead of the **latest nightly build**.
+
+If you do not upgrade you will **continue to receive nightly builds by default** which will start to contain more **significant breaking changes**.
+
+## Releases
+
+### 0.3 (stable)
+
+The Foundry [`0.3` release](https://github.com/foundry-rs/foundry/releases/tag/v0.3.0) marks an exciting new chapter for Foundry. By moving to [stable releases](https://github.com/foundry-rs/foundry/releases/tag/stable), we aim to provide a reliable development environment for the EVM ecosystem. Our next priority is the `1.0` release in early 2025, polishing Foundry for the long term.
+
+Big shoutout to the Foundry community - your bug reports, feature requests and contributions have shaped what Foundry is today.
+
+## FAQ
+
+#### How do I update `foundryup`?
+
+Run: `curl -L https://foundry.paradigm.xyz | bash`
+
+After updating you'll be able to update to the latest version of `foundryup` by running `foundryup --update`.
+
+#### How do I install multiple versions?
+
+Easily install different versions using:
+
+```
+foundryup --install <version>
+```
+
+e.g.
+
+```
+foundryup --install nightly
+foundryup --install stable
+foundryup --install 0.3.0
+```
+
+#### How do I know the versions I have installed?
+
+Run
+
+```
+foundryup --list
+```
+
+This will output a list as follows:
+
+```
+foundryup: nightly
+foundryup: - forge 0.3.0 (017c59d 2025-01-14T00:25:28.977200980Z)
+foundryup: - cast 0.3.0 (017c59d 2025-01-14T00:25:28.933986754Z)
+foundryup: - anvil 0.3.0 (017c59d 2025-01-14T00:25:29.065516554Z)
+foundryup: - chisel 0.3.0 (017c59d 2025-01-14T00:25:29.021147876Z)
+
+foundryup: stable
+foundryup: - forge 0.3.0 (5a8bd89 2024-12-20T08:46:21.555250780Z)
+foundryup: - cast 0.3.0 (5a8bd89 2024-12-20T08:46:21.564365462Z)
+foundryup: - anvil 0.3.0 (5a8bd89 2024-12-20T08:46:21.565569027Z)
+foundryup: - chisel 0.3.0 (5a8bd89 2024-12-20T08:46:21.536871477Z)
+
+foundryup: v0.3.0
+foundryup: - forge 0.3.0 (5a8bd89 2024-12-19T17:17:10.245193696Z)
+foundryup: - cast 0.3.0 (5a8bd89 2024-12-19T17:17:10.252265834Z)
+foundryup: - anvil 0.3.0 (5a8bd89 2024-12-19T17:17:10.248488022Z)
+foundryup: - chisel 0.3.0 (5a8bd89 2024-12-19T17:17:10.201917651Z)
+```
+
+#### How do I switch between versions?
+
+Easily manage your installations with:
+
+```
+foundryup --use <version>
+```
+
+e.g.
+
+```
+foundryup --use nightly
+foundryup --use stable
+foundryup --use 0.3.0
+```
+
+#### I prefer using nightly builds.
+
+You are still able to receive the latest nightly builds by running `foundryup --install nightly`
+
+**Be cautious — nightly builds may include breaking changes that are difficult to debug without context.**

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -1,6 +1,6 @@
 ## Announcements
 
-Stay up to date on the latest changes to Foundry.
+Stay up to date with the latest changes to Foundry.
 
 ## 🚨 Actions required
 

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -36,6 +36,8 @@ foundryup --update
 
 by running `foundryup --update`.
 
+The latest version of `foundryup` is `0.3.0`.
+
 #### How do I install multiple versions?
 
 Easily install different versions using:

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -34,13 +34,11 @@ Run: `curl -L https://foundry.paradigm.xyz | bash`
 
 As a security best practice it is recommended you manually follow the [redirect](https://foundry.paradigm.xyz), inspect the [installer](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/install) you are about to run and the new version of [`foundryup`](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup) you are about to install.
 
-After the initial update you'll be able to update to the latest version of `foundryup` using:
+After the initial update you'll be able to update to the latest version of `foundryup` by running:
 
 ```sh
 foundryup --update
 ```
-
-by running `foundryup --update`.
 
 #### How do I install multiple versions?
 
@@ -58,7 +56,7 @@ foundryup --install stable
 foundryup --install 0.3.0
 ```
 
-#### How do I know the versions I have installed?
+#### How do I know which versions I have installed?
 
 Run
 

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -22,6 +22,12 @@ Big shoutout to the Foundry community - your bug reports, feature requests and c
 
 ## FAQ
 
+#### How do I know which version I have installed?
+
+The latest version of `foundryup` is `0.3.0`.
+
+If you run `foundryup --version` and it does not return this you are not up to date.
+
 #### How do I update `foundryup`?
 
 Run: `curl -L https://foundry.paradigm.xyz | bash`
@@ -35,8 +41,6 @@ foundryup --update
 ```
 
 by running `foundryup --update`.
-
-The latest version of `foundryup` is `0.3.0`.
 
 #### How do I install multiple versions?
 

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -26,7 +26,7 @@ Big shoutout to the Foundry community - your bug reports, feature requests and c
 
 The latest version of `foundryup` is `0.3.0`.
 
-If you run `foundryup --version` and it does not return this you are not up to date.
+If you run `foundryup --version` and it does not return this or returns an error you are not up to date.
 
 #### How do I update `foundryup`?
 

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -4,7 +4,7 @@ Stay up to date with the latest changes to Foundry.
 
 ## 🚨 Actions required
 
-Upgrade your installation of Foundryup!
+Upgrade your installation of `foundryup`!
 
 Run: `curl -L https://foundry.paradigm.xyz | bash`
 
@@ -26,7 +26,15 @@ Big shoutout to the Foundry community - your bug reports, feature requests and c
 
 Run: `curl -L https://foundry.paradigm.xyz | bash`
 
-After updating you'll be able to update to the latest version of `foundryup` by running `foundryup --update`.
+As a security best practice it is recommended you manually follow the [redirect](https://foundry.paradigm.xyz), inspect the [installer](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/install) you are about to run and the new version of [`foundryup`](https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/foundryup) you are about to install.
+
+After the initial update you'll be able to update to the latest version of `foundryup` using:
+
+```sh
+foundryup --update
+```
+
+by running `foundryup --update`.
 
 #### How do I install multiple versions?
 

--- a/src/announcements.md
+++ b/src/announcements.md
@@ -90,8 +90,30 @@ foundryup --use stable
 foundryup --use 0.3.0
 ```
 
+#### How do I configure `foundry-toolchain`?
+
+The `foundry-toolchain` GitHub Action will use the latest `stable` release by default.
+
+If you would prefer to use a different release you can set the `version` key:
+
+```yml
+- name: Install Foundry
+  uses: foundry-rs/foundry-toolchain@v1
+  with:
+    version: <version>
+```
+
+e.g.
+
+```yml
+- name: Install Foundry
+  uses: foundry-rs/foundry-toolchain@v1
+  with:
+    version: nightly
+```
+
 #### I prefer using nightly builds.
 
-You are still able to receive the latest nightly builds by running `foundryup --install nightly`
+You are still able to receive the latest `nightly` builds by running `foundryup --install nightly`
 
 **Be cautious — nightly builds may include breaking changes that are difficult to debug without context.**


### PR DESCRIPTION
Adds announcement page with instructions to update to the latest version of `foundryup`, linking to it from the book index