### PR TITLE
docs: update rpc url to ethereum.reth.rs

### DIFF
--- a/vocs/docs/pages/anvil/overview.md
+++ b/vocs/docs/pages/anvil/overview.md
@@ -16,7 +16,7 @@ To use Anvil, simply type `anvil`. To fork against a live Ethereum network run `
 Let's fork Ethereum mainnet at the latest block:
 
 ```bash
-anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+anvil --fork-url https://ethereum.reth.rs/rpc
 ```
 
 ```bash
@@ -106,5 +106,5 @@ Since the advent of EIP-7702, Anvil's default accounts have been delegated to dr
 This can negatively impact developer experience when users are running Anvil in fork mode and are making RPC calls that involve one of the default anvil accounts. To avoid this issue, use a different mnemonic when starting Anvil:
 
 ```bash
-anvil --mnemonic "<custom mnemonic>" --fork-url https://reth-ethereum.ithaca.xyz/rpc
+anvil --mnemonic "<custom mnemonic>" --fork-url https://ethereum.reth.rs/rpc
 ```

--- a/vocs/docs/pages/cast/overview.md
+++ b/vocs/docs/pages/cast/overview.md
@@ -18,19 +18,19 @@ Here are a few examples of what you can do:
 **Check the latest block on Ethereum Mainnet**:
 
 ```sh
-cast block-number --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast block-number --rpc-url https://ethereum.reth.rs/rpc
 ```
 
 **Check the Ether balance of `vitalik.eth`**
 
 ```sh
-cast balance vitalik.eth --ether --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast balance vitalik.eth --ether --rpc-url https://ethereum.reth.rs/rpc
 ```
 
 **Replay and trace a transaction**
 
 ```sh
-cast run 0x9c32042f5e997e27e67f82583839548eb19dc78c4769ad6218657c17f2a5ed31 --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast run 0x9c32042f5e997e27e67f82583839548eb19dc78c4769ad6218657c17f2a5ed31 --rpc-url https://ethereum.reth.rs/rpc
 ```
 
 Optionally, pass `--etherscan-api-key <API_KEY>` to decode transaction traces using verified source maps, providing more detailed and human-readable information.

--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -142,7 +142,7 @@ forge init Counter
 # Run tests for the Counter contract
 forge test
 # You can run tests against chain state by forking
-forge test --fork-url https://reth-ethereum.ithaca.xyz/rpc
+forge test --fork-url https://ethereum.reth.rs/rpc
 ```
 
 ```bash [Deploy contract]
@@ -174,7 +174,7 @@ anvil
 
 ```bash [Forking mainnet]
 # Fork latest mainnet state
-anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+anvil --fork-url https://ethereum.reth.rs/rpc
 ```
 
 ```bash [Load and Dump State]
@@ -194,7 +194,7 @@ anvil --state ./path/to/state-file
 # Perform an `eth_call` on a contract to read balances
 cast call 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
 "balanceOf(address)" 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
---rpc-url https://reth-ethereum.ithaca.xyz/rpc
+--rpc-url https://ethereum.reth.rs/rpc
 ```
 
 ```bash [Send a transaction]
@@ -211,7 +211,7 @@ echo "\nBalance Of 0xf39F:" && cast balance 0xf39Fd6e51aad88F6F4ce6aB8827279cffF
 ```bash [Call JSON-RPC methods]
 # Calls the `eth_getHeaderByNumber` RPC method with the number param in hexadecimal
 # cast 2h converts integer to hex
-cast rpc eth_getHeaderByNumber $(cast 2h 22539851) --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast rpc eth_getHeaderByNumber $(cast 2h 22539851) --rpc-url https://ethereum.reth.rs/rpc
 ```
 
 :::

--- a/vocs/docs/pages/introduction/getting-started.mdx
+++ b/vocs/docs/pages/introduction/getting-started.mdx
@@ -43,7 +43,7 @@ forge build
 forge test
 
 # Run tests against live chain state by forking
-forge test --fork-url https://reth-ethereum.ithaca.xyz/rpc
+forge test --fork-url https://ethereum.reth.rs/rpc
 ```
 
 #### Deploy contracts
@@ -84,7 +84,7 @@ anvil
 
 ```bash
 # Fork latest mainnet state for testing
-anvil --fork-url https://reth-ethereum.ithaca.xyz/rpc
+anvil --fork-url https://ethereum.reth.rs/rpc
 ```
 
 `anvil` comes up with other advanced capabilities such as:
@@ -104,12 +104,12 @@ Cast is your Swiss army knife for interacting with Ethereum applications from th
 
 ```bash
 # Check ETH balance
-cast balance vitalik.eth --ether --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast balance vitalik.eth --ether --rpc-url https://ethereum.reth.rs/rpc
 
 # Call a contract function to read data
 cast call 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
 "balanceOf(address)" 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 \
---rpc-url https://reth-ethereum.ithaca.xyz/rpc
+--rpc-url https://ethereum.reth.rs/rpc
 ```
 
 #### Send transactions
@@ -126,10 +126,10 @@ cast send 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --value 10000000 --private-
 
 ```bash
 # Call JSON-RPC methods directly
-cast rpc eth_getHeaderByNumber $(cast 2h 22539851) --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast rpc eth_getHeaderByNumber $(cast 2h 22539851) --rpc-url https://ethereum.reth.rs/rpc
 
 # Get latest block number
-cast block-number --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+cast block-number --rpc-url https://ethereum.reth.rs/rpc
 ```
 
 Learn more about `cast` [here](/cast/overview).


### PR DESCRIPTION
Updates the default RPC URL from `reth-ethereum.ithaca.xyz` to `ethereum.reth.rs`.

Same change as https://github.com/paradigmxyz/reth/pull/21574