### PR TITLE
docs(lint): add delegatecall-loop page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -79,6 +79,7 @@ const docs = [
             items: [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
+              { text: "delegatecall-loop", link: "/forge/linting/delegatecall-loop" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
             ],
           },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -181,6 +181,7 @@ navigation on the right to browse by severity.
 
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
+- [`delegatecall-loop`](/forge/linting/delegatecall-loop) — Flags `delegatecall` operations inside loops in externally callable payable functions.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 
 #### Informational

--- a/src/pages/forge/linting/delegatecall-loop.mdx
+++ b/src/pages/forge/linting/delegatecall-loop.mdx
@@ -1,0 +1,58 @@
+---
+description: Delegatecall inside payable loops
+---
+
+## Delegatecall inside payable loops
+
+**Severity**: `Low`
+**ID**: `delegatecall-loop`
+
+Flags `delegatecall` operations inside loops in externally callable payable functions.
+
+### What it does
+
+Reports `delegatecall` expressions that appear in the body of a `for`, `while`, or `do-while`
+loop when the enclosing function is `public payable` or `external payable`.
+
+### Why is this bad?
+
+`delegatecall` executes another contract's code in the caller's storage context and preserves the
+original `msg.sender` and `msg.value`. In a payable function, a loop can therefore expose the same
+`msg.value` to multiple delegatecalls even though Ether was only transferred once.
+
+If the delegated code accounts for `msg.value`, one transaction can credit the same payment
+multiple times or repeatedly mutate the caller's storage in unexpected ways.
+
+### Example
+
+#### Bad
+
+```solidity
+function batch(address[] calldata receivers) external payable {
+    for (uint256 i; i < receivers.length; ++i) {
+        (bool ok,) = address(this).delegatecall(
+            abi.encodeWithSignature("credit(address)", receivers[i])
+        );
+        require(ok);
+    }
+}
+```
+
+#### Good
+
+```solidity
+function batch(address[] calldata receivers) external payable {
+    uint256 share = msg.value / receivers.length;
+    for (uint256 i; i < receivers.length; ++i) {
+        _credit(receivers[i], share);
+    }
+}
+```
+
+### Recommendation
+
+Avoid `delegatecall` in payable loops. Prefer direct internal logic, or calculate the per-iteration
+value explicitly before the loop and pass that value to code that performs the accounting.
+
+If `delegatecall` is required, review the delegated code carefully and make sure it cannot reuse
+the same `msg.value` or unexpectedly modify caller storage across loop iterations.


### PR DESCRIPTION
Adds the Foundry Book page for the new `delegatecall-loop` lint from foundry-rs/foundry#14752.

The page documents what the lint flags, why delegatecall inside payable loops is risky, and a safer accounting pattern. It also links the new low-severity lint from the lint reference index and sidebar navigation.