### PR TITLE
chore: add note on gas snapshots being inaccurate outside of isolated test mode

### DIFF
--- a/src/cheatcodes/gas-snapshots.md
+++ b/src/cheatcodes/gas-snapshots.md
@@ -58,6 +58,15 @@ To disable the emitting of gas snapshots you can set one of the following:
 
 By default this is **enabled** and gas snapshots are written to disk.
 
+> ℹ️ **Isolated tests**
+>
+> These cheatcodss are not accurate if not using isolated test mode.
+>
+> You can enable isolation mode by passing the `--isolate` flag or
+> tag the test function with the inline configuration:
+>
+> `/// forge-config: default.isolate = true`
+
 ### Examples
 
 Capturing the gas usage of a section of code that calls an external contract:

--- a/src/cheatcodes/gas-snapshots.md
+++ b/src/cheatcodes/gas-snapshots.md
@@ -60,10 +60,10 @@ By default this is **enabled** and gas snapshots are written to disk.
 
 > ℹ️ **Isolated tests**
 >
-> These cheatcodss are not accurate if not using isolated test mode.
+> These cheatcodes are not accurate if not using isolated test mode.
 >
 > You can enable isolation mode by passing the `--isolate` flag or
-> tag the test function with the inline configuration:
+> tag the test function with the following inline configuration:
 >
 > `/// forge-config: default.isolate = true`
 


### PR DESCRIPTION
As a placeholder pending this implementation: https://github.com/foundry-rs/foundry/issues/9912