### PR TITLE
Grammar Fixes

### DIFF
--- a/src/cheatcodes/expect-emit.md
+++ b/src/cheatcodes/expect-emit.md
@@ -31,7 +31,7 @@ function expectEmit(
 
 ### Description
 
-Assert a specific log is emitted during the next call.
+Asserts that a specific log is emitted during the next call.
 
 1. Call the cheat code, specifying whether we should check the first, second or third topic, and the log data (`expectEmit()` checks them all). Topic 0 is always checked.
 2. Emit the event we are supposed to see during the next call.

--- a/src/cheatcodes/get-block-timestamp.md
+++ b/src/cheatcodes/get-block-timestamp.md
@@ -8,7 +8,7 @@ function getBlockTimestamp() external view returns (uint256 timestamp);
 
 ### Description
 
-Gets the current `block.timestamp`. This is useful in cases where `vm.warp` along with `--via-ir` compilation is used, as `block.timestamp` is assumed to be a constant during a transaction. This means that on every forge test, multiple calls to `block.timestamp` would get optimized to just returning a constant value, instead of actually accessing the current `block.timestamp`. `vm.getBlockTimestamp()` avoids this optimization and returns the current `block.timestamp`.
+Gets the current `block.timestamp`. This is useful in cases where `vm.warp` along with `--via-ir` compilation is used, as `block.timestamp` is assumed to be a constant during a transaction. This means that in every forge test, multiple calls to `block.timestamp` would get optimized to just returning a constant value, instead of actually accessing the current `block.timestamp`. `vm.getBlockTimestamp()` avoids this optimization and returns the current `block.timestamp`.
 
 ### Examples
 


### PR DESCRIPTION
expectEmit.md
Fixed: "Assert" → "Asserts that" (grammar fix, correct verb form).


get-block-timestamp.md
Fixed: "on every forge test" → "in every forge test" (correct preposition ).