### PR TITLE
fix: update outdated test contract address

### DIFF
--- a/vocs/docs/pages/forge/tests/writing-tests.md
+++ b/vocs/docs/pages/forge/tests/writing-tests.md
@@ -52,9 +52,9 @@ In this way you know exactly what reverted and with which error:
 
 <br></br>
 
-Tests are deployed to `0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84`. If you deploy a contract within your test, then
-`0xb4c...7e84` will be its deployer. If the contract deployed within a test gives special permissions to its deployer,
-such as `Ownable.sol`'s `onlyOwner` modifier, then the test contract `0xb4c...7e84` will have those permissions.
+Tests are deployed to `0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496`. If you deploy a contract within your test, then
+`0x7FA...1496` will be its deployer. If the contract deployed within a test gives special permissions to its deployer,
+such as `Ownable.sol`'s `onlyOwner` modifier, then the test contract `0x7FA...1496` will have those permissions.
 
 > ⚠️ **Note**
 >


### PR DESCRIPTION
Following the instructions in the book I got the address `0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496` instead of `0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84` when trying to use the test contract address. It seems like this was a result of https://github.com/foundry-rs/foundry/pull/3680 but the book wasn't updated in full in #702. Additionally the address used in the book doesn't reflect the address found [here](
https://github.com/foundry-rs/foundry/blob/3374adb64d9e23ee8fca7e16906df4c91872df0c/crates/evm/core/src/constants.rs#L31-L34).


I don't fully understand everything to do with test setup yet, so not sure if this really is a simple find/replace, but everywhere the 0xb4c address was used, it seems like the 0x7FA address is now used, so this change seems appropriate to me.
