### PR TITLE
fix: unpin from `rc`, pin to `nightly` in `update` workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: rc
+          version: nightly
 
       - uses: dtolnay/rust-toolchain@nightly
 


### PR DESCRIPTION
Required for getting the latest references / updates

Related: https://github.com/foundry-rs/book/issues/1446

Related failure: https://github.com/foundry-rs/book/actions/runs/13457286809