### PR TITLE
chore: bump version of `foundryup`

### DIFF
--- a/src/announcements.md
+++ b/src/announcements.md
@@ -24,7 +24,7 @@ Big shoutout to the Foundry community - your bug reports, feature requests and c
 
 #### How do I know which version I have installed?
 
-The latest version of `foundryup` is `0.3.0`.
+The latest version of `foundryup` is `0.3.1`.
 
 If you run `foundryup --version` and it does not return this or returns an error you are not up to date.
 


### PR DESCRIPTION
Update in `foundryup` to use `-V` instead of `--version` to get short version

Related: https://github.com/foundry-rs/foundry/pull/9728

