### PR TITLE
docs: add unprotected initializer lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -50,6 +50,7 @@ const docs = [
               { text: "reentrancy-unlimited-gas", link: "/forge/linting/reentrancy-unlimited-gas" },
               { text: "rtlo", link: "/forge/linting/rtlo" },
               { text: "unchecked-call", link: "/forge/linting/unchecked-call" },
+              { text: "unprotected-initializer", link: "/forge/linting/unprotected-initializer" },
             ],
           },
           {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -160,6 +160,7 @@ navigation on the right to browse by severity.
 - [`reentrancy-unlimited-gas`](/forge/linting/reentrancy-unlimited-gas) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.
 - [`rtlo`](/forge/linting/rtlo) — Flags the presence of Unicode bidirectional override characters in source code, which can be used to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).
 - [`unchecked-call`](/forge/linting/unchecked-call) — Flags low-level calls (`call`, `delegatecall`, `staticcall`, `callcode`) whose `success` return value is ignored.
+- [`unprotected-initializer`](/forge/linting/unprotected-initializer) — Flags upgradeable initializers that can be called directly on an implementation contract with a destructive entry point.
 
 #### Medium severity
 

--- a/src/pages/forge/linting/unprotected-initializer.mdx
+++ b/src/pages/forge/linting/unprotected-initializer.mdx
@@ -16,7 +16,7 @@ Warns on public or external functions that:
 
 1. are marked with an `initializer` or `reinitializer` modifier;
 2. write state directly or through an internal helper;
-3. belong to an implementation whose constructor does not call `_disableInitializers()`; and
+3. belong to an implementation whose constructor does not call an inherited `_disableInitializers()`; and
 4. are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
    that is not restricted to proxy calls with `onlyProxy`.
 

--- a/src/pages/forge/linting/unprotected-initializer.mdx
+++ b/src/pages/forge/linting/unprotected-initializer.mdx
@@ -1,0 +1,74 @@
+---
+description: Unprotected upgradeable initializer
+---
+
+## Unprotected upgradeable initializer
+
+**Severity**: `High`
+**ID**: `unprotected-initializer`
+
+Flags upgradeable contracts whose public or external initializer can still be called directly on
+an implementation contract that exposes a destructive entry point.
+
+### What it does
+
+Warns on public or external functions that:
+
+1. are marked with an `initializer` or `reinitializer` modifier;
+2. write state directly or through an internal helper;
+3. belong to an implementation whose constructor does not call `_disableInitializers()` and is not
+   itself marked `initializer`; and
+4. are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
+   that is not restricted to proxy calls with `onlyProxy`.
+
+The `onlyProxy` exemption is a name-based heuristic for common UUPS implementations.
+
+### Why is this bad?
+
+Upgradeable implementation contracts are deployed as ordinary contracts. If their initializer is
+left callable on the implementation itself, anyone can initialize implementation storage. When the
+same implementation also exposes a destructive path such as `delegatecall` or `selfdestruct`, an
+attacker may be able to take ownership of the implementation context and destroy or replace it.
+
+Lock the implementation during deployment, for example by calling OpenZeppelin's
+`_disableInitializers()` in the constructor.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Vault is Initializable {
+    address public owner;
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract Vault is Initializable {
+    address public owner;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner_) public initializer {
+        owner = owner_;
+    }
+
+    function execute(address target, bytes calldata data) external {
+        (bool ok,) = target.delegatecall(data);
+        require(ok);
+    }
+}
+```

--- a/src/pages/forge/linting/unprotected-initializer.mdx
+++ b/src/pages/forge/linting/unprotected-initializer.mdx
@@ -16,8 +16,7 @@ Warns on public or external functions that:
 
 1. are marked with an `initializer` or `reinitializer` modifier;
 2. write state directly or through an internal helper;
-3. belong to an implementation whose constructor does not call `_disableInitializers()` and is not
-   itself marked `initializer`; and
+3. belong to an implementation whose constructor does not call `_disableInitializers()`; and
 4. are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
    that is not restricted to proxy calls with `onlyProxy`.
 


### PR DESCRIPTION
## Summary
- add the book page for the new `unprotected-initializer` lint
- link it from the linting index and high-severity sidebar

Pairs with foundry-rs/foundry#14886.

## Tests
- `bun run build`