### PR TITLE
docs(lint): document locked-ether lint

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -59,6 +59,7 @@ const docs = [
               { text: "divide-before-multiply", link: "/forge/linting/divide-before-multiply" },
               { text: "incorrect-erc20-interface", link: "/forge/linting/incorrect-erc20-interface" },
               { text: "incorrect-erc721-interface", link: "/forge/linting/incorrect-erc721-interface" },
+              { text: "locked-ether", link: "/forge/linting/locked-ether" },
               { text: "tx-origin", link: "/forge/linting/tx-origin" },
               { text: "unsafe-typecast", link: "/forge/linting/unsafe-typecast" },
             ],

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -164,6 +164,7 @@ navigation on the right to browse by severity.
 - [`divide-before-multiply`](/forge/linting/divide-before-multiply) — Flags arithmetic expressions where division is performed before multiplication, which can cause unintended precision loss in integer arithmetic.
 - [`incorrect-erc20-interface`](/forge/linting/incorrect-erc20-interface) — Flags interfaces or contracts whose function signatures match an ERC20 method by name and parameters but use the wrong return type.
 - [`incorrect-erc721-interface`](/forge/linting/incorrect-erc721-interface) — Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by name and parameters but use the wrong return type.
+- [`locked-ether`](/forge/linting/locked-ether) — Flags contracts that can receive Ether (via `payable` functions, `receive()`, or a payable `fallback()`) but expose no code path that can send Ether out, permanently trapping user funds.
 - [`tx-origin`](/forge/linting/tx-origin) — Flags use of `tx.origin` inside authorization-like predicates, which can be exploited by a malicious contract acting on behalf of a legitimate owner.
 - [`unsafe-typecast`](/forge/linting/unsafe-typecast) — Flags explicit numeric typecasts that can silently truncate or alter the value.
 

--- a/src/pages/forge/linting/locked-ether.mdx
+++ b/src/pages/forge/linting/locked-ether.mdx
@@ -1,0 +1,72 @@
+---
+description: Contract receives ETH but has no way to send it out
+---
+
+## Locked Ether
+
+**Severity**: `Med`
+**ID**: `locked-ether`
+
+Flags contracts that can receive Ether (via `payable` functions, `receive()`, or a payable
+`fallback()`) but expose no code path that can send Ether out. Any Ether sent to such a contract
+is permanently trapped.
+
+### What it does
+
+For every concrete or abstract contract, the lint:
+
+1. Checks whether the contract — or any contract in its inheritance chain — has at least one
+   payable entry point (`receive()`, payable `fallback()`, payable constructor, or any payable
+   function).
+2. Walks every function defined in the contract and its linearized bases looking for a code path
+   that can move Ether out. The following are recognized as ETH-sending operations:
+   - `addr.transfer(amount)` and `addr.send(amount)` with a non-literal-zero amount.
+   - Any call carrying a non-zero `{value: x}` option, including
+     `addr.call{value: x}(...)`, `addr.delegatecall{value: x}(...)`, and `new C{value: x}(...)`.
+   - Low-level `addr.delegatecall(...)` / `addr.callcode(...)` (the callee runs in this contract's
+     context and can `selfdestruct`, draining the balance).
+   - The `selfdestruct(addr)` builtin.
+3. Internal and library calls whose callee statically resolves to a function are followed
+   transitively, so a withdrawal helper buried behind several internal hops is detected. External
+   calls through unresolved member access are not followed, to keep false positives down.
+
+If no ETH-sending path is found, the lint reports the contract as locked at the contract's name.
+
+### Why is this bad?
+
+A contract that accepts Ether but cannot pay it back permanently traps user funds, with no way to
+recover them. This is almost always a bug — typically a missing `withdraw()` function, a forgotten
+access-controlled transfer, or a confused use of `payable` — and is hard to spot during review
+because each individual function looks correct.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Vault {
+    // Accepts ETH...
+    receive() external payable {}
+
+    // ...but provides no way to send it back out.
+}
+```
+
+#### Good
+
+```solidity
+contract Vault {
+    address payable public immutable owner;
+
+    constructor() {
+        owner = payable(msg.sender);
+    }
+
+    receive() external payable {}
+
+    function withdraw(uint256 amount) external {
+        require(msg.sender == owner, "not owner");
+        owner.transfer(amount);
+    }
+}
+```

--- a/src/pages/forge/linting/locked-ether.mdx
+++ b/src/pages/forge/linting/locked-ether.mdx
@@ -22,7 +22,7 @@ For every concrete or abstract contract, the lint:
    that can move Ether out. The following are recognized as ETH-sending operations:
    - `addr.transfer(amount)` and `addr.send(amount)` with a non-literal-zero amount.
    - Any call carrying a non-zero `{value: x}` option, including
-     `addr.call{value: x}(...)`, `addr.delegatecall{value: x}(...)`, and `new C{value: x}(...)`.
+     `addr.call{value: x}(...)` and `new C{value: x}(...)`.
    - Low-level `addr.delegatecall(...)` / `addr.callcode(...)` (the callee runs in this contract's
      context and can `selfdestruct`, draining the balance).
    - The `selfdestruct(addr)` builtin.


### PR DESCRIPTION
Adds the reference page and sidebar entry for the new `locked-ether` lint. https://github.com/foundry-rs/foundry/pull/14736