### PR TITLE
 Fix incorrect return variable in getBlockNumber documentation

### DIFF
--- a/src/cheatcodes/get-block-number.md
+++ b/src/cheatcodes/get-block-number.md
@@ -3,7 +3,7 @@
 ### Signature
 
 ```solidity
-function getBlockNumber() external view returns (uint256 timestamp);
+function getBlockNumber() external view returns (uint256 blockNumber);
 ```
 
 ### Description


### PR DESCRIPTION
Fixed return variable name:

Old: returns (uint256 timestamp);
New: returns (uint256 blockNumber);
Reason: Function returns block.number, not a timestamp.