### PR TITLE
docs(linting): add inline-assembly lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -74,6 +74,7 @@ const docs = [
             collapsed: true,
             items: [
               { text: "boolean-equal", link: "/forge/linting/boolean-equal" },
+              { text: "inline-assembly", link: "/forge/linting/inline-assembly" },
               { text: "interface-file-naming", link: "/forge/linting/interface-file-naming" },
               { text: "interface-naming", link: "/forge/linting/interface-naming" },
               { text: "mixed-case-function", link: "/forge/linting/mixed-case-function" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -165,6 +165,7 @@ navigation on the right to browse by severity.
 #### Informational
 
 - [`boolean-equal`](/forge/linting/boolean-equal) — Flags expressions of the form `x == true`, `x == false`, `x != true`, `x != false`, which can be simplified.
+- [`inline-assembly`](/forge/linting/inline-assembly) — Flags every `assembly { ... }` block; inline assembly bypasses Solidity safety features and should be reviewed deliberately.
 - [`interface-file-naming`](/forge/linting/interface-file-naming) — Flags Solidity files whose only top-level declaration is an interface but whose filename is not prefixed with `I`.
 - [`interface-naming`](/forge/linting/interface-naming) — Flags `interface` declarations whose names are not prefixed with `I`.
 - [`mixed-case-function`](/forge/linting/mixed-case-function) — Flags function names that do not follow `mixedCase`.

--- a/src/pages/forge/linting/inline-assembly.mdx
+++ b/src/pages/forge/linting/inline-assembly.mdx
@@ -1,0 +1,70 @@
+---
+description: Inline assembly usage
+---
+
+## Inline assembly
+
+**Severity**: `Info`
+**ID**: `inline-assembly`
+
+Flags every `assembly { ... }` block. Inline assembly bypasses many of Solidity's safety
+features (type checks, overflow checks, memory layout invariants) and is a common source of
+high-impact bugs, so each occurrence should be reviewed deliberately.
+
+### What it does
+
+Reports every inline assembly statement, including blocks declared with the `"evmasm"` dialect
+and/or the `("memory-safe")` flag. Blocks declared `("memory-safe")` are still reported, but
+with a softer message acknowledging the developer attestation: review focuses on business logic
+and side effects rather than memory layout.
+
+### Why is this bad?
+
+Assembly skips Solidity's compile-time checks and many of its runtime guarantees. Mistakes
+inside an `assembly` block can corrupt memory, break the free memory pointer, leak storage,
+escalate privileges via `delegatecall`, or destroy the contract via `selfdestruct`. Even when
+required for gas or features unavailable in high-level Solidity, assembly should be small,
+documented, and reviewed.
+
+### When inline assembly is reasonable
+
+Some idioms are widely used and generally safe:
+
+- Reading transaction/chain context: `chainid()`, `gas()`, `returndatasize()`.
+- Probing code: `codesize()`, `extcodesize(addr)`, `extcodehash(addr)`.
+- Reading the free memory pointer: `mload(0x40)`.
+- Cheap hashing of a known memory layout, when paired with `("memory-safe")`.
+
+If you must use assembly:
+
+1. Keep the block minimal and well-commented.
+2. Add the `("memory-safe")` flag when the block does not violate Solidity's memory model, so
+   the optimizer (and reviewers) can rely on it.
+3. Suppress the lint locally to mark the block as audited:
+   ```solidity
+   // forge-lint: disable-next-line(inline-assembly)
+   assembly ("memory-safe") { /* reviewed: ... */ }
+   ```
+
+### Example
+
+#### Bad
+
+```solidity
+function rawCall(address target, bytes calldata data) external returns (bytes memory) {
+    assembly {
+        let ok := call(gas(), target, 0, add(data.offset, 0), data.length, 0, 0)
+        // ...
+    }
+}
+```
+
+#### Good
+
+```solidity
+function rawCall(address target, bytes calldata data) external returns (bytes memory result) {
+    bool ok;
+    (ok, result) = target.call(data);
+    require(ok, "call failed");
+}
+```

--- a/src/pages/forge/linting/inline-assembly.mdx
+++ b/src/pages/forge/linting/inline-assembly.mdx
@@ -14,9 +14,10 @@ high-impact bugs, so each occurrence should be reviewed deliberately.
 ### What it does
 
 Reports every inline assembly statement, including blocks declared with the `"evmasm"` dialect
-and/or the `("memory-safe")` flag. Blocks declared `("memory-safe")` are still reported, but
-with a softer message acknowledging the developer attestation: review focuses on business logic
-and side effects rather than memory layout.
+and/or the `("memory-safe")` flag. Blocks declared as memory-safe — either via the modern
+`("memory-safe")` flag or the legacy `/// @solidity memory-safe-assembly` NatSpec marker — are
+still reported, but with a softer message acknowledging the developer attestation: review
+focuses on business logic and side effects rather than memory layout.
 
 ### Why is this bad?
 
@@ -39,7 +40,9 @@ If you must use assembly:
 
 1. Keep the block minimal and well-commented.
 2. Add the `("memory-safe")` flag when the block does not violate Solidity's memory model, so
-   the optimizer (and reviewers) can rely on it.
+   the optimizer (and reviewers) can rely on it. The legacy
+   `/// @solidity memory-safe-assembly` NatSpec marker on the line directly above the block is
+   also recognized for compatibility with older codebases.
 3. Suppress the lint locally to mark the block as audited:
    ```solidity
    // forge-lint: disable-next-line(inline-assembly)


### PR DESCRIPTION
Adds the docs page, sidebar entry, and overview bullet for the new inline-assembly Solidity lint introduced in foundry-rs/foundry#14575.