### PR TITLE
fix(typo): `vm.eth` -> `vm.etch`

### DIFF
--- a/src/cheatcodes/get-code.md
+++ b/src/cheatcodes/get-code.md
@@ -63,7 +63,7 @@ vm.getCode("MyContract:0.8.18");
 ### SEE ALSO
 
 [`getDeployedCode`](./get-deployed-code.md)
-[`eth`](./etch.md)
+[`etch`](./etch.md)
 
 Forge Standard Library
 


### PR DESCRIPTION
In `get-code.md`, the `See Also` points to the hyperlink `eth` instead of `etch`.