### PR TITLE
docs(lint): add external-function lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -102,6 +102,7 @@ const docs = [
               { text: "asm-keccak256", link: "/forge/linting/asm-keccak256" },
               { text: "could-be-immutable", link: "/forge/linting/could-be-immutable" },
               { text: "custom-errors", link: "/forge/linting/custom-errors" },
+              { text: "external-function", link: "/forge/linting/external-function" },
               { text: "unused-state-variables", link: "/forge/linting/unused-state-variables" },
               { text: "var-read-using-this", link: "/forge/linting/var-read-using-this" },
             ],

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -198,6 +198,7 @@ navigation on the right to browse by severity.
 - [`asm-keccak256`](/forge/linting/asm-keccak256) — Flags calls to the high-level `keccak256(...)` builtin that can be cheaply rewritten with inline assembly.
 - [`could-be-immutable`](/forge/linting/could-be-immutable) — Flags state variables that are assigned only in the constructor and never written to afterward — making them eligible to be declared `immutable`.
 - [`custom-errors`](/forge/linting/custom-errors) — Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing them with a `revert CustomError(...)`.
+- [`external-function`](/forge/linting/external-function) — Flags `public` functions that are never called internally and have a reference-type `memory` parameter; switching them to `external` (with `calldata` parameters) avoids an extra calldata-to-memory copy.
 - [`unused-state-variables`](/forge/linting/unused-state-variables) — Flags state variables that are declared but never read or written anywhere in the contract or its descendants.
 - [`var-read-using-this`](/forge/linting/var-read-using-this) — Flags `this.X(...)` calls that read the contract's own state through its external interface; the unnecessary `STATICCALL` can be avoided by accessing the variable directly.
 

--- a/src/pages/forge/linting/external-function.mdx
+++ b/src/pages/forge/linting/external-function.mdx
@@ -1,0 +1,82 @@
+---
+description: Public function can be declared external
+---
+
+## Public function can be declared external
+
+**Severity**: `Gas`
+**ID**: `external-function`
+
+Flags `public` functions that are never called from inside the contract or any of its
+derivatives and that take at least one reference-type parameter currently located in
+`memory`. Such functions can be declared `external` (and their reference parameters moved to
+`calldata`) to avoid copying arguments from `calldata` into `memory` on every call.
+
+### What it does
+
+Reports a `public` function declaration when **all** of the following hold:
+
+- It is `public` (not `external`, `internal`, or `private`).
+- It is an ordinary function (not a constructor, fallback, receive, or modifier).
+- It has at least one parameter that is a reference type (`struct`, array, `bytes`, or
+  `string`) currently located in `memory`.
+- It is not an `override` of another function. The base must be migrated first because
+  Solidity only allows widening visibility from `external` to `public`, never the reverse.
+- It has a body (so it is neither abstract nor an interface declaration).
+- It does not write to any of its parameters inside the body.
+- It is never called from inside the contract or any contract that derives from it,
+  whether directly (`foo(...)`), via `super.foo(...)`, or as a function-pointer
+  reference (`fn = foo;`).
+
+### Why is this bad?
+
+Calling a `public` function from outside the contract is more expensive than calling the
+equivalent `external` function:
+
+- Every reference-type argument is copied from `calldata` into `memory` before the body
+  executes, even when the only callers are external.
+- The dispatcher includes additional bytecode to support both internal and external entry
+  points, increasing deployment cost and adding a branch on every call.
+
+When the function is never called internally, switching `public` to `external` removes both
+costs without changing semantics.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Vault {
+    mapping(address => uint256) public balances;
+
+    function deposit(address[] memory accounts, uint256[] memory amounts) public {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            balances[accounts[i]] += amounts[i];
+        }
+    }
+}
+```
+
+`deposit` is never called from inside `Vault`, but its `memory` arrays force an
+unnecessary calldata-to-memory copy on every external call.
+
+#### Good
+
+```solidity
+contract Vault {
+    mapping(address => uint256) public balances;
+
+    function deposit(address[] calldata accounts, uint256[] calldata amounts) external {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            balances[accounts[i]] += amounts[i];
+        }
+    }
+}
+```
+
+When migrating `public` to `external`, also change reference-type parameters from `memory`
+to `calldata` to capture the full gas saving.
+
+### Notes
+
+This is a `Gas`-severity lint and is **not** applied to test or script files.


### PR DESCRIPTION
Adds the docs page and sidebar/index entries for the new external-function lint. https://github.com/foundry-rs/foundry/pull/14737