### PR TITLE
Update hello_foundry/forge-build

### DIFF
--- a/vocs/docs/snippets/output/hello_foundry/forge-build
+++ b/vocs/docs/snippets/output/hello_foundry/forge-build
@@ -6,11 +6,7 @@ $ forge build
 Compiling 23 files with Solc 0.8.33
 Solc 0.8.33 finished in 542.37ms
 Compiler run successful with warnings:
-Warning (2424): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
-   --> lib/forge-std/src/StdStorage.sol:297:13:
-    |
-297 |             assembly {
-    |             ^ (Relevant source part starts here and spans across multiple lines).
+// a lot of warnings here, is it okay?
 
 Warning (2424): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
    --> lib/forge-std/src/StdStorage.sol:404:9:


### PR DESCRIPTION
Dear friends, I want to notify you about the huge stack of warning messages reflected in the official docs, which causes a flood on the ["Project setup" web page](https://getfoundry.sh/guides/project-setup/creating-a-new-project#build-the-project). 
I suppose this should be hidden, because now it looks like a build output with lots of warnings rather than short code example? 
Kindly ask you to check on this.

<img width="973" height="763" alt="image" src="https://github.com/user-attachments/assets/4da2b4b2-9f19-4135-9418-893f9f1eacbd" />
