### PR TITLE
--broadcast switch required to broadcast the transaction

### DIFF
--- a/vocs/docs/pages/forge/deploying.md
+++ b/vocs/docs/pages/forge/deploying.md
@@ -15,7 +15,7 @@ To deploy a contract, you must provide a RPC URL (env: `ETH_RPC_URL`) and the pr
 To deploy `MyContract` to a network:
 
 ```sh
-forge create src/MyContract.sol:MyContract --rpc-url <YOUR_RPC_URL> --private-key <YOUR_PRIVATE_KEY>
+forge create src/MyContract.sol:MyContract --rpc-url <YOUR_RPC_URL> --private-key <YOUR_PRIVATE_KEY> --broadcast
 compiling...
 success.
 Deployer: 0xa735b3c25f...
@@ -50,6 +50,7 @@ Additionally, we can tell Forge to verify our contract on Etherscan, Sourcify or
 ```sh
 forge create src/MyToken.sol:MyToken --rpc-url <YOUR_RPC_URL> \
     --private-key <YOUR_PRIVATE_KEY> \
+    --broadcast \
     --etherscan-api-key <YOUR_ETHERSCAN_API_KEY> \
     --verify \
     --constructor-args "ForgeUSD" "FUSD" 18 1000000000000000000000


### PR DESCRIPTION
Without the `--broadcast` switch, the `forge create` command treats the deployment as a dry run and does not broadcast the transaction as the docs say. You can check this via the `forge create --help` command and by trying deploying contracts. If you omit `--broadcast`, it prints `Warning: To broadcast this transaction, add --broadcast to the previous command. See forge create --help for more.`.