### PR TITLE
docs(linting): add `redundant-base-constructor-call` lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -85,6 +85,7 @@ const docs = [
               { text: "named-struct-fields", link: "/forge/linting/named-struct-fields" },
               { text: "pascal-case-struct", link: "/forge/linting/pascal-case-struct" },
               { text: "pragma-inconsistent", link: "/forge/linting/pragma-inconsistent" },
+              { text: "redundant-base-constructor-call", link: "/forge/linting/redundant-base-constructor-call" },
               { text: "screaming-snake-case-const", link: "/forge/linting/screaming-snake-case-const" },
               { text: "screaming-snake-case-immutable", link: "/forge/linting/screaming-snake-case-immutable" },
               { text: "too-many-digits", link: "/forge/linting/too-many-digits" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -177,6 +177,7 @@ navigation on the right to browse by severity.
 - [`named-struct-fields`](/forge/linting/named-struct-fields) — Flags struct construction expressions that pass fields positionally instead of by name.
 - [`pascal-case-struct`](/forge/linting/pascal-case-struct) — Flags struct definitions whose names do not follow `PascalCase`.
 - [`pragma-inconsistent`](/forge/linting/pragma-inconsistent) — Flags projects whose source files declare incompatible or differently-shaped Solidity version pragmas.
+- [`redundant-base-constructor-call`](/forge/linting/redundant-base-constructor-call) — Flags explicit empty base-constructor arguments (e.g. `is A()` or `constructor() A() {}`) when the base contract requires no arguments.
 - [`screaming-snake-case-const`](/forge/linting/screaming-snake-case-const) — Flags `constant` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
 - [`screaming-snake-case-immutable`](/forge/linting/screaming-snake-case-immutable) — Flags `immutable` state variables whose names do not follow `SCREAMING_SNAKE_CASE`.
 - [`too-many-digits`](/forge/linting/too-many-digits) — Flags numeric literals containing five or more consecutive zeros, which are easy to misread.

--- a/src/pages/forge/linting/redundant-base-constructor-call.mdx
+++ b/src/pages/forge/linting/redundant-base-constructor-call.mdx
@@ -1,0 +1,45 @@
+---
+description: Redundant base-constructor call
+---
+
+## Redundant base-constructor call
+
+**Severity**: `Info`
+**ID**: `redundant-base-constructor-call`
+
+Flags an explicit empty base-constructor specifier (e.g. `is A()` or `constructor() A() {}`)
+when the base contract either has no constructor or has a constructor that takes no arguments.
+The empty `()` adds no information and can be removed.
+
+### What it does
+
+For every base contract listed in a contract's inheritance specifier or invoked from a derived
+constructor's header, the lint reports the empty `()` when the base does not require any
+arguments.
+
+### Why is this bad?
+
+Writing `A()` suggests an explicit call, but if `A` has no constructor or a zero-parameter
+constructor, the parentheses are redundant noise that obscure the real inheritance shape.
+
+### Example
+
+#### Bad
+
+```solidity
+contract A {}
+contract B { constructor() {} }
+
+contract C is A() {}                        // A has no constructor
+contract D is B { constructor() B() {} }    // B's constructor takes no arguments
+```
+
+#### Good
+
+```solidity
+contract A {}
+contract B { constructor() {} }
+
+contract C is A {}
+contract D is B {}
+```


### PR DESCRIPTION
Adds the reference page for the new `redundant-base-constructor-call` lint.