### PR TITLE
docs: add forge lint reference pages

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -35,7 +35,80 @@ const docs = [
       { text: "Debugging", link: "/forge/debugging" },
       { text: "Gas Tracking", link: "/forge/gas-tracking" },
       { text: "Formatting", link: "/forge/formatting" },
-      { text: "Linting", link: "/forge/linting" },
+      {
+        text: "Linting",
+        link: "/forge/linting",
+        collapsed: true,
+        items: [
+          {
+            text: "High severity",
+            collapsed: true,
+            items: [
+              { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },
+              { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },
+              { text: "rtlo", link: "/forge/linting/rtlo" },
+              { text: "unchecked-call", link: "/forge/linting/unchecked-call" },
+            ],
+          },
+          {
+            text: "Medium severity",
+            collapsed: true,
+            items: [
+              { text: "boolean-cst", link: "/forge/linting/boolean-cst" },
+              { text: "divide-before-multiply", link: "/forge/linting/divide-before-multiply" },
+              { text: "incorrect-erc20-interface", link: "/forge/linting/incorrect-erc20-interface" },
+              { text: "incorrect-erc721-interface", link: "/forge/linting/incorrect-erc721-interface" },
+              { text: "unsafe-typecast", link: "/forge/linting/unsafe-typecast" },
+            ],
+          },
+          {
+            text: "Low severity",
+            collapsed: true,
+            items: [
+              { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
+              { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
+            ],
+          },
+          {
+            text: "Informational",
+            collapsed: true,
+            items: [
+              { text: "boolean-equal", link: "/forge/linting/boolean-equal" },
+              { text: "interface-file-naming", link: "/forge/linting/interface-file-naming" },
+              { text: "interface-naming", link: "/forge/linting/interface-naming" },
+              { text: "mixed-case-function", link: "/forge/linting/mixed-case-function" },
+              { text: "mixed-case-variable", link: "/forge/linting/mixed-case-variable" },
+              { text: "multi-contract-file", link: "/forge/linting/multi-contract-file" },
+              { text: "named-struct-fields", link: "/forge/linting/named-struct-fields" },
+              { text: "pascal-case-struct", link: "/forge/linting/pascal-case-struct" },
+              { text: "pragma-inconsistent", link: "/forge/linting/pragma-inconsistent" },
+              { text: "screaming-snake-case-const", link: "/forge/linting/screaming-snake-case-const" },
+              { text: "screaming-snake-case-immutable", link: "/forge/linting/screaming-snake-case-immutable" },
+              { text: "too-many-digits", link: "/forge/linting/too-many-digits" },
+              { text: "unaliased-plain-import", link: "/forge/linting/unaliased-plain-import" },
+              { text: "unsafe-cheatcode", link: "/forge/linting/unsafe-cheatcode" },
+              { text: "unused-import", link: "/forge/linting/unused-import" },
+            ],
+          },
+          {
+            text: "Gas optimization",
+            collapsed: true,
+            items: [
+              { text: "asm-keccak256", link: "/forge/linting/asm-keccak256" },
+              { text: "could-be-immutable", link: "/forge/linting/could-be-immutable" },
+              { text: "custom-errors", link: "/forge/linting/custom-errors" },
+              { text: "unused-state-variables", link: "/forge/linting/unused-state-variables" },
+            ],
+          },
+          {
+            text: "Code size",
+            collapsed: true,
+            items: [
+              { text: "unwrapped-modifier-logic", link: "/forge/linting/unwrapped-modifier-logic" },
+            ],
+          },
+        ],
+      },
     ],
   },
   {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -136,3 +136,58 @@ Add linting to your CI pipeline:
 ```
 
 See the [linter reference](/config/reference/linter) for all configuration options.
+### Lint reference
+
+Every lint emitted by `forge lint` has its own page describing what it flags, why it
+matters, and how to fix it. Use the index below to jump to a specific lint, or use the
+navigation on the right to browse by severity.
+
+#### High severity
+
+- [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
+- [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.
+- [`rtlo`](/forge/linting/rtlo) — Flags the presence of Unicode bidirectional override characters in source code, which can be used to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).
+- [`unchecked-call`](/forge/linting/unchecked-call) — Flags low-level calls (`call`, `delegatecall`, `staticcall`, `callcode`) whose `success` return value is ignored.
+
+#### Medium severity
+
+- [`boolean-cst`](/forge/linting/boolean-cst) — Flags expressions where a boolean constant (`true`/`false`) is used as a control-flow condition or operand of a boolean operator, which usually indicates dead code or a leftover debug toggle.
+- [`divide-before-multiply`](/forge/linting/divide-before-multiply) — Flags arithmetic expressions where division is performed before multiplication, which can cause unintended precision loss in integer arithmetic.
+- [`incorrect-erc20-interface`](/forge/linting/incorrect-erc20-interface) — Flags interfaces or contracts whose function signatures match an ERC20 method by name and parameters but use the wrong return type.
+- [`incorrect-erc721-interface`](/forge/linting/incorrect-erc721-interface) — Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by name and parameters but use the wrong return type.
+- [`unsafe-typecast`](/forge/linting/unsafe-typecast) — Flags explicit numeric typecasts that can silently truncate or alter the value.
+
+#### Low severity
+
+- [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
+- [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
+
+#### Informational
+
+- [`boolean-equal`](/forge/linting/boolean-equal) — Flags expressions of the form `x == true`, `x == false`, `x != true`, `x != false`, which can be simplified.
+- [`interface-file-naming`](/forge/linting/interface-file-naming) — Flags Solidity files whose only top-level declaration is an interface but whose filename is not prefixed with `I`.
+- [`interface-naming`](/forge/linting/interface-naming) — Flags `interface` declarations whose names are not prefixed with `I`.
+- [`mixed-case-function`](/forge/linting/mixed-case-function) — Flags function names that do not follow `mixedCase`.
+- [`mixed-case-variable`](/forge/linting/mixed-case-variable) — Flags mutable variable names (locals, parameters, mutable state) that do not follow `mixedCase`.
+- [`multi-contract-file`](/forge/linting/multi-contract-file) — Flags source files that declare more than one top-level contract, interface, or library.
+- [`named-struct-fields`](/forge/linting/named-struct-fields) — Flags struct construction expressions that pass fields positionally instead of by name.
+- [`pascal-case-struct`](/forge/linting/pascal-case-struct) — Flags struct definitions whose names do not follow `PascalCase`.
+- [`pragma-inconsistent`](/forge/linting/pragma-inconsistent) — Flags projects whose source files declare incompatible or differently-shaped Solidity version pragmas.
+- [`screaming-snake-case-const`](/forge/linting/screaming-snake-case-const) — Flags `constant` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
+- [`screaming-snake-case-immutable`](/forge/linting/screaming-snake-case-immutable) — Flags `immutable` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
+- [`too-many-digits`](/forge/linting/too-many-digits) — Flags numeric literals containing five or more consecutive zeros, which are easy to misread.
+- [`unaliased-plain-import`](/forge/linting/unaliased-plain-import) — Flags `import "path";` statements that pull in every top-level symbol from another file without an alias.
+- [`unsafe-cheatcode`](/forge/linting/unsafe-cheatcode) — Flags use of Foundry cheatcodes that perform dangerous side effects (filesystem access, network activity, environment variable reads, etc.) so they cannot slip into production code unnoticed.
+- [`unused-import`](/forge/linting/unused-import) — Flags imported symbols (or whole import statements) whose imported names are not referenced anywhere in the source unit.
+
+#### Gas optimization
+
+- [`asm-keccak256`](/forge/linting/asm-keccak256) — Flags calls to the high-level `keccak256(...)` builtin that can be cheaply rewritten with inline assembly.
+- [`could-be-immutable`](/forge/linting/could-be-immutable) — Flags state variables that are assigned only in the constructor and never written to afterward — making them eligible to be declared `immutable`.
+- [`custom-errors`](/forge/linting/custom-errors) — Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing them with a `revert CustomError(...)`.
+- [`unused-state-variables`](/forge/linting/unused-state-variables) — Flags state variables that are declared but never read or written anywhere in the contract or its descendants.
+
+#### Code size
+
+- [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Flags modifiers whose body contains non-trivial logic that should be moved into a helper function to reduce contract code size.
+

--- a/src/pages/forge/linting/asm-keccak256.mdx
+++ b/src/pages/forge/linting/asm-keccak256.mdx
@@ -1,0 +1,46 @@
+---
+description: Inefficient keccak256 call
+---
+
+## Inefficient keccak256 call
+
+**Severity**: `Gas`
+**ID**: `asm-keccak256`
+
+Flags calls to the high-level `keccak256(...)` builtin that can be cheaply rewritten with inline
+assembly.
+
+### What it does
+
+Reports `keccak256(arg)` calls and (when possible) emits a fix suggestion that uses inline
+assembly to compute the hash directly, avoiding the overhead of the high-level call.
+
+### Why is this bad?
+
+The high-level `keccak256` call performs additional memory management and ABI encoding compared
+to a direct `keccak256(ptr, len)` opcode invocation. In hot paths the difference is visible in
+gas reports.
+
+### Example
+
+#### Bad
+
+```solidity
+bytes32 h = keccak256(abi.encodePacked(a, b));
+```
+
+#### Good
+
+```solidity
+bytes32 h;
+assembly ("memory-safe") {
+    let m := mload(0x40)
+    mstore(m, a)
+    mstore(add(m, 0x20), b)
+    h := keccak256(m, 0x40)
+}
+```
+
+### Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/src/pages/forge/linting/block-timestamp.mdx
+++ b/src/pages/forge/linting/block-timestamp.mdx
@@ -1,0 +1,48 @@
+---
+description: Use of block.timestamp in comparisons
+---
+
+## Use of block.timestamp in comparisons
+
+**Severity**: `Low`
+**ID**: `block-timestamp`
+
+Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly
+manipulated by the block proposer.
+
+### What it does
+
+Reports any comparison expression (`<`, `<=`, `>`, `>=`, `==`, `!=`) that directly or
+transitively reads `block.timestamp`.
+
+### Why is this bad?
+
+Block proposers can adjust `block.timestamp` within a small window (a few seconds). This is
+usually harmless, but for short-window logic — auctions ending, randomness, time-locked
+withdrawals — a few seconds of manipulation can be enough for an attacker to capture value.
+
+Using `block.timestamp` for general scheduling (hours/days) is fine; what's risky is fine-grained
+timing and treating timestamps as a source of randomness.
+
+### Example
+
+#### Bad
+
+```solidity
+function settle() external {
+    require(block.timestamp >= auctionEnd, "auction ongoing");
+    // ...
+}
+```
+
+#### Good
+
+```solidity
+// Prefer block numbers for tight windows, or accept a clearly large grace period.
+require(block.number >= endBlock, "auction ongoing");
+```
+
+### Notes
+
+This lint is intentionally conservative: not every flagged comparison is exploitable. Review
+each occurrence in context.

--- a/src/pages/forge/linting/boolean-cst.mdx
+++ b/src/pages/forge/linting/boolean-cst.mdx
@@ -1,0 +1,41 @@
+---
+description: Misuse of a boolean constant
+---
+
+## Misuse of a boolean constant
+
+**Severity**: `Med`
+**ID**: `boolean-cst`
+
+Flags expressions where a boolean constant (`true`/`false`) is used as a control-flow condition
+or operand of a boolean operator, which usually indicates dead code or a leftover debug toggle.
+
+### What it does
+
+Reports `if (true)`, `if (false)`, `while (true)` outside of intentional infinite loops, and
+boolean operators (`&&`, `||`) where one side is a literal `true`/`false`.
+
+### Why is this bad?
+
+A literal boolean as a condition makes the surrounding branch dead, hides logic errors, or
+preserves a forgotten debug shortcut that bypasses real checks.
+
+### Example
+
+#### Bad
+
+```solidity
+if (true) { // always taken
+    doSomething();
+}
+require(condition && true, "unreachable"); // 'true' is redundant
+```
+
+#### Good
+
+```solidity
+if (condition) {
+    doSomething();
+}
+require(condition, "...");
+```

--- a/src/pages/forge/linting/boolean-equal.mdx
+++ b/src/pages/forge/linting/boolean-equal.mdx
@@ -1,0 +1,38 @@
+---
+description: Boolean comparison to a constant
+---
+
+## Boolean comparison to a constant
+
+**Severity**: `Info`
+**ID**: `boolean-equal`
+
+Flags expressions of the form `x == true`, `x == false`, `x != true`, `x != false`, which can be
+simplified.
+
+### What it does
+
+Reports any equality comparison between a boolean expression and a literal `true` or `false`.
+
+### Why is this bad?
+
+Comparing a boolean to a boolean literal is redundant and harms readability. Use the boolean
+expression directly (or its negation).
+
+### Example
+
+#### Bad
+
+```solidity
+if (paused == true) revert();
+if (paused == false) doSomething();
+require(ok != false, "fail");
+```
+
+#### Good
+
+```solidity
+if (paused) revert();
+if (!paused) doSomething();
+require(ok, "fail");
+```

--- a/src/pages/forge/linting/could-be-immutable.mdx
+++ b/src/pages/forge/linting/could-be-immutable.mdx
@@ -1,0 +1,46 @@
+---
+description: State variable could be immutable
+---
+
+## State variable could be immutable
+
+**Severity**: `Gas`
+**ID**: `could-be-immutable`
+
+Flags state variables that are assigned only in the constructor and never written to afterward —
+making them eligible to be declared `immutable`.
+
+### What it does
+
+Reports each non-`constant`, non-`immutable` state variable whose only writes occur in the
+constructor (or in initialization at declaration time).
+
+### Why is this bad?
+
+`immutable` state variables are stored in the deployed bytecode rather than in storage, eliminating
+an `SLOAD` per access and saving substantial gas across the contract's lifetime. Declaring such
+variables `immutable` also expresses intent and prevents future writes.
+
+### Example
+
+#### Bad
+
+```solidity
+contract C {
+    address owner;
+    constructor() { owner = msg.sender; }
+}
+```
+
+#### Good
+
+```solidity
+contract C {
+    address immutable OWNER;
+    constructor() { OWNER = msg.sender; }
+}
+```
+
+### Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/src/pages/forge/linting/custom-errors.mdx
+++ b/src/pages/forge/linting/custom-errors.mdx
@@ -1,0 +1,49 @@
+---
+description: Prefer custom errors over revert strings
+---
+
+## Prefer custom errors over revert strings
+
+**Severity**: `Gas`
+**ID**: `custom-errors`
+
+Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing
+them with a `revert CustomError(...)`.
+
+### What it does
+
+Reports `require` calls whose second argument is a string literal, and `revert(...)` calls that
+are either bare or have a string-literal argument.
+
+### Why is this bad?
+
+Custom errors:
+- cost less gas than encoding/decoding a string,
+- can carry typed parameters for richer diagnostics,
+- shrink contract bytecode (string constants live in code).
+
+Solidity 0.8.4+ supports custom errors natively.
+
+### Example
+
+#### Bad
+
+```solidity
+require(amount > 0, "amount must be > 0");
+revert("not authorized");
+revert();
+```
+
+#### Good
+
+```solidity
+error AmountZero();
+error NotAuthorized();
+
+if (amount == 0) revert AmountZero();
+if (!authorized) revert NotAuthorized();
+```
+
+### Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/src/pages/forge/linting/divide-before-multiply.mdx
+++ b/src/pages/forge/linting/divide-before-multiply.mdx
@@ -1,0 +1,36 @@
+---
+description: Divide before multiply
+---
+
+## Divide before multiply
+
+**Severity**: `Med`
+**ID**: `divide-before-multiply`
+
+Flags arithmetic expressions where division is performed before multiplication, which can cause
+unintended precision loss in integer arithmetic.
+
+### What it does
+
+Warns on expressions of the form `(a / b) * c` (or equivalent shapes), where the integer division
+truncates before the result is multiplied.
+
+### Why is this bad?
+
+Solidity's integer division truncates toward zero. Performing `(a / b) * c` discards the remainder
+of `a / b` before scaling, while `(a * c) / b` preserves precision. This pattern frequently
+manifests as fee/share/yield miscalculations.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 share = (amount / total) * weight; // truncates first, then scales
+```
+
+#### Good
+
+```solidity
+uint256 share = (amount * weight) / total; // preserves precision
+```

--- a/src/pages/forge/linting/erc20-unchecked-transfer.mdx
+++ b/src/pages/forge/linting/erc20-unchecked-transfer.mdx
@@ -1,0 +1,47 @@
+---
+description: Unchecked ERC20 transfer return value
+---
+
+## Unchecked ERC20 transfer return value
+
+**Severity**: `High`
+**ID**: `erc20-unchecked-transfer`
+
+Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
+
+### What it does
+
+Warns when a function with the same signature as
+`transfer(address,uint256)` or `transferFrom(address,address,uint256)` and a `bool` return type is
+invoked but the result is not checked.
+
+### Why is this bad?
+
+The ERC20 spec allows tokens to signal failure by returning `false` instead of reverting. Ignoring
+the return value lets a "failed" transfer go unnoticed, allowing accounting to drift and creating
+common DeFi exploits. Use a wrapper such as OpenZeppelin's `SafeERC20` or check the boolean
+explicitly.
+
+### Example
+
+#### Bad
+
+```solidity
+token.transfer(to, amount);
+token.transferFrom(from, to, amount);
+```
+
+#### Good
+
+```solidity
+require(token.transfer(to, amount), "transfer failed");
+require(token.transferFrom(from, to, amount), "transferFrom failed");
+
+// or use SafeERC20
+SafeERC20.safeTransfer(token, to, amount);
+```
+
+### Notes
+
+This lint can produce false positives when the callee does not strictly conform to the ERC20
+interface (e.g. tokens that revert on failure rather than returning `false`).

--- a/src/pages/forge/linting/incorrect-erc20-interface.mdx
+++ b/src/pages/forge/linting/incorrect-erc20-interface.mdx
@@ -1,0 +1,46 @@
+---
+description: Incorrect ERC20 interface
+---
+
+## Incorrect ERC20 interface
+
+**Severity**: `Med`
+**ID**: `incorrect-erc20-interface`
+
+Flags interfaces or contracts whose function signatures match an ERC20 method by name and
+parameters but use the wrong return type.
+
+### What it does
+
+For each function whose name and parameter types match a canonical ERC20 method
+(`totalSupply`, `balanceOf`, `transfer`, `transferFrom`, `approve`, `allowance`), the lint checks
+that the return type matches the spec. A mismatch is reported.
+
+### Why is this bad?
+
+Tokens that diverge from the ERC20 spec break composability with the wider ecosystem (DEXes,
+lending protocols, multisigs) and are a common source of integration bugs and exploits.
+
+### Example
+
+#### Bad
+
+```solidity
+interface IBadERC20 {
+    function balanceOf(address) external view returns (bool);  // should be uint256
+    function transfer(address, uint256) external;              // should return bool
+}
+```
+
+#### Good
+
+```solidity
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 value) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}
+```

--- a/src/pages/forge/linting/incorrect-erc721-interface.mdx
+++ b/src/pages/forge/linting/incorrect-erc721-interface.mdx
@@ -1,0 +1,52 @@
+---
+description: Incorrect ERC721 interface
+---
+
+## Incorrect ERC721 interface
+
+**Severity**: `Med`
+**ID**: `incorrect-erc721-interface`
+
+Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by
+name and parameters but use the wrong return type.
+
+### What it does
+
+For each function whose name and parameter types match a canonical ERC721/ERC165 method
+(`balanceOf`, `ownerOf`, `safeTransferFrom`, `transferFrom`, `approve`, `setApprovalForAll`,
+`getApproved`, `isApprovedForAll`, `supportsInterface`), the lint checks that the return type
+matches the spec. A mismatch is reported.
+
+### Why is this bad?
+
+Non-conforming NFT contracts break marketplaces, indexers, and any protocol that relies on the
+ERC721 spec. A wrong return type often compiles and deploys silently but causes integration
+failures at runtime.
+
+### Example
+
+#### Bad
+
+```solidity
+interface IBadERC721 {
+    function balanceOf(address) external view returns (bool);   // should be uint256
+    function ownerOf(uint256) external view returns (bool);     // should be address
+    function supportsInterface(bytes4) external view returns (uint256); // should be bool
+}
+```
+
+#### Good
+
+```solidity
+interface IERC721 {
+    function balanceOf(address owner) external view returns (uint256);
+    function ownerOf(uint256 tokenId) external view returns (address);
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+    function transferFrom(address from, address to, uint256 tokenId) external;
+    function approve(address to, uint256 tokenId) external;
+    function setApprovalForAll(address operator, bool approved) external;
+    function getApproved(uint256 tokenId) external view returns (address);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+```

--- a/src/pages/forge/linting/incorrect-shift.mdx
+++ b/src/pages/forge/linting/incorrect-shift.mdx
@@ -1,0 +1,41 @@
+---
+description: Incorrect shift order
+---
+
+## Incorrect shift order
+
+**Severity**: `High`
+**ID**: `incorrect-shift`
+
+Flags shift operations where a literal appears on the left and a non-literal on the right, which
+is almost always the wrong operand order.
+
+### What it does
+
+Warns when the left-hand operand of `<<` or `>>` is a numeric literal and the right-hand operand
+is a non-literal expression (e.g. a variable, function call, or composite expression).
+
+### Why is this bad?
+
+Shift expressions like `2 << x` are usually a typo for `x << 2`. In the former, the *value being
+shifted* is a tiny constant and the *shift amount* is dynamic — almost never the intended
+behavior, and a known source of bugs in production contracts.
+
+### Example
+
+#### Bad
+
+```solidity
+result = 2 << stateValue;        // shift amount comes from state
+result = 8 >> localValue;        // shift amount comes from a local
+result = 16 << (stateValue + 1); // shift amount is a dynamic expression
+```
+
+#### Good
+
+```solidity
+result = stateValue << 2;
+result = localValue >> 3;
+result = stateValue << localShiftAmount;
+result = 1 << 8; // both literals — fine
+```

--- a/src/pages/forge/linting/interface-file-naming.mdx
+++ b/src/pages/forge/linting/interface-file-naming.mdx
@@ -1,0 +1,35 @@
+---
+description: Interface file naming
+---
+
+## Interface file naming
+
+**Severity**: `Info`
+**ID**: `interface-file-naming`
+
+Flags Solidity files whose only top-level declaration is an interface but whose filename is not
+prefixed with `I`.
+
+### What it does
+
+Reports interface-only files whose path basename does not start with `I` (e.g. `IERC20.sol`).
+
+### Why is this bad?
+
+Prefixing interface filenames with `I` is the prevailing convention in the Solidity ecosystem.
+Following it makes import paths predictable and lets reviewers tell at a glance whether they are
+looking at an interface or an implementation.
+
+### Example
+
+#### Bad
+
+```text
+contracts/Token.sol      // file contains only `interface Token { ... }`
+```
+
+#### Good
+
+```text
+contracts/IToken.sol     // file contains only `interface IToken { ... }`
+```

--- a/src/pages/forge/linting/interface-naming.mdx
+++ b/src/pages/forge/linting/interface-naming.mdx
@@ -1,0 +1,35 @@
+---
+description: Interface name should be prefixed with 'I'
+---
+
+## Interface name should be prefixed with 'I'
+
+**Severity**: `Info`
+**ID**: `interface-naming`
+
+Flags `interface` declarations whose names are not prefixed with `I`.
+
+### What it does
+
+Reports `interface Foo` where `Foo` does not start with `I` (e.g. `IFoo`).
+
+### Why is this bad?
+
+Prefixing interfaces with `I` is the prevailing convention in Solidity codebases (`IERC20`,
+`IERC721`, `IUniswapV2Pair`, ...). Following it makes the role of each type unambiguous at use
+sites and aligns with the matching
+[`interface-file-naming`](https://getfoundry.sh/forge/linting/interface-file-naming) lint.
+
+### Example
+
+#### Bad
+
+```solidity
+interface ERC20 { /* ... */ }
+```
+
+#### Good
+
+```solidity
+interface IERC20 { /* ... */ }
+```

--- a/src/pages/forge/linting/missing-zero-check.mdx
+++ b/src/pages/forge/linting/missing-zero-check.mdx
@@ -1,0 +1,43 @@
+---
+description: Missing zero-address check
+---
+
+## Missing zero-address check
+
+**Severity**: `Low`
+**ID**: `missing-zero-check`
+
+Flags entry-point functions and constructors where an `address` parameter flows into a state write
+or value transfer without a zero-address guard.
+
+### What it does
+
+Performs a taint analysis from each `address` parameter of an externally callable, state-mutating
+function (or constructor) and reports a parameter that reaches a sink (state write, `transfer`,
+`call{value: ...}`, etc.) without first being compared against `address(0)` in an `if`/`require`/
+`assert` predicate.
+
+### Why is this bad?
+
+Forgetting a zero-address check is a common source of value loss: tokens become permanently
+unrecoverable, ownership is renounced unintentionally, or upgrades are bricked. Adding an explicit
+guard is cheap and removes an entire class of operational mistakes.
+
+### Example
+
+#### Bad
+
+```solidity
+function setOwner(address newOwner) external onlyOwner {
+    owner = newOwner; // no zero-address check
+}
+```
+
+#### Good
+
+```solidity
+function setOwner(address newOwner) external onlyOwner {
+    require(newOwner != address(0), "zero address");
+    owner = newOwner;
+}
+```

--- a/src/pages/forge/linting/mixed-case-function.mdx
+++ b/src/pages/forge/linting/mixed-case-function.mdx
@@ -1,0 +1,36 @@
+---
+description: Function names should use mixedCase
+---
+
+## Function names should use mixedCase
+
+**Severity**: `Info`
+**ID**: `mixed-case-function`
+
+Flags function names that do not follow `mixedCase`.
+
+### What it does
+
+Reports functions whose names contain underscores, start with an uppercase letter, or otherwise
+deviate from `mixedCase`. Test functions starting with `test`, `invariant_`, or `statefulFuzz`
+and user-defined patterns (e.g. `ERC20`) are exempted.
+
+### Why is this bad?
+
+The Solidity style guide recommends `mixedCase` for function names. Consistent style makes call
+sites uniform, helps editor tooling, and reduces friction in code review.
+
+### Example
+
+#### Bad
+
+```solidity
+function get_balance() external view returns (uint256);
+function GetBalance()  external view returns (uint256);
+```
+
+#### Good
+
+```solidity
+function getBalance() external view returns (uint256);
+```

--- a/src/pages/forge/linting/mixed-case-variable.mdx
+++ b/src/pages/forge/linting/mixed-case-variable.mdx
@@ -1,0 +1,40 @@
+---
+description: Mutable variable names should use mixedCase
+---
+
+## Mutable variable names should use mixedCase
+
+**Severity**: `Info`
+**ID**: `mixed-case-variable`
+
+Flags mutable variable names (locals, parameters, mutable state) that do not follow `mixedCase`.
+
+### What it does
+
+Reports mutable variable identifiers that contain underscores, start with an uppercase letter,
+or otherwise deviate from `mixedCase`.
+
+`constant` and `immutable` state variables are not flagged by this lint — see
+[`screaming-snake-case-const`](https://getfoundry.sh/forge/linting/screaming-snake-case-const) and
+[`screaming-snake-case-immutable`](https://getfoundry.sh/forge/linting/screaming-snake-case-immutable).
+
+### Why is this bad?
+
+The Solidity style guide recommends `mixedCase` for mutable variables. Consistent style makes
+code easier to scan and review.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 public total_supply;
+address Owner;
+```
+
+#### Good
+
+```solidity
+uint256 public totalSupply;
+address owner;
+```

--- a/src/pages/forge/linting/multi-contract-file.mdx
+++ b/src/pages/forge/linting/multi-contract-file.mdx
@@ -1,0 +1,41 @@
+---
+description: Multiple contracts in one file
+---
+
+## Multiple contracts in one file
+
+**Severity**: `Info`
+**ID**: `multi-contract-file`
+
+Flags source files that declare more than one top-level contract, interface, or library.
+
+### What it does
+
+Reports each top-level `contract`, `interface`, or `library` definition (after the first) in a
+file that contains more than one such declaration.
+
+### Why is this bad?
+
+Keeping one contract per file improves discoverability (`grep`, IDE jump-to-file), simplifies
+import paths, and avoids unintentional bytecode bloat from artifacts that bundle unrelated
+contracts.
+
+### Example
+
+#### Bad
+
+```solidity
+// File: Token.sol
+contract TokenA { /* ... */ }
+contract TokenB { /* ... */ }
+```
+
+#### Good
+
+```solidity
+// File: TokenA.sol
+contract TokenA { /* ... */ }
+
+// File: TokenB.sol
+contract TokenB { /* ... */ }
+```

--- a/src/pages/forge/linting/named-struct-fields.mdx
+++ b/src/pages/forge/linting/named-struct-fields.mdx
@@ -1,0 +1,35 @@
+---
+description: Prefer named struct fields
+---
+
+## Prefer named struct fields
+
+**Severity**: `Info`
+**ID**: `named-struct-fields`
+
+Flags struct construction expressions that pass fields positionally instead of by name.
+
+### What it does
+
+Reports `Struct(a, b, c)` style struct construction; suggests `Struct({ field1: a, field2: b,
+field3: c })` instead.
+
+### Why is this bad?
+
+Positional struct construction is fragile: adding or reordering fields silently changes the
+meaning of every existing call site. Named-field construction is self-documenting and resilient
+to struct changes.
+
+### Example
+
+#### Bad
+
+```solidity
+User memory u = User(addr, 100, true);
+```
+
+#### Good
+
+```solidity
+User memory u = User({ wallet: addr, balance: 100, active: true });
+```

--- a/src/pages/forge/linting/pascal-case-struct.mdx
+++ b/src/pages/forge/linting/pascal-case-struct.mdx
@@ -1,0 +1,35 @@
+---
+description: Struct names should use PascalCase
+---
+
+## Struct names should use PascalCase
+
+**Severity**: `Info`
+**ID**: `pascal-case-struct`
+
+Flags struct definitions whose names do not follow `PascalCase`.
+
+### What it does
+
+Reports any `struct` whose identifier does not match the `PascalCase` convention.
+
+### Why is this bad?
+
+The Solidity style guide recommends `PascalCase` for type-like names (contracts, structs,
+enums, libraries). Consistent casing makes code easier to scan and integrates with editor
+features and external tooling.
+
+### Example
+
+#### Bad
+
+```solidity
+struct user_info { uint256 balance; }
+struct USERINFO   { uint256 balance; }
+```
+
+#### Good
+
+```solidity
+struct UserInfo { uint256 balance; }
+```

--- a/src/pages/forge/linting/pragma-inconsistent.mdx
+++ b/src/pages/forge/linting/pragma-inconsistent.mdx
@@ -1,0 +1,45 @@
+---
+description: Inconsistent pragma directives
+---
+
+## Inconsistent pragma directives
+
+**Severity**: `Info`
+**ID**: `pragma-inconsistent`
+
+Flags projects whose source files declare incompatible or differently-shaped Solidity version
+pragmas.
+
+### What it does
+
+Inspects every `pragma solidity ...;` directive across all input source files and reports when
+their version requirements are inconsistent (different exact versions, mixed caret/tilde/range
+shapes, etc.).
+
+### Why is this bad?
+
+A project compiled under multiple Solidity versions can subtly change behavior between files
+(e.g. checked arithmetic, default visibility, ABI encoding). Aligning pragmas across the project
+removes a hidden source of integration bugs and makes upgrades coordinated.
+
+### Example
+
+#### Bad
+
+```solidity
+// A.sol
+pragma solidity 0.8.18;
+
+// B.sol
+pragma solidity ^0.8.20;
+
+// C.sol
+pragma solidity >=0.7.0 <0.9.0;
+```
+
+#### Good
+
+```solidity
+// All files
+pragma solidity 0.8.20;
+```

--- a/src/pages/forge/linting/rtlo.mdx
+++ b/src/pages/forge/linting/rtlo.mdx
@@ -1,0 +1,36 @@
+---
+description: Right-to-left override character
+---
+
+## Right-to-left override character
+
+**Severity**: `High`
+**ID**: `rtlo`
+
+Flags the presence of Unicode bidirectional override characters in source code, which can be used
+to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).
+
+### What it does
+
+Detects the right-to-left override codepoint (`U+202E`) and other bidirectional control characters
+embedded in identifiers, strings, and comments.
+
+### Why is this bad?
+
+These characters render source code in a different visual order than how the compiler reads it,
+allowing an attacker to make malicious code look benign on review. Solidity contracts are public
+and frequently audited visually; this attack vector must not be ignored.
+
+### Example
+
+#### Bad
+
+```solidity
+// transfer(victim‮, attacker)/*  // U+202E hidden between args
+```
+
+#### Good
+
+```solidity
+// Avoid bidirectional override characters in code and comments.
+```

--- a/src/pages/forge/linting/screaming-snake-case-const.mdx
+++ b/src/pages/forge/linting/screaming-snake-case-const.mdx
@@ -1,0 +1,34 @@
+---
+description: Constants should use SCREAMING_SNAKE_CASE
+---
+
+## Constants should use SCREAMING_SNAKE_CASE
+
+**Severity**: `Info`
+**ID**: `screaming-snake-case-const`
+
+Flags `constant` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
+
+### What it does
+
+Reports state variables declared `constant` whose identifier deviates from `SCREAMING_SNAKE_CASE`.
+
+### Why is this bad?
+
+The Solidity style guide recommends `SCREAMING_SNAKE_CASE` for constants so they stand out from
+mutable state and immutables at call sites.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 constant maxSupply = 1_000_000;
+uint256 constant Max_Supply = 1_000_000;
+```
+
+#### Good
+
+```solidity
+uint256 constant MAX_SUPPLY = 1_000_000;
+```

--- a/src/pages/forge/linting/screaming-snake-case-immutable.mdx
+++ b/src/pages/forge/linting/screaming-snake-case-immutable.mdx
@@ -1,0 +1,35 @@
+---
+description: Immutables should use SCREAMING_SNAKE_CASE
+---
+
+## Immutables should use SCREAMING_SNAKE_CASE
+
+**Severity**: `Info`
+**ID**: `screaming-snake-case-immutable`
+
+Flags `immutable` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
+
+### What it does
+
+Reports state variables declared `immutable` whose identifier deviates from
+`SCREAMING_SNAKE_CASE`.
+
+### Why is this bad?
+
+The Solidity style guide recommends `SCREAMING_SNAKE_CASE` for `immutable` variables so they
+visually align with `constant` ones and stand out from mutable state at call sites.
+
+### Example
+
+#### Bad
+
+```solidity
+address immutable owner;
+address immutable Owner;
+```
+
+#### Good
+
+```solidity
+address immutable OWNER;
+```

--- a/src/pages/forge/linting/too-many-digits.mdx
+++ b/src/pages/forge/linting/too-many-digits.mdx
@@ -1,0 +1,36 @@
+---
+description: Numeric literal with too many digits
+---
+
+## Numeric literal with too many digits
+
+**Severity**: `Info`
+**ID**: `too-many-digits`
+
+Flags numeric literals containing five or more consecutive zeros, which are easy to misread.
+
+### What it does
+
+Reports decimal numeric literals that contain a run of 5 or more `0` characters.
+
+### Why is this bad?
+
+Long sequences of zeros are difficult to count visually, and an off-by-one zero is a common bug
+(e.g. funding `1_000_000` instead of `10_000_000`). Use scientific notation, sub-denominations, or
+underscore separators to make the magnitude obvious.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 amount = 1000000000000000000;
+```
+
+#### Good
+
+```solidity
+uint256 amount = 1e18;
+uint256 amount2 = 1 ether;
+uint256 amount3 = 1_000_000_000_000_000_000;
+```

--- a/src/pages/forge/linting/unaliased-plain-import.mdx
+++ b/src/pages/forge/linting/unaliased-plain-import.mdx
@@ -1,0 +1,38 @@
+---
+description: Unaliased plain import
+---
+
+## Unaliased plain import
+
+**Severity**: `Info`
+**ID**: `unaliased-plain-import`
+
+Flags `import "path";` statements that pull in every top-level symbol from another file without
+an alias.
+
+### What it does
+
+Reports plain imports of the form `import "path";`. Suggests using either named imports
+(`import { A, B } from "path"`) or an aliased import (`import "path" as X`).
+
+### Why is this bad?
+
+Plain imports pollute the importing file's namespace and make the source of each symbol
+non-obvious. Named or aliased imports make the dependency surface explicit and reduce the chance
+of accidental name collisions.
+
+### Example
+
+#### Bad
+
+```solidity
+import "./Lib.sol";
+```
+
+#### Good
+
+```solidity
+import { Foo, Bar } from "./Lib.sol";
+// or
+import "./Lib.sol" as Lib;
+```

--- a/src/pages/forge/linting/unchecked-call.mdx
+++ b/src/pages/forge/linting/unchecked-call.mdx
@@ -1,0 +1,38 @@
+---
+description: Unchecked low-level call
+---
+
+## Unchecked low-level call
+
+**Severity**: `High`
+**ID**: `unchecked-call`
+
+Flags low-level calls (`call`, `delegatecall`, `staticcall`, `callcode`) whose `success` return
+value is ignored.
+
+### What it does
+
+Warns when the boolean returned by a low-level call is discarded — either because the return value
+is not assigned or because only the `bytes memory` payload is used.
+
+### Why is this bad?
+
+Low-level calls do **not** revert when the callee fails; they silently return `false`. Ignoring
+the success flag means a failed call is indistinguishable from a successful one, leading to bugs
+where state is updated on the assumption that an external interaction succeeded.
+
+### Example
+
+#### Bad
+
+```solidity
+target.call(data);                          // success ignored
+(, bytes memory ret) = target.call(data);   // only payload kept
+```
+
+#### Good
+
+```solidity
+(bool ok, ) = target.call(data);
+require(ok, "call failed");
+```

--- a/src/pages/forge/linting/unsafe-cheatcode.mdx
+++ b/src/pages/forge/linting/unsafe-cheatcode.mdx
@@ -1,0 +1,39 @@
+---
+description: Usage of unsafe cheatcodes
+---
+
+## Usage of unsafe cheatcodes
+
+**Severity**: `Info`
+**ID**: `unsafe-cheatcode`
+
+Flags use of Foundry cheatcodes that perform dangerous side effects (filesystem access, network
+activity, environment variable reads, etc.) so they cannot slip into production code unnoticed.
+
+### What it does
+
+Reports calls to cheatcodes whose effects extend beyond the EVM sandbox or that bypass typical
+test invariants. The flagged set follows the cheatcode's
+[`Safety::Unsafe`](https://book.getfoundry.sh/cheatcodes) classification.
+
+### Why is this bad?
+
+Unsafe cheatcodes can read/write files, hit the network, or fork external state. They are
+appropriate in tests with explicit intent but should not be added without review, and must
+never end up in shipped contract code.
+
+### Example
+
+#### Bad
+
+```solidity
+vm.writeFile("./out.txt", data);   // unsafe — writes to host filesystem
+vm.envString("PRIVATE_KEY");       // unsafe — reads host environment
+```
+
+#### Good
+
+```solidity
+// Use safe cheatcodes (vm.expectRevert, vm.prank, vm.warp, ...) and explicit
+// inputs/fixtures instead of pulling state from the host environment.
+```

--- a/src/pages/forge/linting/unsafe-typecast.mdx
+++ b/src/pages/forge/linting/unsafe-typecast.mdx
@@ -1,0 +1,44 @@
+---
+description: Unsafe typecast
+---
+
+## Unsafe typecast
+
+**Severity**: `Med`
+**ID**: `unsafe-typecast`
+
+Flags explicit numeric typecasts that can silently truncate or alter the value.
+
+### What it does
+
+Reports casts where the source value's type is wider than the target type
+(e.g. `uint256 → uint128`, `int256 → uint128`), unless the cast is preceded by a check that
+guarantees the value fits in the target.
+
+### Why is this bad?
+
+Solidity does **not** revert on narrowing casts; it silently keeps the lowest bits, which can
+cause severe accounting bugs (e.g. amount overflows, wrong fees, broken invariants). Use a checked
+cast helper such as OpenZeppelin's `SafeCast` whenever the source value is not provably bounded.
+
+### Example
+
+#### Bad
+
+```solidity
+function setAmount(uint256 amount) external {
+    smallAmount = uint128(amount); // silent truncation if amount >= 2**128
+}
+```
+
+#### Good
+
+```solidity
+function setAmount(uint256 amount) external {
+    require(amount <= type(uint128).max, "overflow");
+    smallAmount = uint128(amount);
+}
+
+// or
+smallAmount = SafeCast.toUint128(amount);
+```

--- a/src/pages/forge/linting/unused-import.mdx
+++ b/src/pages/forge/linting/unused-import.mdx
@@ -1,0 +1,44 @@
+---
+description: Unused import
+---
+
+## Unused import
+
+**Severity**: `Info`
+**ID**: `unused-import`
+
+Flags imported symbols (or whole import statements) whose imported names are not referenced
+anywhere in the source unit.
+
+### What it does
+
+Reports `import "..."`, `import "..." as X`, and `import { A, B } from "..."` statements where one
+or more imported names are never used. Symbols brought in via `import * as X` are tracked through
+`X.member` accesses.
+
+### Why is this bad?
+
+Unused imports add noise, slow down compilation, can cause name collisions, and frequently
+indicate dead code or stale refactors.
+
+### Example
+
+#### Bad
+
+```solidity
+import { A, B } from "./Lib.sol"; // B is never used
+
+contract C {
+    A internal a;
+}
+```
+
+#### Good
+
+```solidity
+import { A } from "./Lib.sol";
+
+contract C {
+    A internal a;
+}
+```

--- a/src/pages/forge/linting/unused-state-variables.mdx
+++ b/src/pages/forge/linting/unused-state-variables.mdx
@@ -1,0 +1,43 @@
+---
+description: Unused state variable
+---
+
+## Unused state variable
+
+**Severity**: `Gas`
+**ID**: `unused-state-variables`
+
+Flags state variables that are declared but never read or written anywhere in the contract or its
+descendants.
+
+### What it does
+
+Reports each state variable that has no read or write site across the project.
+
+### Why is this bad?
+
+Unused state variables waste storage slots, inflate deployment cost, and are a strong signal of
+dead or stale code that should be removed.
+
+### Example
+
+#### Bad
+
+```solidity
+contract C {
+    uint256 unused;       // never read or written
+    uint256 public total; // used elsewhere
+}
+```
+
+#### Good
+
+```solidity
+contract C {
+    uint256 public total;
+}
+```
+
+### Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/src/pages/forge/linting/unwrapped-modifier-logic.mdx
+++ b/src/pages/forge/linting/unwrapped-modifier-logic.mdx
@@ -1,0 +1,55 @@
+---
+description: Unwrapped modifier logic
+---
+
+## Unwrapped modifier logic
+
+**Severity**: `CodeSize`
+**ID**: `unwrapped-modifier-logic`
+
+Flags modifiers whose body contains non-trivial logic that should be moved into a helper function
+to reduce contract code size.
+
+### What it does
+
+Reports modifiers whose body contains statements other than a single placeholder, simple builtin
+calls (`require`/`assert`), or a single library function call. Modifiers that use inline assembly
+are exempted.
+
+### Why is this bad?
+
+Solidity inlines a modifier's body at every call site, so any non-trivial logic is duplicated
+across all functions that use the modifier. Wrapping the logic in an internal function and calling
+it from the modifier keeps the bytecode small while preserving behavior.
+
+### Example
+
+#### Bad
+
+```solidity
+modifier onlyAuth() {
+    if (!auth[msg.sender]) revert NotAuth();
+    bytes32 nonce = keccak256(abi.encodePacked(msg.sender, block.number));
+    seenNonce[nonce] = true;
+    _;
+}
+```
+
+#### Good
+
+```solidity
+modifier onlyAuth() {
+    _checkAuth();
+    _;
+}
+
+function _checkAuth() internal {
+    if (!auth[msg.sender]) revert NotAuth();
+    bytes32 nonce = keccak256(abi.encodePacked(msg.sender, block.number));
+    seenNonce[nonce] = true;
+}
+```
+
+### Notes
+
+This is a `CodeSize`-severity lint and is **not** applied to test or script files.


### PR DESCRIPTION
## Summary

- add one Forge lint reference page per registered lint
- add a compact lint reference index to `/forge/linting`
- add lint pages to the sidebar grouped by severity

<img width="2688" height="1756" alt="image" src="https://github.com/user-attachments/assets/5ebed626-1921-4070-adc7-d24f4b338a68" />