### PR TITLE
fix: add cast-index redirect

### DIFF
--- a/vocs/docs/public/_redirects
+++ b/vocs/docs/public/_redirects
@@ -45,3 +45,5 @@
 
 /guides/best-practices /guides/best-practices/writing-contracts
 /guides /guides/best-practices/writing-contracts
+
+/cast/reference/cast-index /cast/reference/cast-


### PR DESCRIPTION
Ref https://github.com/wevm/vocs/issues/294
Vocs/Vite does not allow "index" in file names or URLs.

Add a redirect for the `cast-index` reference