### PR TITLE
Update invariant docs + leftovers

### DIFF
--- a/vocs/docs/pages/config/reference/default-config.mdx
+++ b/vocs/docs/pages/config/reference/default-config.mdx
@@ -69,7 +69,7 @@ chain_id = 31337
 # The `block.number` value during EVM execution
 block_number = 1
 # The gas limit in tests
-gas_limit = 9223372036854775807
+gas_limit = 1073741824
 # The gas price in tests (in wei)
 gas_price = 0
 # The block basefee in tests (in wei)

--- a/vocs/docs/pages/config/reference/testing.mdx
+++ b/vocs/docs/pages/config/reference/testing.mdx
@@ -76,7 +76,7 @@ The value of the `chainid` opcode in tests.
 ##### `gas_limit`
 
 - Type: integer or string
-- Default: 9223372036854775807
+- Default: 1073741824
 - Environment: `FOUNDRY_GAS_LIMIT` or `DAPP_GAS_LIMIT`
 
 The gas limit for each test case.
@@ -88,7 +88,7 @@ The gas limit for each test case.
 > In order to use higher gas limits use a string:
 
 ```toml
-gas_limit = "18446744073709551615" # u64::MAX
+gas_limit = "9223372036854775807" # limited to 64-bit integers
 ```
 
 ##### `gas_price`
@@ -337,6 +337,22 @@ Configuration values for `[fuzz]` section.
 
 The amount of fuzz runs to perform for each fuzz test case. Higher values gives more confidence in results at the cost of testing speed.
 
+##### `timeout`
+
+- Type: integer
+- Default: None
+- Environment: `FOUNDRY_FUZZ_TIMEOUT`
+
+Optional timeout (in seconds) for fuzz test.
+
+##### `fail_on_revert`
+
+- Type: boolean
+- Default: true
+- Environment: `FOUNDRY_FUZZ_FAIL_ON_REVERT`
+
+Fails the fuzzed test if a revert occurs in a call to a contract other than the test contract.
+
 ##### `max_test_rejects`
 
 - Type: integer
@@ -449,6 +465,14 @@ The number of runs that must execute for each invariant test group. See also [fu
 
 The number of calls executed to attempt to break invariants in one run.
 
+##### `timeout`
+
+- Type: integer
+- Default: None
+- Environment: `FOUNDRY_INVARIANT_TIMEOUT`
+
+Optional timeout (in seconds) for invariant time based campaigns.
+
 ##### `fail_on_revert`
 
 - Type: boolean
@@ -521,6 +545,46 @@ Number of runs to use for generating gas report.
 
 Path where invariant failures are recorded and replayed.
 
+##### `corpus_dir`
+
+- Type: string (path)
+- Default: None
+- Environment: `FOUNDRY_INVARIANT_CORPUS_DIR`
+
+Optional path where invariant corpus is stored. Enables coverage guided fuzzing and edge coverage metrics.
+
+##### `corpus_gzip`
+
+- Type: boolean
+- Default: true
+- Environment: `FOUNDRY_INVARIANT_CORPUS_GZIP`
+
+Flag indicating whether corpus should use gzip file compression and decompression (relevant only if `corpus_dir` is configured). If set to `false`, then corpus is persisted as regular json file.
+
+##### `corpus_min_mutations`
+
+- Type: integer
+- Default: 5
+- Environment: `FOUNDRY_INVARIANT_CORPUS_MIN_MUTATIONS`
+
+Number of corpus mutations until marked as eligible to be flushed from memory (relevant only if `corpus_dir` is configured).
+
+##### `corpus_min_size`
+
+- Type: integer
+- Default: 0
+- Environment: `FOUNDRY_INVARIANT_CORPUS_MIN_SIZE`
+
+Minimum corpus size to mutate and won't be evicted from memory (relevant only if `corpus_dir` is configured).
+
+##### `show_edge_coverage`
+
+- Type: boolean
+- Default: false
+- Environment: `FOUNDRY_INVARIANT_SHOW_EDGE_COVERAGE`
+
+Flag indicating whether to collect and display edge coverage metrics (automatically enabled if `corpus_dir` is configured).
+
 ##### `show_metrics`
 
 - Type: boolean
@@ -528,3 +592,11 @@ Path where invariant failures are recorded and replayed.
 - Environment: `FOUNDRY_INVARIANT_SHOW_METRICS`
 
 The flag indicating whether to collect and display fuzzed selectors metrics in test report.
+
+##### `show_solidity`
+
+- Type: boolean
+- Default: false
+- Environment: `FOUNDRY_INVARIANT_SHOW_SOLIDITY`
+
+Flag indicating whether to display counterexamples as solidity calls.

--- a/vocs/docs/pages/forge/tests/fork-testing.md
+++ b/vocs/docs/pages/forge/tests/fork-testing.md
@@ -11,6 +11,10 @@ Forge supports testing in a forked environment with two different approaches:
 
 Which approach to use? Forking mode affords running an entire test suite against a specific forked environment, while forking cheatcodes provide more flexibility and expressiveness to work with multiple forks in your tests. Your particular use case and testing strategy will help inform which approach to use.
 
+:::tip
+Starting with Foundry v1.3.0, forked tests using the Reth client are faster thanks to the `eth_getAccountInfo` API which reduce account data fetching from three requests to one.
+:::
+
 ### Forking Mode
 
 To run all tests in a forked environment, such as a forked Ethereum mainnet, pass an RPC URL via the `--fork-url` flag:


### PR DESCRIPTION
- document Invariant time based campaigns and Coverage-Guided Fuzzing mode 
- add time based campaigns `timeout` and `show_solidity` configs for `[invariant]` section
- add `timeout` and `fail_on_revert` configs for `[fuzz]` section
- forking test note re `eth_getAccountInfo` Reth API
- update default value of `gas_limit` config