### PR TITLE
fix: use release candidate version for update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: rc
 
       - uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Update


### PR DESCRIPTION
Prevents the undo-ing of breaking changes that are not yet in stable but need to be documented e.g. https://github.com/foundry-rs/book/pull/1418

This is in lieu of setting up two or three different versions of the book, the release candidate version seems to be appropriate to use here