### PR TITLE
docs(anvil): add missing JSON-RPC endpoints

### DIFF
--- a/vocs/docs/pages/anvil/reference.md
+++ b/vocs/docs/pages/anvil/reference.md
@@ -170,6 +170,15 @@ Accepts `true` to enable auto impersonation of accounts, and `false` to disable 
 `anvil_getAutomine`
 Returns true if automatic mining is enabled, and false if it is not.
 
+`anvil_getBlobByHash`
+Returns the blob for a given a KZG commitment versionned hash.
+
+`anvil_getBlobsByTransactionHash`
+Returns the blobs for a given transaction hash.
+
+`anvil_getBlobSidecarsByBlockId`
+Returns the blob sidecars for a given block id.
+
 `anvil_mine`
 Mines a series of blocks.
 


### PR DESCRIPTION
Added descriptions for:
- `anvil_getBlobByHash`
- `anvil_getBlobsByTransactionHash`
- `anvil_getBlobSidecarsByBlockId`

to close foundry-rs/foundry#11838.