### PR TITLE
docs(lint): add weak-prng page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -61,6 +61,7 @@ const docs = [
               { text: "incorrect-erc721-interface", link: "/forge/linting/incorrect-erc721-interface" },
               { text: "tx-origin", link: "/forge/linting/tx-origin" },
               { text: "unsafe-typecast", link: "/forge/linting/unsafe-typecast" },
+              { text: "weak-prng", link: "/forge/linting/weak-prng" },
             ],
           },
           {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -166,6 +166,7 @@ navigation on the right to browse by severity.
 - [`incorrect-erc721-interface`](/forge/linting/incorrect-erc721-interface) — Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by name and parameters but use the wrong return type.
 - [`tx-origin`](/forge/linting/tx-origin) — Flags use of `tx.origin` inside authorization-like predicates, which can be exploited by a malicious contract acting on behalf of a legitimate owner.
 - [`unsafe-typecast`](/forge/linting/unsafe-typecast) — Flags explicit numeric typecasts that can silently truncate or alter the value.
+- [`weak-prng`](/forge/linting/weak-prng) — Flags randomness-like expressions that directly derive entropy from predictable on-chain values.
 
 #### Low severity
 
@@ -204,4 +205,3 @@ navigation on the right to browse by severity.
 #### Code size
 
 - [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Flags modifiers whose body contains non-trivial logic that should be moved into a helper function to reduce contract code size.
-

--- a/src/pages/forge/linting/weak-prng.mdx
+++ b/src/pages/forge/linting/weak-prng.mdx
@@ -1,0 +1,44 @@
+---
+description: Weak pseudo-random number generation
+---
+
+## Weak pseudo-random number generation
+
+**Severity**: `Med`
+**ID**: `weak-prng`
+
+Flags randomness-like expressions that directly derive entropy from predictable on-chain values.
+
+### What it does
+
+Reports direct use of `block.timestamp`, `blockhash(...)`, `block.prevrandao`, or
+`block.difficulty` in modulo expressions, `keccak256(...)`, or `abi.encodePacked(...)`.
+
+### Why is this bad?
+
+Block data is visible before transaction execution and can often be influenced or withheld by a
+block proposer. Hashing or applying modulo to these values does not make them unpredictable, so an
+attacker may be able to bias outcomes such as lotteries, mints, or game mechanics.
+
+Use a commit-reveal scheme, an oracle such as a VRF, or another protocol designed for
+unpredictable randomness.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 winner = uint256(keccak256(abi.encodePacked(block.timestamp, msg.sender))) % players.length;
+```
+
+#### Good
+
+```solidity
+// Example shape only: consume randomness that was committed before it was revealed.
+uint256 winner = uint256(keccak256(abi.encodePacked(revealedSeed, msg.sender))) % players.length;
+```
+
+### Notes
+
+This lint is intentionally local and conservative. It does not attempt interprocedural taint
+tracking, so values copied into a variable before use may require manual review.


### PR DESCRIPTION
## Summary
- add the Foundry Book page for `weak-prng`
- list the lint in the Forge linting index and sidebar

CLOSES OSS-54