### PR TITLE
Remove `--no-commit`, add `--commit`

### DIFF
--- a/src/reference/forge/forge-clone.md
+++ b/src/reference/forge/forge-clone.md
@@ -2,7 +2,7 @@
 
 ### NAME
 
-forge-clone - Clone a on-chain verified contract as a Forge project.
+forge-clone - Clone an on-chain verified contract as a Forge project.
 
 ### SYNOPSIS
 

--- a/src/reference/forge/forge-clone.md
+++ b/src/reference/forge/forge-clone.md
@@ -18,7 +18,7 @@ Obtaining data from Etherscan is subject to rate limit. `forge clone` requires t
 
 Specifying Etherscan API key via `--etherscan-api-key <API_KEY>` will increase Etherscan API rate limit and avoid the *5-second* wait time in `forge clone`.
 
-Just as `forge init`, `forge clone` will by default initialize a new git repository, install some submodules and create an initial commit message.
+Just as `forge init`, `forge clone` will by default initialize a new git repository and install some submodules.
 
 If you do not want this behavior, pass `--no-git`.
 
@@ -39,8 +39,8 @@ If you do not want this behavior, pass `--no-git`.
 
 #### VCS Options
 
-`--no-commit`  
-&nbsp;&nbsp;&nbsp;&nbsp;Do not create an initial commit.
+`--commit`  
+&nbsp;&nbsp;&nbsp;&nbsp;Create an initial commit.
 
 `--no-git`  
 &nbsp;&nbsp;&nbsp;&nbsp;Do not create a git repository.

--- a/src/reference/forge/forge-init.md
+++ b/src/reference/forge/forge-init.md
@@ -20,7 +20,7 @@ The default template creates the following project layout:
 
 However, it is possible to create a project from another using `--template`.
 
-By default, `forge init` will also initialize a new git repository, install some submodules and create an initial commit message.
+By default, `forge init` will also initialize a new git repository and install some submodules.
 
 If you do not want this behavior, pass `--no-git`.
 
@@ -43,8 +43,8 @@ If you do not want this behavior, pass `--no-git`.
 
 #### VCS Options
 
-`--no-commit`  
-&nbsp;&nbsp;&nbsp;&nbsp;Do not create an initial commit.
+`--commit`  
+&nbsp;&nbsp;&nbsp;&nbsp;Create an initial commit.
 
 `--no-git`  
 &nbsp;&nbsp;&nbsp;&nbsp;Do not create a git repository.

--- a/src/reference/forge/forge-install.md
+++ b/src/reference/forge/forge-install.md
@@ -40,7 +40,7 @@ the repository. If you want to change the name of the folder, prepend `<folder>=
 #### VCS Options
 
 `--commit`  
-&nbsp;&nbsp;&nbsp;&nbsp;Create a commit.
+&nbsp;&nbsp;&nbsp;&nbsp;Create a commit after installing the dependencies.
 
 `--no-git`  
 &nbsp;&nbsp;&nbsp;&nbsp;Install without adding the dependency as a submodule.

--- a/src/reference/forge/forge-install.md
+++ b/src/reference/forge/forge-install.md
@@ -39,8 +39,8 @@ the repository. If you want to change the name of the folder, prepend `<folder>=
 
 #### VCS Options
 
-`--no-commit`  
-&nbsp;&nbsp;&nbsp;&nbsp;Do not create a commit.
+`--commit`  
+&nbsp;&nbsp;&nbsp;&nbsp;Create a commit.
 
 `--no-git`  
 &nbsp;&nbsp;&nbsp;&nbsp;Install without adding the dependency as a submodule.


### PR DESCRIPTION
Forge v1.1.0 with https://github.com/foundry-rs/foundry/pull/9884 removed the option for `--no-commit` and added an option for `--commit`

This PR updates the corresponding pages according to the new behavior.