### PR TITLE
fix: redo getting-started, mv guides up, one-liners in quick actions

### DIFF
--- a/vocs/docs/pages/anvil/overview.md
+++ b/vocs/docs/pages/anvil/overview.md
@@ -13,6 +13,9 @@ Let's fork Ethereum mainnet at the latest block:
 
 ```bash
 anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+```
+
+```bash
 
 
                              _   _

--- a/vocs/docs/pages/guides/best-practices.md
+++ b/vocs/docs/pages/guides/best-practices.md
@@ -1,8 +1,5 @@
 # Best Practices
 
-This guide documents the suggested best practices when developing with Foundry.
-In general, it's recommended to handle as much as possible with [`forge fmt`](/config/reference/formatter), and anything this doesn't handle is below.
-
 ## General Contract Guidance
 
 1. Always use named import syntax, don't import full files. This restricts what is being imported to just the named items, not everything in the file. Importing full files can result in solc complaining about duplicate definitions and slither erroring, especially as repos grow and have more dependencies with overlapping names.

--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -129,6 +129,8 @@ import { HomePage, Sponsors } from "vocs/components";
 
 ## Forge
 
+[`forge`](/forge/overview) helps you build, test, debug, deploy and verify smart contracts.
+
 :::code-group
 
 ```bash [Initialize forge project]
@@ -161,6 +163,8 @@ forge clone 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
 ## Anvil
 
+[`anvil`](/anvil/overview) is your local development node that complies with the [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc) spec.
+
 :::code-group
 
 ```bash [Start a local node]
@@ -181,6 +185,8 @@ anvil --state ./path/to/state-file
 :::
 
 ## Cast
+
+[`cast`](/cast/overview) is your swiss army knife for interacting with onchain applications from the command line.
 
 :::code-group
 

--- a/vocs/docs/pages/introduction/getting-started.mdx
+++ b/vocs/docs/pages/introduction/getting-started.mdx
@@ -1,42 +1,163 @@
 ## Getting Started
 
-This section introduces the `forge` command-line tool. We will walk through creating a new project, compiling it, and running tests.
+Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust. It consists of four essential tools that suffice all the needs a blockchain app developer will ever have.
 
-### Start a new project
+Here's an overview of the tools available at your disposal after [running foundryup](/introduction/installation#using-foundryup):
 
-To start a new project with Foundry, use the [`forge init`](/forge/reference/forge-init) command:
-
-```sh
-// [!include ~/snippets/output/hello_foundry/forge-init:command]
-```
-
-Now, let’s explore the structure that `forge` has generated for us:
-
-```sh
-cd hello_foundry
-```
-
-```sh
-// [!include ~/snippets/output/hello_foundry/tree:all]
-
-```
-
-### Build the project
-
-You can compile the project using [`forge build`](/forge/reference/forge-build):
-
-```sh
-// [!include ~/snippets/output/hello_foundry/forge-build:all]
-```
-
-### Run the tests
-
-To run the tests, use the [`forge test`](/forge/reference/forge-test) command:
-
-```sh
-// [!include ~/snippets/output/hello_foundry/forge-test:all]
-```
+| Tool                             | What it enables                                                     |
+| -------------------------------- | ------------------------------------------------------------------- |
+| **[`forge`](/forge/overview)**   | Build, test, debug, deploy and verify smart contracts               |
+| **[`anvil`](/anvil/overview)**   | Run a local Ethereum development node with forking capabilities     |
+| **[`cast`](/cast/overview)**     | Interact with contracts, send transactions, and retrieve chain data |
+| **[`chisel`](/chisel/overview)** | Fast Solidity REPL for rapid prototyping and debugging              |
 
 :::tip
 You can always view detailed help for any command or subcommand by appending `--help` to it.
 :::
+
+---
+
+### Forge
+
+Forge is a command-line tool for building, testing, and deploying smart contracts.
+
+#### Initialize a new project
+
+```bash
+# Create a new project called Counter
+forge init Counter
+cd Counter
+```
+
+#### Build and test contracts
+
+```bash
+# Compile your contracts
+forge build
+
+# Run your test suite
+forge test
+
+# Run tests against live chain state by forking
+forge test --fork-url https://reth-ethereum.ithaca.xyz/rpc
+```
+
+#### Deploy contracts
+
+```bash
+# Use forge scripts to deploy contracts
+# Set your private key
+export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+# Deploy to local anvil instance
+forge script script/Counter.s.sol --rpc-url http://127.0.0.1:8545 --broadcast --private-key $PRIVATE_KEY
+```
+
+`forge` also enables more advanced workflows such as:
+
+- [Fuzz testing](/forge/advanced-testing/fuzz-testing) - Property-based testing with randomized inputs
+- [Invariant testing](/forge/advanced-testing/invariant-testing) - Test system-wide properties across function call sequences
+- [Gas tracking](/forge/gas-tracking/overview) - Monitor and optimize gas consumption across your contracts
+- [Coverage reports](/forge/reference/forge-coverage) - Generate detailed test coverage analysis with `forge coverage`
+
+Learn more about `forge` [here](/forge/overview).
+
+---
+
+### Anvil
+
+Anvil is a fast local Ethereum development node that is perfect for testing your contracts and other blockchain workflows in a controlled environment.
+
+#### Start a local development node
+
+```bash
+# Start anvil with 10 pre-funded accounts
+anvil
+```
+
+#### Fork mainnet state
+
+```bash
+# Fork latest mainnet state for testing
+anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+```
+
+`anvil` comes up with other advanced capabilities such as:
+
+- **Custom `anvil_` methods** - Advanced node control including [account impersonation](/anvil/reference#anvil_impersonateaccount), [state manipulation](/anvil/reference#anvil_setbalance), and [mining control](/anvil/reference#anvil_mine)
+- **Forking capabilities** - Fork anvil off another live chain
+
+All of the above is provided while maintaining full compliance with the Ethereum JSON-RPC spec.
+
+Learn more about `anvil` [here](/anvil/overview).
+
+### Cast
+
+Cast is your Swiss army knife for interacting with Ethereum applications from the command line. You can make smart contract calls, send transactions, or retrieve any type of chain data.
+
+#### Read contract data
+
+```bash
+# Check ETH balance
+cast balance vitalik.eth --ether --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+
+# Call a contract function to read data
+cast call 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
+"balanceOf(address)" 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
+--rpc-url https://reth-ethereum.ithaca.xyz/rpc
+```
+
+#### Send transactions
+
+```bash
+# Set your private key
+export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+# Send ETH to an address
+cast send 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --value 10000000 --private-key $PRIVATE_KEY
+```
+
+#### Interact with JSON-RPC
+
+```bash
+# Call JSON-RPC methods directly
+cast rpc eth_getHeaderByNumber $(cast 2h 22539851) --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+
+# Get latest block number
+cast block-number --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+```
+
+Learn more about `cast` [here](/cast/overview).
+
+---
+
+### Chisel
+
+Chisel is a fast, utilitarian, and verbose Solidity REPL for rapid prototyping and debugging. It's perfect for testing Solidity snippets and exploring contract behavior interactively.
+
+#### Start the REPL
+
+```bash
+# Launch chisel REPL
+chisel
+```
+
+#### Interactive Solidity development
+
+```solidity
+// Create and query variables
+➜ uint256 a = 123;
+➜ a
+Type: uint256
+├ Hex: 0x7b
+├ Hex (full word): 0x000000000000000000000000000000000000000000000000000000000000007b
+└ Decimal: 123
+
+// Test contract functions
+➜ function add(uint256 x, uint256 y) pure returns (uint256) { return x + y; }
+➜ add(5, 10)
+Type: uint256
+└ Decimal: 15
+```
+
+Learn more about `chisel` [here](/chisel/overview).

--- a/vocs/docs/pages/introduction/getting-started.mdx
+++ b/vocs/docs/pages/introduction/getting-started.mdx
@@ -6,22 +6,26 @@ This section introduces the `forge` command-line tool. We will walk through crea
 
 To start a new project with Foundry, use the [`forge init`](/forge/reference/forge-init) command:
 
-```sh [forge init]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-init:command]
 ```
 
 Now, let’s explore the structure that `forge` has generated for us:
 
-```sh [tree]
+```sh
 cd hello_foundry
+```
+
+```sh
 // [!include ~/snippets/output/hello_foundry/tree:all]
+
 ```
 
 ### Build the project
 
 You can compile the project using [`forge build`](/forge/reference/forge-build):
 
-```sh [forge build]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-build:all]
 ```
 
@@ -29,7 +33,7 @@ You can compile the project using [`forge build`](/forge/reference/forge-build):
 
 To run the tests, use the [`forge test`](/forge/reference/forge-test) command:
 
-```sh [forge test]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-test:all]
 ```
 

--- a/vocs/docs/pages/introduction/installation.md
+++ b/vocs/docs/pages/introduction/installation.md
@@ -93,6 +93,10 @@ For instructions on setting up Foundry in a CI pipeline, refer to the [foundry-r
 
 ### Using Foundry with Docker
 
+:::note
+Some systems, including those with M1 chips, may experience issues when building the Docker image locally. This is a known issue.
+:::
+
 Foundry can also be run inside a Docker container. If you don’t have Docker installed, you can download it from [Docker's website](https://docs.docker.com/get-docker/).
 
 Once Docker is installed, you can pull the latest Foundry release by running:
@@ -108,6 +112,3 @@ docker build -t foundry .
 ```
 
 For examples and guides on using this image, refer to the [Docker guide](/guides/foundry-in-docker).
-
-> ℹ️ **Note**  
-> Some systems, including those with M1 chips, may experience issues when building the Docker image locally. This is a known issue.

--- a/vocs/docs/pages/introduction/overview.md
+++ b/vocs/docs/pages/introduction/overview.md
@@ -6,15 +6,21 @@ Foundry is a smart contract development toolchain.
 
 Foundry manages your dependencies, compiles your project, runs tests, deploys, and lets you interact with the chain from the command-line and via Solidity scripts.
 
-### Sections
+### Navigating the Documentation
 
 **[Getting Started](/introduction/installation.md)**
 
 To get started with Foundry, install Foundry and set up your first project.
 
-**[Projects](/projects/creating-a-new-project.md)**
+[**Guides**]
 
-This section will give you an overview of how to create and work with existing projects.
+Guides for building smart contracts with Foundry.
+
+- [Best Practices](/guides/best-practices)
+- [Scripting with Solidity](/guides/scripting-with-solidity)
+- [Deterministic deployments using CREATE2](/guides/deterministic-deployments-using-create2)
+- [Forking Mainnet with Cast and Anvil](/guides/forking-mainnet-with-cast-anvil)
+- [Running Foundry inside of Docker](/guides/foundry-in-docker)
 
 **[Forge Overview](/forge/overview)**
 
@@ -45,15 +51,9 @@ Guides on configuring Foundry.
 - [Vyper support](/config/vyper)
 - [Forge Lint](/config/lint)
 
-**Guides**
+**[Projects](/projects/creating-a-new-project.md)**
 
-Guides for building smart contracts with Foundry.
-
-- [Best Practices](/guides/best-practices)
-- [Scripting with Solidity](/guides/scripting-with-solidity)
-- [Deterministic deployments using CREATE2](/guides/deterministic-deployments-using-create2)
-- [Forking Mainnet with Cast and Anvil](/guides/forking-mainnet-with-cast-anvil)
-- [Running Foundry inside of Docker](/guides/foundry-in-docker)
+This section will give you an overview of how to create and work with existing projects.
 
 **Contributing**
 

--- a/vocs/docs/pages/projects/creating-a-new-project.md
+++ b/vocs/docs/pages/projects/creating-a-new-project.md
@@ -2,7 +2,7 @@
 
 To start a new project with Foundry, use [`forge init`](/forge/reference/forge-init):
 
-```sh [forge init]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-init:command]
 ```
 
@@ -10,14 +10,17 @@ This creates a new directory `hello_foundry` from the default template. This als
 
 If you want to create a new project using a different template, you would pass the `--template` flag, like so:
 
-```sh [forge init]
+```sh
 forge init --template https://github.com/foundry-rs/forge-template hello_template
 ```
 
 For now, let's check what the default template looks like:
 
-```sh [tree]
+```sh
 cd hello_foundry
+```
+
+```sh
 // [!include ~/snippets/output/hello_foundry/tree:all]
 ```
 
@@ -25,13 +28,13 @@ The default template comes with one dependency installed: Forge Standard Library
 
 Let's build the project:
 
-```sh [forge build]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-build:all]
 ```
 
 And run the tests:
 
-```sh [forge test]
+```sh
 // [!include ~/snippets/output/hello_foundry/forge-test:all]
 ```
 

--- a/vocs/sidebar/forge-overview.ts
+++ b/vocs/sidebar/forge-overview.ts
@@ -20,7 +20,7 @@ export const forgeOverview: SidebarItem[] = [
     },
     {
         text: 'Advanced Testing',
-        collapsed: false,
+        collapsed: true,
         items: [
             { text: 'Overview', link: '/forge/advanced-testing/overview' },
             { text: 'Fuzz Testing', link: '/forge/advanced-testing/fuzz-testing' },
@@ -31,7 +31,7 @@ export const forgeOverview: SidebarItem[] = [
     { text: 'Deploying and Verifying', link: '/forge/deploying' },
     {
         text: 'Gas Tracking',
-        collapsed: false,
+        collapsed: true,
         items: [
             { text: 'Overview', link: '/forge/gas-tracking/overview' },
             { text: 'Gas Reports', link: '/forge/gas-tracking/gas-reports' },

--- a/vocs/sidebar/sidebar.ts
+++ b/vocs/sidebar/sidebar.ts
@@ -12,14 +12,17 @@ export const sidebar: Sidebar = [
         ]
     },
     {
-        text: 'Projects',
-        items: [
-            { text: 'Creating a New Project', link: '/projects/creating-a-new-project' },
-            { text: 'Clone a Verified Contract', link: '/projects/clone-a-verified-contract' },
-            { text: 'Dependencies', link: '/projects/dependencies' },
-            { text: 'Soldeer', link: '/projects/soldeer' },
-            { text: 'Project Layout', link: '/projects/project-layout' }
-        ]
+      text: 'Guides',
+      link: '/guides',
+      items: [
+          
+          { text: 'Best Practices', link: '/guides/best-practices' },
+          { text: 'Scripting with Solidity', link: '/guides/scripting-with-solidity' },
+          { text: 'Deterministic deployments using CREATE2', link: '/guides/deterministic-deployments-using-create2' },
+          { text: 'Forking Mainnet with Cast and Anvil', link: '/guides/forking-mainnet-with-cast-anvil' },
+          { text: 'Running Foundry inside of Docker', link: '/guides/foundry-in-docker' },
+          { text: 'Video tutorials', link: '/guides/video-tutorials' }
+      ]
     },
     {
         text: 'Forge',
@@ -238,17 +241,14 @@ export const sidebar: Sidebar = [
         ]
     },
     {
-        text: 'Guides',
-        link: '/guides',
-        items: [
-            
-            { text: 'Best Practices', link: '/guides/best-practices' },
-            { text: 'Scripting with Solidity', link: '/guides/scripting-with-solidity' },
-            { text: 'Deterministic deployments using CREATE2', link: '/guides/deterministic-deployments-using-create2' },
-            { text: 'Forking Mainnet with Cast and Anvil', link: '/guides/forking-mainnet-with-cast-anvil' },
-            { text: 'Running Foundry inside of Docker', link: '/guides/foundry-in-docker' },
-            { text: 'Video tutorials', link: '/guides/video-tutorials' }
-        ]
+      text: 'Project Setup',
+      items: [
+          { text: 'Creating a New Project', link: '/projects/creating-a-new-project' },
+          { text: 'Clone a Verified Contract', link: '/projects/clone-a-verified-contract' },
+          { text: 'Dependencies', link: '/projects/dependencies' },
+          { text: 'Soldeer', link: '/projects/soldeer' },
+          { text: 'Project Layout', link: '/projects/project-layout' }
+      ]
     },
     {
         text: 'Cheatcode Reference',


### PR DESCRIPTION
- Redo Getting Started 843bc237a43048cfd52da39cea8f8a5834f82326
- Quick Action one-liners 33528f891da2edfde35f679f48435214e2be3ba8
- Refac sidebar to move guides section up and project setup down 3a1da43234ee3b24caaf95dee15d60d70367e5e7
- Collapse some forge section as sidebar is too long to scroll 3a1da43234ee3b24caaf95dee15d60d70367e5e7
- Remove dup titles in command snippets 28760c406980b864a65ec765e10ace98fa27527f