### PR TITLE
chore(deps): bump vocs + waku, remove unused mermaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "fetch-benchmarks": "bun scripts/fetch-benchmarks.ts"
   },
   "dependencies": {
-    "mermaid": "^11.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.2",
-    "vocs": "https://pkg.pr.new/wevm/vocs@1337e71",
-    "waku": "1.0.0-alpha.2"
+    "vocs": "https://pkg.pr.new/wevm/vocs@e754e7a",
+    "waku": "1.0.0-alpha.6"
   },
   "devDependencies": {
     "@types/bun": "^1.3.12",


### PR DESCRIPTION
## Changes

- **vocs**: `pkg.pr.new/wevm/vocs@1337e71` (Feb 9, 2026) → `@e754e7a` (Apr 28, 2026, latest on `next` branch).
- **waku**: `1.0.0-alpha.2` → `1.0.0-alpha.6` (matches the version vocs `next` was tested against — see [wevm/vocs@8a74064](https://github.com/wevm/vocs/commit/8a74064) "update typescript to v6, waku to alpha.6, fix twoslash compat").
- **mermaid**: removed. Not imported anywhere, no `mermaid` blocks in any `.mdx`, no reference in [vocs.config.ts](file:///Users/zerosnacks/Projects/foundry-book/vocs.config.ts).