### PR TITLE
chore: remove tailwind in favor of plain CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "mermaid": "^11.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "tailwindcss": "^4.2.2",
     "vocs": "https://pkg.pr.new/wevm/vocs@1337e71",
     "waku": "1.0.0-alpha.2"
   },

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1,3 +1,42 @@
-@import "tailwindcss" important;
+.foundry-banner {
+  max-width: 600px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 0.75rem;
+}
 
-@source "./";
+.sponsor-logo {
+  height: 40px;
+  filter: brightness(0);
+}
+
+.dark .sponsor-logo {
+  filter: invert(1);
+}
+
+@media (max-width: 767px) {
+  .home-install-snippet {
+    margin-left: calc(-1 * var(--vocs-content_horizontalPadding, 24px));
+    margin-right: calc(-1 * var(--vocs-content_horizontalPadding, 24px));
+  }
+
+  .home-install-snippet [data-v-code-container] {
+    border-radius: 0 !important;
+  }
+
+  .home-install-snippet pre,
+  .home-install-snippet code,
+  .home-install-snippet .line {
+    white-space: pre-wrap !important;
+    word-break: break-all !important;
+  }
+
+  .home-install-snippet pre {
+    overflow-x: hidden !important;
+  }
+
+  .home-install-snippet code {
+    display: block !important;
+  }
+}

--- a/src/pages/components/Sponsors.tsx
+++ b/src/pages/components/Sponsors.tsx
@@ -12,7 +12,7 @@ function SponsorCard({ sponsor }: { sponsor: Sponsor }) {
     >
       <img
         alt={sponsor.name}
-        className="h-[40px] brightness-0 dark:invert"
+        className="sponsor-logo"
         src={sponsor.image}
       />
     </a>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -12,10 +12,10 @@ import { HomePage, Cards, Card } from 'vocs'
 import { SponsorCards } from './components/Sponsors'
 
 <HomePage.Root>
-  <img src="/foundry-banner.png" alt="Foundry" className="max-w-[600px] w-full mx-auto rounded-xl" />
+  <img src="/foundry-banner.png" alt="Foundry" className="foundry-banner" />
   <HomePage.Tagline>Blazing fast smart contract development toolkit</HomePage.Tagline>
 
-<div className="max-md:-mx-[var(--vocs-content_horizontalPadding,24px)] max-md:[&_[data-v-code-container]]:!rounded-none max-md:[&_pre]:!whitespace-pre-wrap max-md:[&_pre]:!overflow-x-hidden max-md:[&_pre]:!break-all max-md:[&_code]:!block max-md:[&_code]:!whitespace-pre-wrap max-md:[&_code]:!break-all max-md:[&_.line]:!whitespace-pre-wrap max-md:[&_.line]:!break-all">
+<div className="home-install-snippet">
 ```bash
 curl -L https://foundry.paradigm.xyz | bash && foundryup
 ```


### PR DESCRIPTION
Removes `tailwindcss` as a top-level dependency since it was only used in two files for a handful of utilities.

## Changes

- **[src/pages/_root.css](file:///src/pages/_root.css)**: dropped `@import \"tailwindcss\"` and `@source \"./\";`. Added plain CSS classes for the foundry banner, sponsor logos, and the responsive home install snippet (with mobile media queries).
- **[src/pages/components/Sponsors.tsx](file:///src/pages/components/Sponsors.tsx)**: replaced `h-[40px] brightness-0 dark:invert` on the `<img>` with the new `.sponsor-logo` class.
- **[src/pages/index.mdx](file:///src/pages/index.mdx)**: replaced the inline tailwind utilities (`max-w-[600px] w-full mx-auto rounded-xl`, plus the lengthy `max-md:[&_…]:!…` chain) with `.foundry-banner` and `.home-install-snippet`.
- **`package.json`**: removed `tailwindcss`.

The `vocs:` prefixed classes (`vocs:flex`, `vocs:grid`, etc.) are kept — those come from vocs's own internal tailwind setup, not this project's dependency.