### PR TITLE
fix: redirect /dependencies

### DIFF
--- a/vocs/docs/public/_redirects
+++ b/vocs/docs/public/_redirects
@@ -57,6 +57,8 @@
 /guides/best-practices /guides/best-practices/writing-contracts
 /guides /guides/best-practices/writing-contracts
 
+/dependencies /guides/project-setup/dependencies
+
 # General pattern for simple cast commands
 
 


### PR DESCRIPTION
Hi team. Just found a minor broken link in the docs site. 

https://getfoundry.sh/guides/project-setup/soldeer
@> As explained here, 

redirects to https://getfoundry.sh/dependencies (broken). Correct should be https://getfoundry.sh/guides/project-setup/dependencies