### PR TITLE
redirect also forge-std url with trailing /

### DIFF
--- a/vocs/docs/public/_redirects
+++ b/vocs/docs/public/_redirects
@@ -19,6 +19,7 @@
 /reference/forge /forge/reference/forge
 /forge/reference /forge/reference/forge
 /reference/forge-std /forge/tests/forge-std
+/reference/forge-std/ /forge/tests/forge-std
 
 /anvil /anvil/overview
 /cast /cast/overview


### PR DESCRIPTION
https://getfoundry.sh/reference/forge-std redirects now properly but https://getfoundry.sh/reference/forge-std/ which was originally pointed out doesn't. Add redirect for URL with trailing slash 