### PR TITLE
fix: fetch-benches script to identify latest version

### DIFF
--- a/vocs/docs/pages/benches.mdx
+++ b/vocs/docs/pages/benches.mdx
@@ -1,8 +1,8 @@
-{/* Auto-generated benchmark table from 7/31/2025. Do not edit manually. */}
+{/* Auto-generated benchmark table from 8/1/2025. Do not edit manually. */}
 
   <strong>Baseline:</strong> [v1.2.3](https://github.com/foundry-rs/foundry/releases/tag/v1.2.3)
 
-  <strong>Latest:</strong> [nightly-9c3feff](https://github.com/foundry-rs/foundry/commit/9c3feff)
+  <strong>Latest:</strong> [nightly-master](https://github.com/foundry-rs/foundry/commit/master)
 
   Learn more about what went into the latest release [here](/releases)
 <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '1rem', marginBottom: 0 }}>
@@ -20,39 +20,39 @@
   <tbody>
     <tr style={{ borderBottom: '1px solid var(--vocs-color_border)' }}>
       <td style={{ padding: '0.4rem', fontWeight: 500 }}>[Uniswap-v4-core](https://github.com/Uniswap/v4-core)</td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.03s /</span><br/><span style={{ fontSize: '0.85rem' }}>6.76s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓15.82%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.03s /</span><br/><span style={{ fontSize: '0.85rem' }}>7.46s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓7.10%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.98s /</span><br/><span style={{ fontSize: '0.85rem' }}>8.34s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓7.13%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2m 8.3s /</span><br/><span style={{ fontSize: '0.85rem' }}>2m 9.0s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.55%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.190s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.136s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓28.42%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>1m 40.4s /</span><br/><span style={{ fontSize: '0.85rem' }}>1m 40.9s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.50%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.14s /</span><br/><span style={{ fontSize: '0.85rem' }}>7.14s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓12.29%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.20s /</span><br/><span style={{ fontSize: '0.85rem' }}>6.90s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓15.85%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>8.61s /</span><br/><span style={{ fontSize: '0.85rem' }}>7.72s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓10.34%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2m 3.5s /</span><br/><span style={{ fontSize: '0.85rem' }}>2m 4.0s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.40%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.131s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.132s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.76%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>1m 36.6s /</span><br/><span style={{ fontSize: '0.85rem' }}>1m 35.2s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓1.45%</span></td>
     </tr>
     <tr style={{ borderBottom: '1px solid var(--vocs-color_border)' }}>
       <td style={{ padding: '0.4rem', fontWeight: 500 }}>[ithacaxyz-account](https://github.com/ithacaxyz/account)</td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.69s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.12s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓15.45%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.58s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.39s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓5.31%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.53s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.15s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓10.76%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.88s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.05s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓21.39%</span></td>
       <td style={{ padding: '0.4rem' }}>–</td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>9.53s /</span><br/><span style={{ fontSize: '0.85rem' }}>9.58s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.52%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.199s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.206s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑3.52%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>16.51s /</span><br/><span style={{ fontSize: '0.85rem' }}>16.62s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.67%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>9.25s /</span><br/><span style={{ fontSize: '0.85rem' }}>9.27s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.22%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.195s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.198s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑1.54%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>15.79s /</span><br/><span style={{ fontSize: '0.85rem' }}>15.63s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓1.01%</span></td>
     </tr>
     <tr style={{ borderBottom: '1px solid var(--vocs-color_border)' }}>
       <td style={{ padding: '0.4rem', fontWeight: 500 }}>[solady](https://github.com/Vectorized/solady)</td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2.95s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.32s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓21.36%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.34s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.54s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓23.95%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.02s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.18s</span><br/><span style={{ color: 'red', fontSize: '0.85rem' }}>↑5.30%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>15.29s /</span><br/><span style={{ fontSize: '0.85rem' }}>14.97s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓2.09%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.092s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.089s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓3.26%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2.72s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.30s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓15.44%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2.93s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.46s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓16.04%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>2.98s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.57s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓13.76%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>14.59s /</span><br/><span style={{ fontSize: '0.85rem' }}>14.65s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑0.41%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.086s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.089s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑3.49%</span></td>
       <td style={{ padding: '0.4rem' }}>–</td>
     </tr>
     <tr>
       <td style={{ padding: '0.4rem', fontWeight: 500 }}>[sparkdotfi-spark-psm](https://github.com/sparkdotfi/spark-psm)</td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>57.02s /</span><br/><span style={{ fontSize: '0.85rem' }}>44.76s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓21.50%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.70s /</span><br/><span style={{ fontSize: '0.85rem' }}>3.06s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓17.30%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>58.19s /</span><br/><span style={{ fontSize: '0.85rem' }}>54.06s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓7.10%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>13.33s /</span><br/><span style={{ fontSize: '0.85rem' }}>13.29s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓0.30%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.239s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.202s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓15.48%</span></td>
-      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3m 55.3s /</span><br/><span style={{ fontSize: '0.85rem' }}>4m 0.4s</span><br/><span style={{ color: 'inherit', fontSize: '0.85rem' }}>↑2.17%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>57.18s /</span><br/><span style={{ fontSize: '0.85rem' }}>47.27s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓17.33%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3.81s /</span><br/><span style={{ fontSize: '0.85rem' }}>2.99s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓21.52%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>53.01s /</span><br/><span style={{ fontSize: '0.85rem' }}>45.94s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓13.34%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>13.24s /</span><br/><span style={{ fontSize: '0.85rem' }}>13.21s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓0.23%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>0.181s /</span><br/><span style={{ fontSize: '0.85rem' }}>0.171s</span><br/><span style={{ color: 'green', fontSize: '0.85rem' }}>↓5.52%</span></td>
+      <td style={{ padding: '0.4rem' }}><span style={{ fontSize: '0.85rem' }}>3m 38.4s /</span><br/><span style={{ fontSize: '0.85rem' }}>3m 50.0s</span><br/><span style={{ color: 'red', fontSize: '0.85rem' }}>↑5.31%</span></td>
     </tr>
   </tbody>
 </table>

--- a/vocs/docs/pages/benches.mdx
+++ b/vocs/docs/pages/benches.mdx
@@ -2,7 +2,7 @@
 
   <strong>Baseline:</strong> [v1.2.3](https://github.com/foundry-rs/foundry/releases/tag/v1.2.3)
 
-  <strong>Latest:</strong> [nightly-master](https://github.com/foundry-rs/foundry/commit/master)
+  <strong>Latest:</strong> [v1.3.0](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0)
 
   Learn more about what went into the latest release [here](/releases)
 <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '1rem', marginBottom: 0 }}>

--- a/vocs/docs/pages/releases.mdx
+++ b/vocs/docs/pages/releases.mdx
@@ -3,7 +3,7 @@ title: Foundry Releases
 description: Latest release notes for Foundry
 ---
 
-# v1.3.0-rc3 [July 29, 2025]
+# v1.3.0-rc4 [July 30, 2025]
 
 # Foundry v1.3.0
 
@@ -13,7 +13,7 @@ This release includes support for `forge lint`, time-based campaigns and coverag
 
 ## Performance Improvements
 
-- This release includes an updated [`revm`](https://github.com/bluealloy/revm) ([#11079](https://github.com/foundry-rs/foundry/pull/11079)) and an optimized inspector stack ([#11077](https://github.com/foundry-rs/foundry/pull/11077) [#11100](https://github.com/foundry-rs/foundry/pull/11100)), which enhances Forge test performance by up to 21.50% [compared to previous versions](https://github.com/foundry-rs/foundry/blob/release-1.3.0/benches/LATEST.md)
+- This release includes an updated [`revm`](https://github.com/bluealloy/revm) ([#11079](https://github.com/foundry-rs/foundry/pull/11079)) and an optimized inspector stack ([#11077](https://github.com/foundry-rs/foundry/pull/11077)), which enhances Forge test performance by up to 21.50% [compared to previous versions](https://github.com/foundry-rs/foundry/blob/release-1.3.0/benches/LATEST.md)
 #### Forge Test
 
 | Repository           | v1.2.3  | v1.3.0  |
@@ -249,7 +249,6 @@ For more details please refer to [EIP-712 foundry guide](https://getfoundry.sh/g
 - fix: spawn fork backendhandler on current tokio runtime ([#10923](https://github.com/foundry-rs/foundry/pull/10923)) by [@mattsse](https://github.com/mattsse)
 - perf: find latest block for next-base-fee. replaces [#10505](https://github.com/foundry-rs/foundry/pull/10505) ([#10511](https://github.com/foundry-rs/foundry/pull/10511)) by [@naps62](https://github.com/naps62)
 - perf: improve InspectorStack ([#11077](https://github.com/foundry-rs/foundry/pull/11077)) by [@DaniPopes](https://github.com/DaniPopes) 
-- perf: box inspectors in InspectorStack ([#11100](https://github.com/foundry-rs/foundry/pull/11100)) by [@DaniPopes](https://github.com/DaniPopes) 
 
 
 ## Other
@@ -334,13 +333,15 @@ For more details please refer to [EIP-712 foundry guide](https://getfoundry.sh/g
 - docs(lintrules): reflect latest impl changes ([#11031](https://github.com/foundry-rs/foundry/pull/11031)) by [@0xrusowsky](https://github.com/0xrusowsky)
 
 ## Full Changelog:
- https://github.com/foundry-rs/foundry/compare/v1.2.3...v1.3.0-rc3
+ https://github.com/foundry-rs/foundry/compare/v1.2.3...v1.3.0-rc4
 
 
 ## Previous Releases
 
 | Version | Release Date | Release Notes |
 |---------|--------------|---------------|
+| v1.3.0 | July 31, 2025 | [View](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0) |
+| v1.3.0-rc3 | July 29, 2025 | [View](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0-rc3) |
 | v1.3.0-rc2 | July 24, 2025 | [View](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0-rc2) |
 | v1.3.0-rc1 | July 17, 2025 | [View](https://github.com/foundry-rs/foundry/releases/tag/v1.3.0-rc1) |
 | v1.2.3 | June 8, 2025 | [View](https://github.com/foundry-rs/foundry/releases/tag/v1.2.3) |

--- a/vocs/docs/pages/releases/nightly.mdx
+++ b/vocs/docs/pages/releases/nightly.mdx
@@ -3,26 +3,18 @@ title: Foundry Nightly Release
 description: Latest nightly release notes for Foundry
 ---
 
-# Nightly (2025-07-29) [July 29, 2025]
-
-## Cast Fixes
-
-- fix(`cast`): unknown signatures are cached as an empty string ([#11127](https://github.com/foundry-rs/foundry/pull/11127)) by [@zerosnacks](https://github.com/zerosnacks)
-
-## Forge Features
-
-- feat(`cheatcodes`): decode and show mismatched params on expectEmit ([#11098](https://github.com/foundry-rs/foundry/pull/11098)) by [@yash-atreya](https://github.com/yash-atreya)
+# Nightly (2025-08-01) [August 1, 2025]
 
 
 ## Other
 
-- feat(forge): "add" alias for install subcommand ([#11124](https://github.com/foundry-rs/foundry/pull/11124)) by [@mablr](https://github.com/mablr)
-- chore: update package.homepage ([#11131](https://github.com/foundry-rs/foundry/pull/11131)) by [@DaniPopes](https://github.com/DaniPopes)
-- fix: use existing functions for accountinfo ([#11134](https://github.com/foundry-rs/foundry/pull/11134)) by [@mattsse](https://github.com/mattsse)
-- fix: tracy integration ([#11135](https://github.com/foundry-rs/foundry/pull/11135)) by [@DaniPopes](https://github.com/DaniPopes)
+- chore(cheatcodes): avoid unnecessary lookup in store ([#11163](https://github.com/foundry-rs/foundry/pull/11163)) by [@DaniPopes](https://github.com/DaniPopes)
+- feat(cast): new `pad` cmd for hex data ([#11152](https://github.com/foundry-rs/foundry/pull/11152)) by [@0xrusowsky](https://github.com/0xrusowsky)
+- fix(forge): consistent handling unresolved imports ([#11164](https://github.com/foundry-rs/foundry/pull/11164)) by [@grandizzy](https://github.com/grandizzy)
+- chore: make all random cheatcodes view ([#11166](https://github.com/foundry-rs/foundry/pull/11166)) by [@DaniPopes](https://github.com/DaniPopes)
 
 ## Full Changelog:
- https://github.com/foundry-rs/foundry/compare/nightly...nightly-8030cbc986e588c4d8216883f088aa2b3eae057d
+ https://github.com/foundry-rs/foundry/compare/nightly...nightly-99d3a4123eff947a0dbbfb7c3a27360db9e3a8c1
 
 ---
 

--- a/vocs/vocs.config.ts
+++ b/vocs/vocs.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
       text: 'Rustdocs',
     },
     {
-      text: 'v1.3.0-rc4',
+      text: 'v1.3.0',
       items: [
         {
           text: 'Release notes',


### PR DESCRIPTION
The script would only categorize nightly versions as the latest version in script and not tagged releases. 