### PR TITLE
Fix Hardhat install command to use compatible v2.x

### DIFF
--- a/vocs/docs/pages/config/hardhat.md
+++ b/vocs/docs/pages/config/hardhat.md
@@ -24,7 +24,7 @@ If you want to adapt this to a Foundry project you already have or learn how it 
 Inside your Foundry project working directory:
 
 1. `npm init -y` - This will set up a `package.json` file.
-2. `npm install --save-dev hardhat@^2.22.0` - Install Hardhat as a dev dependency into your project.
+2. `npm install --save-dev hardhat@2` - Install Hardhat as a dev dependency into your project.
 3. `npx hardhat init` - Initialize your Hardhat project inside the same directory and choose the  "**Create an empty hardhat.config.js**" option. This will create a basic `hardhat.config.js` file.
 4. `npm i --save-dev @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox` - This will install the hardhat-foundry plugin and the Hardhat toolbox plugin which is a combination of all the basic dependencies you need to run Hardhat tests.
 

--- a/vocs/docs/pages/config/hardhat.md
+++ b/vocs/docs/pages/config/hardhat.md
@@ -24,7 +24,7 @@ If you want to adapt this to a Foundry project you already have or learn how it 
 Inside your Foundry project working directory:
 
 1. `npm init -y` - This will set up a `package.json` file.
-2. `npm i --save-dev hardhat` - Install Hardhat as a dev dependency into your project.
+2. `npm install --save-dev hardhat@^2.22.0` - Install Hardhat as a dev dependency into your project.
 3. `npx hardhat init` - Initialize your Hardhat project inside the same directory and choose the  "**Create an empty hardhat.config.js**" option. This will create a basic `hardhat.config.js` file.
 4. `npm i --save-dev @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox` - This will install the hardhat-foundry plugin and the Hardhat toolbox plugin which is a combination of all the basic dependencies you need to run Hardhat tests.
 

--- a/vocs/docs/pages/config/hardhat.md
+++ b/vocs/docs/pages/config/hardhat.md
@@ -24,7 +24,7 @@ If you want to adapt this to a Foundry project you already have or learn how it 
 Inside your Foundry project working directory:
 
 1. `npm init -y` - This will set up a `package.json` file.
-2. `npm install --save-dev hardhat@2` - Install Hardhat as a dev dependency into your project.
+2. `npm i --save-dev hardhat@2` - Install Hardhat as a dev dependency into your project.
 3. `npx hardhat init` - Initialize your Hardhat project inside the same directory and choose the  "**Create an empty hardhat.config.js**" option. This will create a basic `hardhat.config.js` file.
 4. `npm i --save-dev @nomicfoundation/hardhat-foundry @nomicfoundation/hardhat-toolbox` - This will install the hardhat-foundry plugin and the Hardhat toolbox plugin which is a combination of all the basic dependencies you need to run Hardhat tests.
 


### PR DESCRIPTION
The current documentation suggests installing Hardhat with:
```bash
npm install --save-dev hardhat
```
This now pulls in **Hardhat v3.0.0**, which is not yet supported by `@nomicfoundation/hardhat-foundry` (requires Hardhat `^2.26.0`).
This PR updates the command to explicitly install the latest supported **Hardhat v2.x**:

```bash
npm install --save-dev hardhat@^2.22.0
```

This ensures compatibility with the Hardhat–Foundry integration and prevents dependency resolution errors when following the setup guide.