### PR TITLE
docs(lint): add cache-array-length page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -100,6 +100,7 @@ const docs = [
             collapsed: true,
             items: [
               { text: "asm-keccak256", link: "/forge/linting/asm-keccak256" },
+              { text: "cache-array-length", link: "/forge/linting/cache-array-length" },
               { text: "could-be-immutable", link: "/forge/linting/could-be-immutable" },
               { text: "custom-errors", link: "/forge/linting/custom-errors" },
               { text: "unused-state-variables", link: "/forge/linting/unused-state-variables" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -196,6 +196,7 @@ navigation on the right to browse by severity.
 #### Gas optimization
 
 - [`asm-keccak256`](/forge/linting/asm-keccak256) — Flags calls to the high-level `keccak256(...)` builtin that can be cheaply rewritten with inline assembly.
+- [`cache-array-length`](/forge/linting/cache-array-length) — Flags `for` loop conditions that read a dynamic array or `bytes` value's `.length` on every iteration instead of comparing against a cached local length.
 - [`could-be-immutable`](/forge/linting/could-be-immutable) — Flags state variables that are assigned only in the constructor and never written to afterward — making them eligible to be declared `immutable`.
 - [`custom-errors`](/forge/linting/custom-errors) — Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing them with a `revert CustomError(...)`.
 - [`unused-state-variables`](/forge/linting/unused-state-variables) — Flags state variables that are declared but never read or written anywhere in the contract or its descendants.
@@ -204,4 +205,3 @@ navigation on the right to browse by severity.
 #### Code size
 
 - [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Flags modifiers whose body contains non-trivial logic that should be moved into a helper function to reduce contract code size.
-

--- a/src/pages/forge/linting/cache-array-length.mdx
+++ b/src/pages/forge/linting/cache-array-length.mdx
@@ -1,0 +1,60 @@
+---
+description: Array length not cached
+---
+
+## Array length not cached
+
+**Severity**: `Gas`
+**ID**: `cache-array-length`
+
+Flags `for` loop conditions that read a dynamic array or `bytes` value's `.length` on every
+iteration instead of comparing against a cached local length.
+
+### What it does
+
+Reports comparison expressions in `for` loop conditions when either side reads `.length` from a
+dynamic array-like value, such as `i < values.length`, `values.length > i`, or compound conditions
+that repeat the same pattern.
+
+The lint does not report loops that already compare against a local cached length variable.
+
+### Why is this bad?
+
+Reading `.length` in the loop condition repeats the length lookup for every iteration. Caching the
+length once before entering the loop avoids repeated storage, memory, or calldata reads and can
+reduce gas for hot loops.
+
+### Example
+
+#### Bad
+
+```solidity
+contract C {
+    uint256[] values;
+
+    function sum() external view returns (uint256 total) {
+        for (uint256 i = 0; i < values.length; ++i) {
+            total += values[i];
+        }
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract C {
+    uint256[] values;
+
+    function sum() external view returns (uint256 total) {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; ++i) {
+            total += values[i];
+        }
+    }
+}
+```
+
+### Notes
+
+This is a `Gas`-severity lint and is not applied to test or script files.


### PR DESCRIPTION
## Summary
- add the Foundry Book page for `cache-array-length`
- list the lint in the Forge linting index and sidebar

CLOSES OSS-85