### PR TITLE
docs: add lint rules reference page

### DIFF
--- a/sidebar/forge-cli-reference.ts
+++ b/sidebar/forge-cli-reference.ts
@@ -74,6 +74,7 @@ export const forgeCliReference: SidebarItem = {
                 { text: "forge eip712", link: "/reference/forge/eip712" },
                 { text: "forge fmt", link: "/reference/forge/fmt" },
                 { text: "forge lint", link: "/reference/forge/lint" },
+                { text: "Lint Rules", link: "/reference/forge/lint-rules" },
                 { text: "forge script", link: "/reference/forge/script" },
                 { text: "forge selectors", link: "/reference/forge/selectors" },
                 { text: "forge selectors cache", link: "/reference/forge/selectors/cache" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -135,4 +135,4 @@ Add linting to your CI pipeline:
   run: forge lint
 ```
 
-See the [linter reference](/config/reference/linter) for all configuration options.
+See the [linter reference](/config/reference/linter) for all configuration options and the [lint rules reference](/reference/forge/lint-rules) for a complete list of available rules.

--- a/src/pages/reference/forge/lint-rules.mdx
+++ b/src/pages/reference/forge/lint-rules.mdx
@@ -1,0 +1,68 @@
+---
+description: Reference of all built-in forge lint rules.
+---
+
+## Lint Rules Reference
+
+All lint rules supported by `forge lint`. Each rule has a unique ID that can be used with [`--only-lint`](/reference/forge/lint), [`exclude_lints`](/config/reference/linter), and [inline suppression directives](/forge/linting#inline-suppression).
+
+### High
+
+| ID | Description |
+|---|---|
+| `incorrect-shift` | The order of arguments in a shift operation is incorrect |
+| `unchecked-call` | Low-level calls should check the success return value |
+| `erc20-unchecked-transfer` | ERC20 `transfer` and `transferFrom` calls should check the return value |
+| `rtlo` | Unicode bidirectional override character can hide malicious code |
+
+### Med
+
+| ID | Description |
+|---|---|
+| `divide-before-multiply` | Multiplication should occur before division to avoid loss of precision |
+| `incorrect-erc20-interface` | Incorrect ERC20 function interface |
+| `incorrect-erc721-interface` | Incorrect ERC721 function interface |
+| `unsafe-typecast` | Typecasts that can truncate values should be checked |
+| `boolean-cst` | Misuse of a boolean constant |
+
+### Low
+
+| ID | Description |
+|---|---|
+| `block-timestamp` | Usage of `block.timestamp` in a comparison may be manipulated by validators |
+| `missing-zero-check` | Address parameter is used in a state write or value transfer without a zero-address check |
+
+### Info
+
+| ID | Description |
+|---|---|
+| `boolean-equal` | Boolean comparisons to constants should be simplified |
+| `interface-file-naming` | Interface file names should be prefixed with `I` |
+| `interface-naming` | Interface names should be prefixed with `I` |
+| `mixed-case-function` | Function names should use mixedCase |
+| `mixed-case-variable` | Mutable variables should use mixedCase |
+| `multi-contract-file` | Prefer having only one contract, interface, or library per file |
+| `named-struct-fields` | Prefer initializing structs with named fields |
+| `pascal-case-struct` | Structs should use PascalCase |
+| `pragma-inconsistent` | Inconsistent Solidity pragma version requirements across the project |
+| `screaming-snake-case-const` | Constants should use SCREAMING_SNAKE_CASE |
+| `screaming-snake-case-immutable` | Immutables should use SCREAMING_SNAKE_CASE |
+| `too-many-digits` | Numeric literal with many digits is error-prone; consider using underscores |
+| `unaliased-plain-import` | Use named imports `{A, B}` or alias `import "..." as X` |
+| `unsafe-cheatcode` | Usage of unsafe cheatcodes that can perform dangerous operations |
+| `unused-import` | Unused imports should be removed |
+
+### Gas
+
+| ID | Description |
+|---|---|
+| `asm-keccak256` | Use of inefficient hashing mechanism; consider using inline assembly |
+| `could-be-immutable` | State variable could be declared immutable |
+| `custom-errors` | Prefer using custom errors on revert and require calls |
+| `unused-state-variables` | State variable is never used |
+
+### Code Size
+
+| ID | Description |
+|---|---|
+| `unwrapped-modifier-logic` | Wrap modifier logic to reduce code size |


### PR DESCRIPTION
## Summary

The Foundry book documents the `forge lint` CLI flags and the `[lint]` config section, but has **no page listing the actual lint rules** by ID. Users landing on the book (e.g. via the `asm-keccak256` help link) get a 404.

This PR adds a dedicated **Lint Rules Reference** page enumerating all 30 built-in rules, grouped by severity, with their IDs and descriptions—sourced directly from the `declare_forge_lint!` declarations in `crates/lint/`.

## Changes

| File | Change |
|---|---|
| `src/pages/reference/forge/lint-rules.mdx` | **New** — full rules table (high, med, low, info, gas, code-size) |
| `sidebar/forge-cli-reference.ts` | Register `Lint Rules` entry under Utility Commands |
| `src/pages/forge/linting.mdx` | Add cross-link to the new rules reference |

Fixes the missing doc for `asm-keccak256` and all other lint rule IDs.