### PR TITLE
Update config link in foundry.toml to point to official repository

### DIFF
--- a/projects/cheatcodes/foundry.toml
+++ b/projects/cheatcodes/foundry.toml
@@ -3,4 +3,4 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 
-# See more config options https://github.com/gakonst/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
Old:
https://github.com/gakonst/foundry/tree/master/config

New:
https://github.com/foundry-rs/foundry/tree/master/crates/config

Reason for the change:
The original link pointed to gakonst/foundry, which is outdated or deprecated.
The new link redirects users to the canonical and actively maintained foundry-rs repository, improving accuracy and consistency in documentation.

