### PR TITLE
Fix: correct editLink path by removing `vocs/` prefix

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     sources: [McpSource.github({ repo: "foundry-rs/foundry" })],
   },
   editLink: {
-    link: "https://github.com/foundry-rs/book/edit/master/vocs/src/pages/:path",
+    link: "https://github.com/foundry-rs/book/edit/master/src/pages/:path",
     text: "Suggest changes on GitHub",
   },
   logoUrl: "/foundry-logo.png",


### PR DESCRIPTION
Closes #1767 

- `suggest changes on Github` link was giving 404, fixed it by removing `vocs/` prefix from path.