### PR TITLE
docs(linting): add missing-inheritance lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -78,6 +78,7 @@ const docs = [
               { text: "inline-assembly", link: "/forge/linting/inline-assembly" },
               { text: "interface-file-naming", link: "/forge/linting/interface-file-naming" },
               { text: "interface-naming", link: "/forge/linting/interface-naming" },
+              { text: "missing-inheritance", link: "/forge/linting/missing-inheritance" },
               { text: "mixed-case-function", link: "/forge/linting/mixed-case-function" },
               { text: "mixed-case-variable", link: "/forge/linting/mixed-case-variable" },
               { text: "multi-contract-file", link: "/forge/linting/multi-contract-file" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -170,6 +170,7 @@ navigation on the right to browse by severity.
 - [`inline-assembly`](/forge/linting/inline-assembly) — Flags every `assembly { ... }` block; inline assembly bypasses Solidity safety features and should be reviewed deliberately.
 - [`interface-file-naming`](/forge/linting/interface-file-naming) — Flags Solidity files whose only top-level declaration is an interface but whose filename is not prefixed with `I`.
 - [`interface-naming`](/forge/linting/interface-naming) — Flags `interface` declarations whose names are not prefixed with `I`.
+- [`missing-inheritance`](/forge/linting/missing-inheritance) — Flags contracts that implement every external function of an interface but do not explicitly inherit from it.
 - [`mixed-case-function`](/forge/linting/mixed-case-function) — Flags function names that do not follow `mixedCase`.
 - [`mixed-case-variable`](/forge/linting/mixed-case-variable) — Flags mutable variable names (locals, parameters, mutable state) that do not follow `mixedCase`.
 - [`multi-contract-file`](/forge/linting/multi-contract-file) — Flags source files that declare more than one top-level contract, interface, or library.

--- a/src/pages/forge/linting/missing-inheritance.mdx
+++ b/src/pages/forge/linting/missing-inheritance.mdx
@@ -1,0 +1,67 @@
+---
+description: Missing inheritance from an implemented interface
+---
+
+## Missing inheritance from an implemented interface
+
+**Severity**: `Info`
+**ID**: `missing-inheritance`
+
+Flags contracts that implement every external function of an interface but do not explicitly
+inherit from it.
+
+### What it does
+
+For each non-interface contract `C` in the analyzed sources, reports each interface `I` where:
+
+- `C` does not transitively inherit from `I`,
+- `C` (including its inherited bases) implements every external selector exported by `I`, and
+- no already-inherited base of `C` already covers all of `I`'s selectors.
+
+Candidate interfaces include both user-defined interfaces and those declared in dependencies
+(e.g. OpenZeppelin's `IERC20`). When several candidates overlap (e.g. `IERC20` and
+`IERC20Metadata`), only the maximal one is reported. Signature-only abstract contracts — those
+with no state, no constructor, no modifier bodies, and no function bodies — are also treated as
+candidate interfaces.
+
+### Why is this bad?
+
+Explicit inheritance:
+
+- documents which standards a contract claims to implement,
+- enables the compiler to verify function signatures, visibility, mutability, and return types via
+  `override`,
+- makes `type(I).interfaceId` and ERC-165 introspection meaningful,
+- makes refactors safer: changing the interface fails the build instead of silently drifting.
+
+Implementing the API by coincidence (or by copy-paste) skips all of those checks.
+
+### Example
+
+#### Bad
+
+```solidity
+interface ISomething {
+    function f1() external returns (uint256);
+}
+
+contract Something {
+    function f1() external returns (uint256) {
+        return 42;
+    }
+}
+```
+
+#### Good
+
+```solidity
+interface ISomething {
+    function f1() external returns (uint256);
+}
+
+contract Something is ISomething {
+    function f1() external override returns (uint256) {
+        return 42;
+    }
+}
+```


### PR DESCRIPTION
Adds the docs page for the new `missing-inheritance` lint introduced - https://github.com/foundry-rs/foundry/pull/14661