### PR TITLE
docs(expect-emit): clarify next-call semantics and warn about caught-revert leak

### DIFF
--- a/src/pages/reference/cheatcodes/expect-emit.mdx
+++ b/src/pages/reference/cheatcodes/expect-emit.mdx
@@ -113,6 +113,49 @@ function testFails() public {
 ```
 :::
 
+:::warning
+`expectEmit` enforces the "next call must emit" rule by reverting the call when no matching log is found. If the caller catches that revert (low-level `call` or `try/catch`), the expectation is not consumed and remains active for the rest of the test, where it can be satisfied by a log emitted from any later call:
+
+```solidity [test/ExpectEmitCaughtRevert.t.sol]
+contract Example {
+    event Foo();
+
+    function reverting() external pure { revert(); }
+    function emitFoo() external { emit Foo(); }
+}
+
+function testLeaks() public {
+    Example example = new Example();
+
+    vm.expectEmit();
+    emit Example.Foo();
+
+    // This call is the one expectEmit applies to. It reverts before emitting Foo,
+    // but the parent catches the revert, so the expectation remains active.
+    (bool ok,) = address(example).call(abi.encodeCall(example.reverting, ()));
+    require(!ok);
+
+    // This call emits Foo and satisfies the still-active expectation, so the test passes.
+    example.emitFoo();
+}
+```
+
+To prevent this, perform any caught-revert calls first and register `expectEmit` immediately before the call you want to assert against:
+
+```solidity [test/ExpectEmitCorrect.t.sol]
+function testCorrect() public {
+    Example example = new Example();
+
+    (bool ok,) = address(example).call(abi.encodeCall(example.reverting, ()));
+    require(!ok);
+
+    vm.expectEmit();
+    emit Example.Foo();
+    example.emitFoo();
+}
+```
+:::
+
 ### Related Cheatcodes
 
 - [`expectRevert`](/reference/cheatcodes/expect-revert) - Assert that calls revert


### PR DESCRIPTION
Companion docs PR for [foundry#14620](https://github.com/foundry-rs/foundry/pull/14620).

Adds a gotcha to `reference/cheatcodes/expect-emit` covering the case where the call immediately after `expectEmit` reverts and the revert is caught by the caller (low-level `call` or `try/catch`). `expectEmit` enforces the next-call rule by reverting the call when no matching log is found; if that revert is caught, the expectation is not consumed and remains active for the rest of the test, where it can be satisfied by a log emitted from any later call. Includes the leak example and the recommended pattern of performing the caught-revert call first, then registering `expectEmit` immediately before the asserted call.

Refs: [foundry-rs/foundry#14618](https://github.com/foundry-rs/foundry/issues/14618)