### PR TITLE
docs(lint): add dead-code page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -110,6 +110,7 @@ const docs = [
             text: "Code size",
             collapsed: true,
             items: [
+              { text: "dead-code", link: "/forge/linting/dead-code" },
               { text: "unwrapped-modifier-logic", link: "/forge/linting/unwrapped-modifier-logic" },
             ],
           },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -203,5 +203,5 @@ navigation on the right to browse by severity.
 
 #### Code size
 
+- [`dead-code`](/forge/linting/dead-code) — Flags internal and private functions that are not reachable from contract entry points or construction-time initializers.
 - [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Flags modifiers whose body contains non-trivial logic that should be moved into a helper function to reduce contract code size.
-

--- a/src/pages/forge/linting/dead-code.mdx
+++ b/src/pages/forge/linting/dead-code.mdx
@@ -1,0 +1,55 @@
+---
+description: Dead code
+---
+
+## Dead code
+
+**Severity**: `CodeSize`
+**ID**: `dead-code`
+
+Flags internal and private functions that are not reachable from contract entry points or
+construction-time initializers.
+
+### What it does
+
+Reports implemented internal or private functions that are never reachable from public/external
+functions, constructors, fallback/receive functions, modifiers used by reachable functions, or state
+variable initializers. Public and external functions are treated as entry points. Abstract
+declarations, library functions, and virtual base implementations that are overridden are skipped.
+
+### Why is this bad?
+
+Dead functions increase bytecode size and make review harder. Removing them reduces deployment cost,
+keeps contracts easier to audit, and avoids carrying stale implementation paths.
+
+### Example
+
+#### Bad
+
+```solidity
+contract C {
+    function run() external {}
+
+    function unused() internal pure returns (uint256) {
+        return 1;
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract C {
+    function run() external pure returns (uint256) {
+        return helper();
+    }
+
+    function helper() internal pure returns (uint256) {
+        return 1;
+    }
+}
+```
+
+### Notes
+
+This is a `CodeSize`-severity lint and is **not** applied to test or script files.


### PR DESCRIPTION
## Summary
- Add the `dead-code` lint reference page.
- Add `dead-code` to the Forge linting index and Code size sidebar group.

## Counterpart
- Foundry PR: https://github.com/foundry-rs/foundry/pull/14726
