### PR TITLE
Additional compilers docs

### DIFF
--- a/src/guides/v1.0-migration.md
+++ b/src/guides/v1.0-migration.md
@@ -21,6 +21,10 @@ optimizer = true
 optimizer_runs = 200
 ```
 
+> ℹ️ **Note**
+> 
+> Projects using additional compiler profiles with optimizer runs but without explicitly enable optimizer could fail to build with `Missing profile satisfying settings restrictions` message.
+
 See: [optimizer configuration](../reference/config/solidity-compiler.md#optimizer)
 
 ### Expect revert cheatcode disabled on internal calls by default
@@ -116,7 +120,12 @@ should be rewritten as
 ```solidity
 console.log("testMisc", uint256(42));
 console.log(uint256(0));
+console.logUint(0);
 ```
+
+> ℹ️ **Note**
+> 
+> Latest `forge-std` version should be used in order to use the newly signatures for console logging and avoid unexpected behaviour.
 
 ### Conflicting remappings are ignored
 


### PR DESCRIPTION
- add additional compilers docs
- update v1.0 migration guide to point to missing `optimizer` and additional compilers usage
- update v1.0 migration guide to warn re usage of new console.log with older signatures / need to update forge-std