### PR TITLE
docs: add incorrect ERC20 lint entry

### DIFF
--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -17,6 +17,7 @@ The linter checks for:
 - Unchecked external calls
 - Divide-before-multiply bugs
 - Incorrect ERC721 interface signatures
+- Incorrect ERC20 interface definitions
 - Unsafe typecasts
 - Naming convention violations
 - Unused imports


### PR DESCRIPTION
## Summary
- add the incorrect ERC20 interface lint to the Forge linting overview page
- ensure the page mentions the new lint so Foundry's docs validation recognizes it

## Context
- companion docs PR for foundry-rs/foundry#14428

## Testing
- not run locally; content-only MDX change