### PR TITLE
fix: add valid link in solidity compiler extra_output reference

### DIFF
--- a/src/reference/config/solidity-compiler.md
+++ b/src/reference/config/solidity-compiler.md
@@ -225,7 +225,7 @@ extra_output = [
 ]
 ```
 
-For a list of valid values, see the [Solidity docs][output-desc].
+For a list of valid values, see the [Solidity docs](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description) (search for: _The available output types are as follows_).
 
 ##### `bytecode_hash`
 


### PR DESCRIPTION
The link in [extra_output](https://book.getfoundry.sh/reference/config/solidity-compiler#extra_output) is invalid and it doesn't help finding anything in the Solidity docs.

I've changed the link to the correct place and included a remark to help people find the available options.