### PR TITLE
chore: clarify naming requirement for parameters w/ fixtures

### DIFF
--- a/vocs/docs/pages/forge/advanced-testing/fuzz-testing.md
+++ b/vocs/docs/pages/forge/advanced-testing/fuzz-testing.md
@@ -82,13 +82,13 @@ Fuzz tests execution is governed by parameters that can be controlled by users v
 Fuzz test fixtures can be defined when you want to make sure a certain set of values is used as inputs for fuzzed parameters.
 These fixtures can be declared in tests as:
 
-- storage arrays prefixed with `fixture` and followed by param name to be fuzzed. For example, fixtures to be used when fuzzing parameter `amount` of type `uint32` can be defined as
+- storage arrays prefixed with `fixture` and followed by parameter name to be fuzzed. For example, fixtures to be used when fuzzing parameter `amount` of type `uint32` can be defined as
 
 ```solidity
 uint32[] public fixtureAmount = [1, 5, 555];
 ```
 
-- functions named with `fixture` prefix, followed by param name to be fuzzed. Function should return an (fixed size or dynamic) array of values to be used for fuzzing. For example, fixtures to be used when fuzzing parameter named `owner` of type `address` can be defined in a function with signature
+- functions named with `fixture` prefix, followed by parameter name to be fuzzed. Function should return an (fixed size or dynamic) array of values to be used for fuzzing. For example, fixtures to be used when fuzzing parameter named `owner` of type `address` can be defined in a function with signature
 
 ```solidity
 function fixtureOwner() public returns (address[] memory)
@@ -131,6 +131,8 @@ To make sure fuzzer includes in the same run a `slate` value derived from a `yay
         keccak256(abi.encodePacked(makeAddr("yay3")))
     ];
 ```
+
+Note the name `fixtureYay` matches against `etch`'s parameter `yay` and `fixtureSlate` matches against `voteSlate`'s parameter `slate`.
 
 Following image shows how fuzzer generates values with and without fixtures being declared:
 

--- a/vocs/docs/pages/forge/advanced-testing/table-testing.md
+++ b/vocs/docs/pages/forge/advanced-testing/table-testing.md
@@ -9,27 +9,31 @@ Foundry v1.3.0 comes with support for table testing, which enables the definitio
 #### Test definition
 
 In forge, table tests are functions named with `table` prefix that accepts datasets as one or multiple arguments:
+
 ```solidity
-function tableSumsTest(TestCase memory testCaseSum) public
+function tableSumsTest(TestCase memory sums) public
 ```
+
 ```solidity
-function tableSumsTest(TestCase memory testCaseSum, bool enable) public
+function tableSumsTest(TestCase memory sums, bool enable) public
 ```
 
 The datasets are defined as forge fixtures which can be:
+
 - storage arrays prefixed with `fixture` prefix and followed by dataset name
 - functions named with `fixture` prefix, followed by dataset name. Function should return an (fixed size or dynamic) array of values.
 
 #### Examples
 
 - Single dataset. In following example, `tableSumsTest` test will be executed twice, with inputs from `fixtureSums` dataset: once with `TestCase(1, 2, 3)` and once with `TestCase(4, 5, 9)`.
+
 ```solidity
 struct TestCase {
     uint256 a;
     uint256 b;
     uint256 expected;
 }
-    
+
 function fixtureSums() public returns (TestCase[] memory) {
     TestCase[] memory entries = new TestCase[](2);
     entries[0] = TestCase(1, 2, 3);
@@ -42,7 +46,10 @@ function tableSumsTest(TestCase memory sums) public pure {
 }
 ```
 
+It is required to name the `tableSumsTest`'s `TestCase` parameter `sums` as the parameter name is resolved against the available fixtures (`fixtureSums`). In this example, if the parameter is not named `sums` the following error is raised: `[FAIL: Table test should have fixtures defined]`.
+
 - Multiple datasets. `tableSwapTest` test will be executed twice, by using values at the same position from `fixtureWallet` and `fixtureSwap` datasets.
+
 ```solidity
 struct Wallet {
     address owner;
@@ -53,7 +60,7 @@ struct Swap {
     bool swap;
     uint256 amount;
 }
-    
+
 Wallet[] public fixtureWallet;
 Swap[] public fixtureSwap;
 
@@ -63,7 +70,7 @@ function setUp() public {
     fixtureSwap.push(Swap(true, 11));
 
     // second table test input
-    fixtureWallet.push(Wallet(address(12), 12));        
+    fixtureWallet.push(Wallet(address(12), 12));
     fixtureSwap.push(Swap(false, 12));
 }
 
@@ -73,3 +80,5 @@ function tableSwapTest(Wallet memory wallet, Swap memory swap) public pure {
     );
 }
 ```
+
+The same naming requirement mentioned above in relevant here.


### PR DESCRIPTION
Relevant to table tests / fuzz test fixtures

Ref: https://x.com/zerosnacks/status/1957825999812403275