### PR TITLE
Fix minor typo in key-management.md

### DIFF
--- a/vocs/docs/pages/guides/best-practices/key-management.md
+++ b/vocs/docs/pages/guides/best-practices/key-management.md
@@ -8,7 +8,7 @@ Script execution requires a private key to send transactions. This key controls 
 
 ### Using Hardware Wallet
 
-Hardware wallets such as Ledger and Trezor store seed phrases in a secure enclave. Forge can send a raw transaction to the wallet, and the wallet will sign the transaction. The signed transaction is returned to forge and broadcaster. This way, private keys never leave the hardware wallet, making this a very secure approach. To use a hardware wallet with scripts, see the `--ledger` and `--trezor` [flags](/forge/reference/script).
+Hardware wallets such as Ledger and Trezor store seed phrases in a secure enclave. Forge can send a raw transaction to the wallet, and the wallet will sign the transaction. The signed transaction is returned to forge and broadcasted. This way, private keys never leave the hardware wallet, making this a very secure approach. To use a hardware wallet with scripts, see the `--ledger` and `--trezor` [flags](/forge/reference/script).
 
 ### Using Private Keys
 


### PR DESCRIPTION

<img width="731" height="208" alt="image" src="https://github.com/user-attachments/assets/393204c8-7c3e-432e-b383-abc9f30588d6" />


Page: https://getfoundry.sh/guides/best-practices/key-management

Typo: "The signed transaction is returned to forge and **_broadcaster_**."

Fix: _broadcaster_ -> "broadcasted"