### PR TITLE
fix: remove unused and deprecated `testFail*` tests for update workflow to pass

### DIFF
--- a/scripts/gen_output/forge.sh
+++ b/scripts/gen_output/forge.sh
@@ -55,12 +55,6 @@ gen_forge() {
   run_command "$OUTPUT_DIR/cheatcodes/forge-test-simple" \
     forge test --match-test test_IncrementAsOwner
 
-  run_command "$OUTPUT_DIR/cheatcodes/forge-test-cheatcodes" \
-    forge test --match-test "test_IncrementAsOwner|testFail_IncrementAsNotOwner" --match-path test/OwnerUpOnly.t.sol
-
-  run_command "$OUTPUT_DIR/cheatcodes/forge-test-cheatcodes-tracing" \
-    forge test -vvvv --match-test testFail_IncrementAsNotOwner --match-path test/OwnerUpOnly.t.sol
-
   run_command "$OUTPUT_DIR/cheatcodes/forge-test-cheatcodes-expectrevert" \
     forge test --match-test "test_IncrementAsOwner|test_IncrementAsNotOwner" --match-path test/OwnerUpOnly.t.sol
 


### PR DESCRIPTION
Related: https://github.com/foundry-rs/book/pull/1420

No content related changes, required for re-running update workflow resulting from https://github.com/foundry-rs/book/pull/1419