### PR TITLE
chore(`ci`): only deploy on pushes and pull requests to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,10 @@
 name: deploy
-on: [push]
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   deploy:


### PR DESCRIPTION
I think this makes sense, we should not be deploying on random pushes to any branch for any reason