### PR TITLE
`docs: Fix forge create command argument order`

### DIFF
--- a/vocs/docs/pages/forge/deploying.md
+++ b/vocs/docs/pages/forge/deploying.md
@@ -49,10 +49,10 @@ Additionally, we can tell Forge to verify our contract on Etherscan, Sourcify or
 
 ```sh
 forge create src/MyToken.sol:MyToken --rpc-url <YOUR_RPC_URL> \
-    --constructor-args "ForgeUSD" "FUSD" 18 1000000000000000000000 \
     --private-key <YOUR_PRIVATE_KEY> \
     --etherscan-api-key <YOUR_ETHERSCAN_API_KEY> \
-    --verify
+    --verify \
+    --constructor-args "ForgeUSD" "FUSD" 18 1000000000000000000000
 ```
 
 ## Multi-chain deployments

--- a/vocs/docs/pages/forge/reference/forge-create.mdx
+++ b/vocs/docs/pages/forge/reference/forge-create.mdx
@@ -15,13 +15,13 @@ forge-create - Deploy a smart contract.
 
 ### SYNOPSIS
 
-`forge create` [*options*] _contract_
+`forge create` _contract_ [*options*]
 
 ### DESCRIPTION
 
 Deploy a smart contract.
 
-The path to the contract is in the format `<path>:<contract>`, e.g. `src/Contract.sol:Contract`.
+The path to the contract must be specified first, in the format `<path>:<contract>`, e.g. `src/Contract.sol:Contract`.
 
 You can specify constructor arguments with `--constructor-args`. Alternatively, you can specify a file
 containing space-separated constructor arguments with `--constructor-args-path`.


### PR DESCRIPTION
### Description:

This pull request corrects the documentation for the `forge create` command to reflect the correct argument order, addressing an issue where the documented examples would fail.

The `<CONTRACT>` argument must be specified before any other options. This PR updates the command's synopsis, examples, and adds an explicit note to clarify the correct usage.

**Changes:**

*   Updated the `SYNOPSIS` in `forge/reference/forge-create.mdx` to show the correct argument position.
*   Corrected the command example in `forge/deploying.md` to move `--constructor-args` to the end.
*   Added a note to `forge/reference/forge-create.mdx` to explicitly state that the contract path must be provided first.

This resolves the confusion reported and ensures the documentation matches the tool's behavior.

Fixes #1244