### PR TITLE
chore: update RPC URLs from ithaca.xyz to reth.rs

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -5,7 +5,7 @@ set -eo pipefail
 # the commands and outputs into files that are easily
 # includeable in the book.
 
-ETH_RPC_URL="${ETH_RPC_URL:=https://reth-ethereum.ithaca.xyz/rpc}"
+ETH_RPC_URL="${ETH_RPC_URL:=https://ethereum.reth.rs/rpc}"
 SNIPPETS_DIR="$(realpath vocs/docs/snippets)"
 OUTPUT_DIR="$(realpath $SNIPPETS_DIR/output)"
 ROOT="$(dirname "$(dirname "$(realpath "$0")")")"

--- a/vocs/docs/snippets/output/cast/cast-call
+++ b/vocs/docs/snippets/output/cast/cast-call
@@ -1,6 +1,6 @@
 // [!region all]
 // [!region command]
-$ cast call 0x6b175474e89094c44da98b954eedeac495271d0f "totalSupply()(uint256)" --rpc-url https://reth-ethereum.ithaca.xyz/rpc
+$ cast call 0x6b175474e89094c44da98b954eedeac495271d0f "totalSupply()(uint256)" --rpc-url https://ethereum.reth.rs/rpc
 // [!endregion command]
 // [!region output]
 4363741229891681909323642622 [4.363e27]


### PR DESCRIPTION
## Summary
Updates RPC endpoint URLs from `ithaca.xyz` to `reth.rs`.

## Changes
- `reth-ethereum.ithaca.xyz/rpc` -> `ethereum.reth.rs/rpc`

Mirrors paradigmxyz/reth#21574