### PR TITLE
chore: document `cast send --auth` and `cast wallet sign-auth` (EIP-7702)

### DIFF
--- a/src/reference/cast/cast-send.md
+++ b/src/reference/cast/cast-send.md
@@ -6,13 +6,13 @@ cast-send - Sign and publish a transaction.
 
 ### SYNOPSIS
 
-``cast send`` [*options*] *to* [*sig*] [*args...*]
+`cast send` [*options*] _to_ [*sig*] [*args...*]
 
 ### DESCRIPTION
 
 Sign and publish a transaction.
 
-The destination (*to*) can be an ENS name or an address.
+The destination (_to_) can be an ENS name or an address.
 
 {{#include sig-description.md}}
 
@@ -23,8 +23,18 @@ The destination (*to*) can be an ENS name or an address.
 `--resend`  
 &nbsp;&nbsp;&nbsp;&nbsp;Reuse the latest nonce of the sending account.
 
-`--create` *code* [*sig* *args...*]  
-&nbsp;&nbsp;&nbsp;&nbsp;Deploy a contract by specifying raw bytecode, in place of specifying a *to* address.
+`--create` _code_ [*sig* *args...*]  
+&nbsp;&nbsp;&nbsp;&nbsp;Deploy a contract by specifying raw bytecode, in place of specifying a _to_ address.
+
+`--auth` _auth_  
+&nbsp;&nbsp;&nbsp;&nbsp;EIP-7702 authorization list.
+
+&nbsp;&nbsp;&nbsp;&nbsp;Can be either a hex-encoded signed authorization or an address.
+
+`--access-list` _access_list_  
+&nbsp;&nbsp;&nbsp;&nbsp;EIP-2930 access list.
+
+&nbsp;&nbsp;&nbsp;&nbsp;Accepts either a JSON-encoded access list or an empty value to create the access list via an RPC call to `eth_createAccessList`. To retrieve only the access list portion, use the `cast access-list` command.
 
 #### Receipt Options
 
@@ -33,8 +43,8 @@ The destination (*to*) can be an ENS name or an address.
 &nbsp;&nbsp;&nbsp;&nbsp;Do not wait for the transaction receipt if it does not exist yet.  
 &nbsp;&nbsp;&nbsp;&nbsp;Environment: `CAST_ASYNC`
 
-`-c` *confirmations*  
-`--confirmations` *confirmations*  
+`-c` _confirmations_  
+`--confirmations` _confirmations_  
 &nbsp;&nbsp;&nbsp;&nbsp;Wait a number of confirmations before exiting. Default: `1`.
 
 {{#include ../common/wallet-options.md}}
@@ -53,48 +63,51 @@ The destination (*to*) can be an ENS name or an address.
 ### EXAMPLES
 
 1. Send some ether to Vitalik using your Ledger:
-    ```sh
-    cast send --ledger vitalik.eth --value 0.1ether
-    ```
+
+   ```sh
+   cast send --ledger vitalik.eth --value 0.1ether
+   ```
 
 2. Call `deposit(address token, uint256 amount)` on a contract:
-    ```sh
-    cast send --ledger 0x... "deposit(address,uint256)" 0x... 1
-    ```
+
+   ```sh
+   cast send --ledger 0x... "deposit(address,uint256)" 0x... 1
+   ```
 
 3. Call a function that expects a `struct`:
 
-    ```solidity
-    contract Test {
-        struct MyStruct {
-            address addr;
-            uint256 amount;
-        }
-        function myfunction(MyStruct memory t) public pure {}
-    }
-    ```
+   ```solidity
+   contract Test {
+       struct MyStruct {
+           address addr;
+           uint256 amount;
+       }
+       function myfunction(MyStruct memory t) public pure {}
+   }
+   ```
 
-    Structs are encoded as tuples (see [struct encoding](../../misc/struct-encoding.md))
+   Structs are encoded as tuples (see [struct encoding](../../misc/struct-encoding.md))
 
-    ```sh
-    cast send 0x... "myfunction((address,uint256))" "(0x...,1)"
-    ```
+   ```sh
+   cast send 0x... "myfunction((address,uint256))" "(0x...,1)"
+   ```
 
 4. Send a transaction with hex data in the `input` field of the transaction object:
-    ```sh
-    cast send 0x... 0x68656c6c6f20776f726c64
-    ```
+
+   ```sh
+   cast send 0x... 0x68656c6c6f20776f726c64
+   ```
 
 5. Sign an EIP-7702 authorization and attach it to a transaction from a different sender:
-    ```sh
-    cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
-    ```
+
+   ```sh
+   cast send $(cast az) --private-key <sender-pk> --auth $(cast wallet sign-auth <address> --private-key <delegator-pk>)
+   ```
 
 6. Send an EIP-7702 transaction delegating the sender to `<address>`:
-    ```sh
-    cast send $(cast az) --auth <address>
-    ```
-
+   ```sh
+   cast send $(cast az) --auth <address>
+   ```
 
 ### SEE ALSO
 

--- a/src/reference/cast/cast-wallet-sign-auth.md
+++ b/src/reference/cast/cast-wallet-sign-auth.md
@@ -1,0 +1,44 @@
+## cast wallet sign-auth
+
+### NAME
+
+cast-wallet-sign-auth - Sign an EIP-7702 authorization.
+
+### SYNOPSIS
+
+`cast wallet sign-auth` _address_
+
+### DESCRIPTION
+
+Sign an [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) authorization for an address.
+
+Note that `sign-auth` uses the current nonce as it is not aware of whether you are going to broadcast the authorization from the same or a different sender.
+
+If you are sending the transaction from the same address you will need to either pass the next nonce using the `--nonce` flag or alternatively use `cast send <to> --auth <address>` to sign and send directly.
+
+### OPTIONS
+
+{{#include ../common/wallet-options-raw.md}}
+
+{{#include ../common/wallet-options-keystore.md}}
+
+{{#include ../common/wallet-options-hardware.md}}
+
+{{#include common-options.md}}
+
+### EXAMPLES
+
+1. Sign an EIP-7702 authorization using a keystore:
+
+   ```sh
+   cast wallet sign-auth 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keystore keystore.json --interactive
+   ```
+
+2. Sign an EIP-7702 authorization using a raw private key:
+   ```sh
+   cast wallet sign-auth 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --private-key $PRIV_KEY
+   ```
+
+### SEE ALSO
+
+[cast](./cast.md), [cast wallet](./cast-wallet.md)


### PR DESCRIPTION
Closes: https://github.com/foundry-rs/book/issues/1440

Looks like the references have gotten a bit incomplete, will look into how we can more easily automate this.

Added the note on nonce management when using `sign-auth` when intending to send with the same signer