### PR TITLE
fix error in verification existing contract example

### DIFF
--- a/vocs/docs/pages/forge/deploying.md
+++ b/vocs/docs/pages/forge/deploying.md
@@ -128,7 +128,7 @@ Let's say you want to verify `MyToken` (see above). You set the [number of optim
 Here's how to verify it:
 
 ```bash
-forge verify-contract <CONTRACT_ADDRESS> src/MyToken.sol:MyToken \
+forge verify-contract \
     --chain-id 11155111 \
     --num-of-optimizations 1000000 \
     --watch \


### PR DESCRIPTION
The suggested command for verification of an existing contract was failing. 

Contract address and name should only appear after the options before the change it appeared twice.