### PR TITLE
chore: add note on setting `evm_version` if you are experimenting with future hardfork content (e.g. `EIP-7702`)

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -171,6 +171,12 @@ If you are relying on a specific EVM version for compatibility reasons you are r
 evm_version = "paris"
 ```
 
+If you are experimenting with future hardforks that Foundry already supports, such as [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) to be added in `Prague`, you should set your `evm_version` as follows:
+
+```toml
+evm_version = "prague"
+```
+
 ##### `revert_strings`
 
 - Type: string


### PR DESCRIPTION
Easy to forget having to set your `evm_version`, this note should help