### PR TITLE
fix: lint redirect

### DIFF
--- a/vocs/docs/public/_redirects
+++ b/vocs/docs/public/_redirects
@@ -12,7 +12,7 @@
 /cast/reference /cast/reference/cast
 /cast/reference/overview /cast/reference/cast
 
-/forge/reference/forge-lint/#:splat /forge/linting/#:splat
+/forge/reference/forge-lint/ /forge/linting
 /forge/reference/forge-lint /forge/linting
 /forge/reference/forge-:splat /forge/reference/:splat
 /reference/forge/:id /forge/reference/:id


### PR DESCRIPTION
Changes existing redirect to account for the slash `/`

`/forge/reference/forge-lint/ /forge/linting`