### PR TITLE
fix(sidebar): add missing links for Anvil and Chisel reference page

### DIFF
--- a/vocs/sidebar/anvil-cli-reference.ts
+++ b/vocs/sidebar/anvil-cli-reference.ts
@@ -2,6 +2,7 @@ import { SidebarItem } from "vocs";
 
 export const anvilCliReference: SidebarItem = {
     text: "Reference",
+    link: "/anvil/reference",
     collapsed: true,
     items: [
         { text: "anvil", link: "/anvil/reference/anvil" },

--- a/vocs/sidebar/chisel-cli-reference.ts
+++ b/vocs/sidebar/chisel-cli-reference.ts
@@ -2,6 +2,7 @@ import { SidebarItem } from "vocs";
 
 export const chiselCliReference: SidebarItem = {
     text: "Reference",
+    link: "/chisel/reference",
     collapsed: true,
     items: [
         { text: "chisel", link: "/chisel/reference/chisel" },


### PR DESCRIPTION
Fix #1699 (a further doc refactor may be relevant)

This change aims to make `/anvil/reference` and `/chisel/reference` pages accessible from the sidebar.

Now, in both sections, clicking on the `reference` link, in addition to displaying the dropdown menu, also shows the actual reference page.