### PR TITLE
docs: update forge inspect documentation

### DIFF
--- a/src/reference/forge/forge-inspect.md
+++ b/src/reference/forge/forge-inspect.md
@@ -33,8 +33,8 @@ The field to inspect (*field*) can be any of:
 
 ### OPTIONS
 
-`--pretty`  
-&nbsp;&nbsp;&nbsp;&nbsp;Pretty print the selected field, if supported.
+`--json`  
+&nbsp;&nbsp;&nbsp;&nbsp;Format output as JSON.
 
 {{#include core-build-options.md}}
 
@@ -52,9 +52,9 @@ The field to inspect (*field*) can be any of:
     forge inspect MyContract storage
     ```
 
-3. Inspect the abi of a contract in a pretty format:
+3. Inspect the abi of a contract in JSON format:
    ```sh
-   forge inspect --pretty MyContract abi
+   forge inspect --json MyContract abi
    ```
 
 ### SEE ALSO


### PR DESCRIPTION
Remove --pretty flag which no longer exists and add --json flag to the forge inspect documentation.

The --pretty flag was removed in Foundry v1.0 as mentioned in the migration guide.
Updated the example to use --json instead of --pretty.

Fixes #1443