### PR TITLE
docs: note npm distribution deprecation

### DIFF
--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -88,6 +88,10 @@ Use `foundryup --force` to skip verification and force a fresh install.
 
 ## Alternative installation methods
 
+:::note
+Foundry no longer publishes npm packages for `forge`, `cast`, `anvil`, or `chisel`. Use `foundryup`, GitHub releases, Docker, or build from source instead.
+:::
+
 ### Precompiled binaries
 
 Download binaries directly from the [GitHub releases page](https://github.com/foundry-rs/foundry/releases). Extract and add them to your `PATH`.


### PR DESCRIPTION
## Summary
- add a note to the installation page that Foundry is no longer distributed through npm packages
- point users to foundryup, GitHub releases, Docker, or source builds instead

## Context
Follows up on foundry-rs/foundry@a4f639d7ac7241dfd57bd0409f5589e34687bf2a, which removed npm publishing support.

## Testing
- Searched the book for npm/@foundry-rs/npx references
- Attempted `bun install --frozen-lockfile` (failed: Bun wanted lockfile changes)
- Attempted `bun run build` (failed at `vite`: dependencies unavailable after frozen install failure)