### PR TITLE
docs: add return-bomb lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -80,6 +80,7 @@ const docs = [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
+              { text: "return-bomb", link: "/forge/linting/return-bomb" },
             ],
           },
           {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -22,6 +22,7 @@ The linter checks for:
 - Unsafe typecasts
 - Naming convention violations
 - Use of tx.origin for authorization
+- Return bomb risks from gas-limited calls
 - Unused imports
 - Gas optimizations
 
@@ -182,6 +183,7 @@ navigation on the right to browse by severity.
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
+- [`return-bomb`](/forge/linting/return-bomb) — Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.
 
 #### Informational
 

--- a/src/pages/forge/linting/return-bomb.mdx
+++ b/src/pages/forge/linting/return-bomb.mdx
@@ -1,0 +1,52 @@
+---
+description: Return bomb
+---
+
+## Return bomb
+
+**Severity**: `Low`
+**ID**: `return-bomb`
+
+Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.
+
+### What it does
+
+Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`.
+Solidity copies the full returndata for these calls even when the second tuple element is ignored.
+
+It also detects high-level external calls with `{gas: ...}` that consume dynamically encoded return
+values such as `bytes`, `string`, dynamic arrays, or structs containing dynamic fields.
+
+### Why is this bad?
+
+The gas option limits gas forwarded to the callee, but copying returndata into memory is paid by
+the caller after the call returns. A malicious callee can return or revert with large returndata,
+causing the caller to run out of gas while implicitly copying the result.
+
+### Example
+
+#### Bad
+
+```solidity
+function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
+    (bool ok, ) = target.call{gas: gasLimit}(payload);
+    require(ok);
+}
+```
+
+#### Good
+
+```solidity
+function callTarget(address target, bytes memory payload, uint256 gasLimit) external {
+    bool ok;
+    assembly {
+        ok := call(gasLimit, target, 0, add(payload, 0x20), mload(payload), 0, 0)
+    }
+    require(ok);
+}
+```
+
+### Notes
+
+Ignoring the second tuple element does not avoid the returndata copy. If the returndata is needed,
+copy only a bounded number of bytes with a helper that caps returndata size.


### PR DESCRIPTION
## Summary

- add a dedicated `return-bomb` lint reference page
- list the lint under low severity in the linting index and sidebar
- explain the returndata-copy risk for gas-limited calls and the bounded-copy mitigation