### PR TITLE
chore: switch to evm_version `prague` by default

### DIFF
--- a/vocs/docs/pages/anvil/reference.md
+++ b/vocs/docs/pages/anvil/reference.md
@@ -329,7 +329,7 @@ Gets the transaction hash and the address which created a contract.
 &nbsp;&nbsp;&nbsp;&nbsp; Print help information.
 
 `--hardfork <HARDFORK>`
-&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use e.g. `shanghai`, `paris`, `london`, etc... [default: latest]
+&nbsp;&nbsp;&nbsp;&nbsp; Choose the EVM hardfork to use e.g. `prague`, `cancun`, `shanghai`, `paris`, `london`, etc... [default: latest]
 
 `--init <PATH>`
 &nbsp;&nbsp;&nbsp;&nbsp; Initialize the genesis block with the given `genesis.json` file.

--- a/vocs/docs/pages/config/reference/solidity-compiler.mdx
+++ b/vocs/docs/pages/config/reference/solidity-compiler.mdx
@@ -161,7 +161,7 @@ If enabled, Foundry will treat Solidity compiler warnings as errors, stopping ar
 ##### `evm_version`
 
 - Type: string
-- Default: cancun
+- Default: prague
 - Environment: `FOUNDRY_EVM_VERSION` or `DAPP_EVM_VERSION`
 
 The EVM version to use during tests. The value **must** be an EVM hardfork name, such as `london`, `byzantium`, etc.
@@ -170,12 +170,6 @@ If you are relying on a specific EVM version for compatibility reasons you are r
 
 ```toml
 evm_version = "paris"
-```
-
-If you are experimenting with future hardforks that Foundry already supports, such as [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md) to be added in `Prague`, you should set your `evm_version` as follows:
-
-```toml
-evm_version = "prague"
 ```
 
 ##### `revert_strings`
@@ -521,7 +515,7 @@ Additional compiler profile [via_ir](#via_ir) setting.
 ##### `additional_compiler_profile.evm_version`
 
 - Type: string
-- Default: cancun
+- Default: prague
 
 Additional compiler profile [evm_version](#evm_version) setting.
 

--- a/vocs/docs/pages/forge/tests/fork-testing.md
+++ b/vocs/docs/pages/forge/tests/fork-testing.md
@@ -230,7 +230,7 @@ Proper configuration is needed to execute forked tests with chains using differe
 - if same EVM version applies for all forked chains used, then it can be globally configured in `foundry.toml` file
 
 ```toml
-evm_version = "cancun"
+evm_version = "prague"
 ```
 
 - if different EVM versions are used, specific EVM test version can be set using inline configuration

--- a/vocs/docs/pages/guides/deterministic-deployments-using-create2.md
+++ b/vocs/docs/pages/guides/deterministic-deployments-using-create2.md
@@ -26,8 +26,8 @@ In order to reliably deploy to deterministic addresses we will need to make sure
 
 ```toml
 [profile.default]
-solc = "0.8.28"
-evm_version = "cancun"
+solc = "<SOLC_VERSION>"
+evm_version = "<EVM_VERSION>"
 bytecode_hash = "none"
 cbor_metadata = false
 ```


### PR DESCRIPTION
Upstream PR: https://github.com/foundry-rs/foundry/issues/10564

Previous PR: https://github.com/foundry-rs/book/pull/1517 (closed due to large diff after `vocs`)

