### PR TITLE
chore: fix broken links

### DIFF
--- a/vocs/docs/pages/config/reference/inline-test-config.mdx
+++ b/vocs/docs/pages/config/reference/inline-test-config.mdx
@@ -84,11 +84,11 @@ contract MyInvariantTest is Test {
 }
 ```
 
-[Testing Reference]: ./testing.md
-[testing]: ./testing.md#runs
-[Max test rejects]: ./testing.md#max_test_rejects
-[Fuzz show logs]: ./testing.md#show_logs
-[Invariant runs]: ./testing.md#runs-1
-[Invariant depth]: ./testing.md#depth
-[Fail on revert]: ./testing.md#fail_on_revert
-[Invariant call override]: ./testing.md#call_override
+[Testing Reference]: ./testing
+[testing]: ./testing#runs
+[Max test rejects]: ./testing#max_test_rejects
+[Fuzz show logs]: ./testing#show_logs
+[Invariant runs]: ./testing#runs-1
+[Invariant depth]: ./testing#depth
+[Fail on revert]: ./testing#fail_on_revert
+[Invariant call override]: ./testing#call_override

--- a/vocs/docs/pages/guides/forking-mainnet-with-cast-anvil.md
+++ b/vocs/docs/pages/guides/forking-mainnet-with-cast-anvil.md
@@ -86,7 +86,7 @@ cast call $DAI \
 
 ::::
 
-[anvil]: ../reference/anvil/
-[cast]: ../cast/reference/
-[cast-call]: ../cast/reference/call.md
-[cast-send]: ../cast/reference/send.md
+[anvil]: /anvil/overview
+[cast]: /cast/overview
+[cast-call]: /cast/reference/call
+[cast-send]: /cast/reference/send

--- a/vocs/docs/pages/misc/faq.md
+++ b/vocs/docs/pages/misc/faq.md
@@ -161,7 +161,7 @@ A common layout may look like:
 
 Where the Foundry workspace is in `./contracts`, but packages in `./contracts/node_modules` are symlinked to `./node_modules`.
 
-When running `forge build` in `./contracts/node_modules`, this can lead to an error like:
+When running [`forge build`][forge-build] in `./contracts/node_modules`, this can lead to an error like:
 
 ```console
 error[6275]: ParserError: Source "node_modules/@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol" not found: File outside of allowed directories. The following are allowed: "<repo>/contracts", "<repo>/contracts/contracts", "<repo>/contracts/lib".
@@ -195,7 +195,7 @@ It has been [reported](https://github.com/foundry-rs/foundry/issues/3268) that o
 
 ### Connection refused when running `forge build`
 
-If you're unable to access github URLs called by `forge build`, you will see an error like
+If you're unable to access github URLs called by [`forge build`][forge-build], you will see an error like
 
 ```console
 Error:
@@ -204,18 +204,18 @@ error sending request for url (https://raw.githubusercontent.com/roynalnaruto/so
 
 Connection failed because access to the URL from your location may be restricted. To solve this, you should set proxy.
 
-You could run `export http_proxy=http://127.0.0.1:7890 https_proxy=http://127.0.0.1:7890` first in the terminal then you will `forge build` successfully.
+You could run `export http_proxy=http://127.0.0.1:7890 https_proxy=http://127.0.0.1:7890` first in the terminal then you will [`forge build`][forge-build] successfully.
 
 ### I'm getting `[NotActivated] EvmError: NotActivated` error in my tests.
 
 This error refers to an EVM version mismatch, make sure the `evm_version` configuration is inline with the test (forked chain) you're using (similar for errors like `prevrandao not set`). See [`evm_version` configuration](/config/reference/solidity-compiler#evm_version)
 
 [tg-support]: https://t.me/foundry_support
-[forge-test]: ./forge/reference/test.md
-[traces]: ./forge/traces.md
-[config-solc]: ./config/reference/solidity-compiler.md#solc_version
-[config]: ./config/
-[forge-build]: ./forge/reference/build.md
-[console-log]: ./reference/forge-std/console-log.md
+[forge-test]: /forge/tests/overview
+[traces]: /forge/tests/traces
+[config-solc]: /config/reference/solidity-compiler#solc_version
+[config]: /config/overview
+[forge-build]: /forge/reference/build
+[console-log]: /reference/forge-std/console-log
 [forge-std]: https://github.com/foundry-rs/forge-std
 [dstestplus]: https://github.com/transmissions11/solmate/blob/19a4f345970ed39ee6369f343d145e0d4071c18a/src/test/utils/DSTestPlus.sol#L10

--- a/vocs/docs/pages/reference/cheatcodes/assume.mdx
+++ b/vocs/docs/pages/reference/cheatcodes/assume.mdx
@@ -42,9 +42,8 @@ function testSomethingElse(uint256 a) public {
 ### SEE ALSO
 
 Forge Standard Library
+[`bound`][forge-std-bound]
 
-[`bound`](/reference/forge-std/bound.mdx)
-
-[max-test-rejects]: ../config/reference/testing.md#max_test_rejects
-[forge-std-bound]: ../reference/forge-std/bound.md
+[max-test-rejects]: /config/reference/testing#max_test_rejects
+[forge-std-bound]: /reference/forge-std/bound
 [filtering-guide]: https://altsysrq.github.io/proptest-book/proptest/tutorial/filtering.html#filtering

--- a/vocs/docs/pages/reference/cheatcodes/difficulty.mdx
+++ b/vocs/docs/pages/reference/cheatcodes/difficulty.mdx
@@ -20,4 +20,4 @@ emit log_uint(block.difficulty); // 25
 ```
 
 
-[prevrandao]: ./prevrandao.md
+[prevrandao]: ./prevrandao

--- a/vocs/docs/pages/reference/cheatcodes/get-code.mdx
+++ b/vocs/docs/pages/reference/cheatcodes/get-code.mdx
@@ -70,4 +70,4 @@ Forge Standard Library
 [`deployCode`](/reference/forge-std/deployCode.mdx)
 [`deployCodeTo`](/reference/forge-std/deployCodeTo.mdx)
 
-[forge-std]: ../reference/forge-std
+[forge-std]: /reference/forge-std/overview

--- a/vocs/docs/pages/reference/cheatcodes/get-deployed-code.mdx
+++ b/vocs/docs/pages/reference/cheatcodes/get-deployed-code.mdx
@@ -66,4 +66,4 @@ Forge Standard Library
 [`getCode`](/reference/cheatcodes/get-code.mdx)
 [`etch`](/reference/cheatcodes/etch.mdx)
 
-[forge-std]: ../reference/forge-std
+[forge-std]: /reference/forge-std/overview

--- a/vocs/docs/pages/reference/cheatcodes/prevrandao.mdx
+++ b/vocs/docs/pages/reference/cheatcodes/prevrandao.mdx
@@ -20,4 +20,4 @@ emit log_uint(block.prevrandao); // 42
 ```
 
 
-[prevrandao]: ./difficulty.md
+[prevrandao]: ./difficulty


### PR DESCRIPTION
<details>
<summary>Error logs</summary>
<img width="930" height="630" alt="image" src="https://github.com/user-attachments/assets/320ce596-babd-40a3-a8e9-348ec8e1bdfa" />
</details>

This PR fixes all the broken links, allowing `bun preview` to run successfully.