### PR TITLE
Update README.md to include no-request-size-limit flag

### DIFF
--- a/src/reference/anvil/README.md
+++ b/src/reference/anvil/README.md
@@ -430,6 +430,9 @@ Gets the transaction hash and the address which created a contract.
 `--prune-history`
 &nbsp;&nbsp;&nbsp;&nbsp; Don't keep full chain history.
 
+`--no-request-size-limit`
+&nbsp;&nbsp;&nbsp;&nbsp; Disable the request size limit. Default is 2MB
+
 ### EXAMPLES
 
 1. Set the number of accounts to 15 and their balance to 300 ETH


### PR DESCRIPTION
The no-request-size-limit is very useful when dumping and loading large anvil state. A state dump from replaying all transactions from block 24363415 on top of the previous block is about 5MB which causes anvil to reject loading the state. Had to dig through the source code to find this so it might be helpful to other people who come across a similar issue