### PR TITLE
Docs/cast estimate create flag

### DIFF
--- a/vocs/docs/pages/cast/reference/cast-estimate.mdx
+++ b/vocs/docs/pages/cast/reference/cast-estimate.mdx
@@ -43,6 +43,11 @@ The destination (_to_) can be an ENS name or an address.
    cast estimate 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
      --value 0.1ether "deposit()"
    ```
+2. Estimate the gas cost for deploying a new contract:
+   ```sh
+   cast estimate --create 0x608060405234801561001057600080fd5b506040516101...
+   ```
+   Replace `0x6080...` with your contract's deployment (init) bytecode. 
 
 ### SEE ALSO
 

--- a/vocs/docs/pages/cast/reference/cast-estimate.mdx
+++ b/vocs/docs/pages/cast/reference/cast-estimate.mdx
@@ -3,6 +3,7 @@ import TxValueOption from "../../reference/common/tx-value-option.mdx";
 import RpcOptions from "../../reference/common/rpc-options.mdx";
 import EtherscanOptions from "../../reference/common/etherscan-options.mdx";
 import CommonOptions from "./common-options.mdx";
+import CastEstimateCreateOption from "../../reference/common/cast-estimate-create-option.mdx";
 
 ## cast estimate
 
@@ -23,6 +24,7 @@ The destination (_to_) can be an ENS name or an address.
 <SigDescription />
 
 ### OPTIONS
+<CastEstimateCreateOption />
 
 #### Transaction Options
 

--- a/vocs/docs/pages/reference/common/cast-estimate-create-option.mdx
+++ b/vocs/docs/pages/reference/common/cast-estimate-create-option.mdx
@@ -1,0 +1,5 @@
+#### Create Option
+
+`--create` _init_code_  
+&nbsp;&nbsp;&nbsp;&nbsp;Estimate gas as if deploying a new contract, rather than calling a function on an existing contract.  
+&nbsp;&nbsp;&nbsp;&nbsp;_init_code_ is the contract's deployment bytecode, provided as a hexadecimal string.


### PR DESCRIPTION
This pull request improves the documentation for the `cast estimate` command by adding details and a usage example for the `--create` flag.

- Documents what the `--create` flag does and specifies the expected `init_code` (deployment bytecode) input.
- Adds a practical example to the EXAMPLES section, showing how to use `--create` to estimate gas for contract deployment.
- Aims to make it easier for users to understand and utilize the `cast estimate --create` workflow.

Closes #1570.
