### PR TITLE
docs: document --no-lint for forge build

### DIFF
--- a/src/pages/config/reference/linter.mdx
+++ b/src/pages/config/reference/linter.mdx
@@ -84,7 +84,13 @@ Where:
 
 By default, the linter runs automatically when you build your project with `forge build`.
 
-To disable this behavior, in your `foundry.toml` set:
+To skip linting for a single invocation, pass `--no-lint` (alias `--skip-lint`):
+
+```bash
+forge build --no-lint
+```
+
+To disable persistently, in your `foundry.toml` set:
 
 ```toml
 [lint]

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -120,7 +120,14 @@ Or explicitly:
 
 ### Disable linting on build
 
-By default, `forge build` runs the linter. To disable:
+By default, `forge build` runs the linter. To disable for a single invocation, pass
+`--no-lint` (alias `--skip-lint`):
+
+```bash
+forge build --no-lint
+```
+
+To disable persistently:
 
 ```toml [foundry.toml]
 [lint]


### PR DESCRIPTION
Document the new `forge build --no-lint` flag added in https://github.com/foundry-rs/foundry/pull/14676, alongside the existing `lint_on_build = false` config option.