### PR TITLE
docs: expand forge linting sidebar

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -38,7 +38,7 @@ const docs = [
       {
         text: "Linting",
         link: "/forge/linting",
-        collapsed: true,
+        collapsed: false,
         items: [
           {
             text: "High severity",


### PR DESCRIPTION
## Summary

- expand the Forge Linting sidebar group by default
- keep the severity groups collapsed so the first-level lint categories are visible

## Testing

- `bun run build`
- manually checked `/forge/linting` locally