### PR TITLE
Update getting-started.mdx

### DIFF
--- a/vocs/docs/pages/introduction/getting-started.mdx
+++ b/vocs/docs/pages/introduction/getting-started.mdx
@@ -159,7 +159,7 @@ Type: uint256
 └ Decimal: 123
 
 // Test contract functions
-➜ function add(uint256 x, uint256 y) pure public returns (uint256) { return x + y; }
+➜ function add(uint256 x, uint256 y) public pure returns (uint256) { return x + y; }
 ➜ add(5, 10)
 Type: uint256
 └ Decimal: 15


### PR DESCRIPTION
Missing public declaration, needed for default chisel declaration