### PR TITLE
docs(lint): add calls-loop lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -76,6 +76,7 @@ const docs = [
             collapsed: true,
             items: [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
+              { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
             ],
           },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -178,6 +178,7 @@ navigation on the right to browse by severity.
 #### Low severity
 
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
+- [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 
 #### Informational
@@ -217,4 +218,3 @@ navigation on the right to browse by severity.
 #### Code size
 
 - [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Flags modifiers whose body contains non-trivial logic that should be moved into a helper function to reduce contract code size.
-

--- a/src/pages/forge/linting/calls-loop.mdx
+++ b/src/pages/forge/linting/calls-loop.mdx
@@ -1,0 +1,66 @@
+---
+description: External calls inside loops
+---
+
+## External calls inside loops
+
+**Severity**: `Low`
+**ID**: `calls-loop`
+
+Flags external calls made from inside loops.
+
+### What it does
+
+Reports external calls that are reachable from a `for`, `while`, or `do-while` loop body. This
+includes low-level calls, ETH `send`/`transfer`, contract or interface calls, calls through
+`this`, and external calls reached through an internal helper called from inside the loop.
+
+Library-style member calls on non-contract values are ignored.
+
+### Why is this bad?
+
+External calls can revert or consume enough gas to prevent the loop from completing. If the loop
+must process many recipients or contracts in one transaction, one failing callee can deny service
+to every later iteration.
+
+This is especially risky for push-payment patterns where every recipient must accept ETH before the
+function can finish.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Payouts {
+    address payable[] recipients;
+
+    function payAll() external payable {
+        for (uint256 i; i < recipients.length; ++i) {
+            recipients[i].transfer(1 ether);
+        }
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract Payouts {
+    mapping(address => uint256) public owed;
+
+    function queuePayment(address recipient, uint256 amount) external {
+        owed[recipient] += amount;
+    }
+
+    function claim() external {
+        uint256 amount = owed[msg.sender];
+        owed[msg.sender] = 0;
+        payable(msg.sender).transfer(amount);
+    }
+}
+```
+
+### Recommendation
+
+Favor pull-based accounting: record what each recipient can claim, then let each recipient claim in
+a separate transaction.


### PR DESCRIPTION
## Summary
- add the `calls-loop` lint reference page
- add `calls-loop` to the linting index and low-severity sidebar

## Related
- foundry-rs/foundry#14778

## Tests
- `git diff --check`