### PR TITLE
docs: Fix zsh autocompletion setup for macOS

### DIFF
--- a/vocs/docs/pages/config/shell-autocompletion.md
+++ b/vocs/docs/pages/config/shell-autocompletion.md
@@ -4,7 +4,7 @@ You can generate autocompletion shell scripts for `bash`, `elvish`, `fish`, `nus
 
 ### zsh
 
-First, ensure that the following is present somewhere in your `~/.zshrc` file (if not, add it):
+First, ensure that the following is present at the end in your `~/.zshrc` file (if not, add it):
 
 ```sh
 autoload -U compinit
@@ -22,9 +22,9 @@ anvil completions zsh | sudo tee /usr/local/share/zsh/site-functions/_anvil
 For macOS:
 
 ```sh
-forge completions zsh > /opt/homebrew/completions/zsh/_forge
-cast completions zsh > /opt/homebrew/completions/zsh/_cast
-anvil completions zsh > /opt/homebrew/completions/zsh/_anvil
+forge completions zsh > /opt/homebrew/share/zsh/site-functions/_forge
+cast completions zsh > /opt/homebrew/share/zsh/site-functions/_cast
+anvil completions zsh > /opt/homebrew/share/zsh/site-functions/_anvil
 ```
 
 ### fish


### PR DESCRIPTION
This PR addresses two issues in our [zsh autocompletion](https://getfoundry.sh/config/shell-autocompletion#zsh) documentation for macOS that prevent the feature from working.

## Problem:
1. Incorrect Autocompletion Path:
The current zsh autocompletion instructions for macOS incorrectly instruct to create the completion files in `/opt/homebrew/completions/zsh/`. This path is not included in `$fpath` within a modern Homebrew environment, causing the autocompletion setup to not work.

2. `Compinit` Execution Order:
The documentation currently advises placing the compinit initialization script "somewhere" in the ~/.zshrc file. This can cause conflicts when using frameworks like [OhMyZsh](https://ohmyz.sh/), which also manage zsh completions with different arguments.

## Solution:
1. Correct Autocompletion Path:
Update the directory to `/opt/homebrew/share/zsh/site-functions` as outlined in the [Homebrew Shell Completion documentation](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh). This change ensures the autocompletion to work correctly for users with modern homebrew configuration.

2. Specify Compinit Placement:
Instruct users to add autoload and compinit at the end of the ~/.zshrc file. This ensures our setup is the last executed and prevents other scripts or frameworks from overriding it.

By combining these two fixes, the autocompletion setup will now work as expected for macOS users with zsh and homebrew.