### PR TITLE
docs: add complete Turnkey signer documentation

### DIFF
--- a/vocs/docs/pages/cast/reference/access-list.mdx
+++ b/vocs/docs/pages/cast/reference/access-list.mdx
@@ -223,6 +223,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/call.mdx
+++ b/vocs/docs/pages/cast/reference/call.mdx
@@ -286,6 +286,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/estimate.mdx
+++ b/vocs/docs/pages/cast/reference/estimate.mdx
@@ -232,6 +232,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/logs.mdx
+++ b/vocs/docs/pages/cast/reference/logs.mdx
@@ -181,6 +181,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/mktx.mdx
+++ b/vocs/docs/pages/cast/reference/mktx.mdx
@@ -236,6 +236,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/send.mdx
+++ b/vocs/docs/pages/cast/reference/send.mdx
@@ -246,6 +246,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/wallet/address.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/address.mdx
@@ -99,6 +99,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/wallet/list.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/list.mdx
@@ -34,6 +34,14 @@ Options:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          List accounts using Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
       --all
           List all configured accounts
 

--- a/vocs/docs/pages/cast/reference/wallet/private-key.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/private-key.mdx
@@ -103,6 +103,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/wallet/public-key.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/public-key.mdx
@@ -98,6 +98,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/wallet/sign-auth.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/sign-auth.mdx
@@ -153,6 +153,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/cast/reference/wallet/sign.mdx
+++ b/vocs/docs/pages/cast/reference/wallet/sign.mdx
@@ -121,6 +121,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/vocs/docs/pages/forge/reference/create.mdx
+++ b/vocs/docs/pages/forge/reference/create.mdx
@@ -397,6 +397,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 Verifier options:
       --verifier <VERIFIER>
           The contract verification provider to use

--- a/vocs/docs/pages/forge/reference/script.mdx
+++ b/vocs/docs/pages/forge/reference/script.mdx
@@ -394,6 +394,14 @@ Wallet options - remote:
           
           See: [https://cloud.google.com/kms/docs](https://cloud.google.com/kms/docs)
 
+      --turnkey
+          Use Turnkey.
+
+          Ensure the following environment variables are set:
+          TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, TURNKEY_ADDRESS.
+
+          See: [https://docs.turnkey.com/getting-started/quickstart](https://docs.turnkey.com/getting-started/quickstart)
+
 EVM options:
   -f, --fork-url <URL>
           Fetch state over a remote endpoint instead of starting from an empty


### PR DESCRIPTION
## Summary
- Add detailed documentation for the `--turnkey` flag across all Cast and Forge commands that support wallet operations
- Documentation now mirrors the full `--help` output from the Turnkey signer implementation

## Changes
Updated 14 command reference pages to include complete `--turnkey` flag documentation:
- Required environment variables: `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORGANIZATION_ID`, `TURNKEY_ADDRESS`
- Link to Turnkey quickstart documentation: https://docs.turnkey.com/getting-started/quickstart

## Related
- foundry-rs/foundry#12026 - Main Turnkey signer implementation PR

## Files Modified
**Cast commands (12 files):**
- cast/reference/access-list.mdx
- cast/reference/call.mdx
- cast/reference/estimate.mdx
- cast/reference/logs.mdx
- cast/reference/mktx.mdx
- cast/reference/send.mdx
- cast/reference/wallet/address.mdx
- cast/reference/wallet/list.mdx
- cast/reference/wallet/private-key.mdx
- cast/reference/wallet/public-key.mdx
- cast/reference/wallet/sign-auth.mdx
- cast/reference/wallet/sign.mdx

**Forge commands (2 files):**
- forge/reference/create.mdx
- forge/reference/script.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)