### PR TITLE
docs(anvil): add troubleshooting note for chained txs when automine i…

### DIFF
--- a/vocs/docs/pages/anvil/reference/anvil.mdx
+++ b/vocs/docs/pages/anvil/reference/anvil.mdx
@@ -361,3 +361,15 @@ EVM options:
           
           [aliases: --tracing]
 ```
+Troubleshooting: Chained transactions with automine disabled
+
+When **automine is off**, a second transaction that **depends on funds** created by a previous pending transaction may be rejected with:
+
+```text
+error: Insufficient funds for gas * price + value
+```
+
+This happens because the second tx is validated **before** the funding tx is mined.  
+**Workarounds:**
+- Temporarily enable automine and mine the funding tx first, or
+- Manually mine a block between the two transactions.


### PR DESCRIPTION
### Summary
Adds a troubleshooting note explaining why a second tx can be rejected with
“Insufficient funds for gas * price + value” when `automine` is disabled, and
lists two workarounds. Docs-only change; no code.

### Context
Follow-up to foundry-rs/foundry#11264 — moved here per maintainer guidance.
