### PR TITLE
It's `fs_permissions` not, `fs_permission`

### DIFF
--- a/src/cheatcodes/fs.md
+++ b/src/cheatcodes/fs.md
@@ -48,7 +48,7 @@ function isDir(string calldata) external returns (bool);
 
 These cheatcodes provided by [forge-std](https://github.com/foundry-rs/forge-std) can be used for filesystem manipulation operations.
 
-By default, filesystem access is disallowed and requires the `fs_permission` setting in `foundry.toml`:
+By default, filesystem access is disallowed and requires the `fs_permissions` setting in `foundry.toml`:
 
 ```toml
 # Configures permissions for cheatcodes that touch the filesystem like `vm.writeFile`


### PR DESCRIPTION
Be me. Spend 30 minutes trying to figure out why I couldn't get permissions to write a csv file, when I had copied the config name out of the docs. It's `fs_permissions` not, `fs_permission`.

Fix the docs, for those who follow after.