### PR TITLE
docs: add incorrect ERC721 lint entry

### DIFF
--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -16,6 +16,7 @@ The linter checks for:
 - Incorrect shift operations
 - Unchecked external calls
 - Divide-before-multiply bugs
+- Incorrect ERC721 interface signatures
 - Unsafe typecasts
 - Naming convention violations
 - Unused imports


### PR DESCRIPTION
## Summary
- add the incorrect ERC721 interface lint to the Forge linting overview page
- ensure the  page mentions the new lint so Foundry's docs validation recognizes it

## Context
- companion docs PR for foundry-rs/foundry#14412
- this unblocks the  check for 

## Testing
- not run locally; content-only MDX change