### PR TITLE
chore: match forge page title with others

### DIFF
--- a/vocs/docs/pages/forge/overview.md
+++ b/vocs/docs/pages/forge/overview.md
@@ -2,7 +2,7 @@
 description: Forge is a command-line tool for building, testing, and deploying smart contracts with advanced features like fuzzing and gas tracking.
 ---
 
-## Forge Overview
+## Forge
 
 Forge is a command-line tool that ships with Foundry. Forge tests, builds, and deploys your smart contracts.
 


### PR DESCRIPTION
All three page titles are the name of the tool:

Chisel: https://getfoundry.sh/chisel/overview
Anvil: https://getfoundry.sh/anvil/overview
Cast: https://getfoundry.sh/cast/overview

except Forge where title is `Forge Overview`. Smol update to match the others.