### PR TITLE
docs(lint): add missing events arithmetic page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -81,6 +81,7 @@ const docs = [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "delegatecall-loop", link: "/forge/linting/delegatecall-loop" },
+              { text: "missing-events-arithmetic", link: "/forge/linting/missing-events-arithmetic" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
               { text: "reentrancy-events", link: "/forge/linting/reentrancy-events" },
               { text: "return-bomb", link: "/forge/linting/return-bomb" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -184,6 +184,7 @@ navigation on the right to browse by severity.
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`delegatecall-loop`](/forge/linting/delegatecall-loop) — Flags `delegatecall` operations inside loops in externally callable payable functions.
+- [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags access-controlled updates to integer state used in arithmetic when the update path does not emit an event.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 - [`reentrancy-events`](/forge/linting/reentrancy-events) — Flags `emit` statements reachable after an external call, where a reentrant callee can reorder or fabricate logs that off-chain consumers rely on.
 - [`return-bomb`](/forge/linting/return-bomb) — Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.

--- a/src/pages/forge/linting/missing-events-arithmetic.mdx
+++ b/src/pages/forge/linting/missing-events-arithmetic.mdx
@@ -7,23 +7,27 @@ description: Missing events for arithmetic state changes
 **Severity**: `Low`
 **ID**: `missing-events-arithmetic`
 
-Flags protected entry-point functions that update tainted integer state used in arithmetic by an
-unprotected function without emitting an event.
+Flags protected entry-point functions that update dynamic integer state used in arithmetic by an
+unprotected function without emitting an event on the update path.
 
 ### What it does
 
 Looks for scalar `int` and `uint` state variables that are:
 
 1. written by a public or external state-mutating function with access control;
-2. assigned from function input, directly or through local aliases or internal helpers, or changed
+2. assigned from a dynamic value, directly or through local aliases or internal helpers, or changed
    with an arithmetic assignment or increment/decrement;
 3. used in arithmetic by an unprotected public or external function; and
-4. changed along a path that does not emit an event.
+4. changed along a path where the pending write is not followed by an event.
+
+Dynamic values include function inputs, mutable state variables, built-ins such as `block.timestamp`,
+and call results.
 
 The lint intentionally skips fixed-value writes, constructors, unprotected setters, mappings,
-arrays, and update paths that emit an event directly or through an internal helper. These limits
-keep the rule focused on configuration-style arithmetic parameters and avoid noisy warnings for
-updates that are not clearly part of an externally visible calculation.
+arrays, and update paths where the write is followed by an event directly, through an internal
+helper, or after `_` in a modifier. These limits keep the rule focused on configuration-style
+arithmetic parameters and avoid noisy warnings for updates that are not clearly part of an
+externally visible calculation.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/missing-events-arithmetic.mdx
+++ b/src/pages/forge/linting/missing-events-arithmetic.mdx
@@ -15,14 +15,15 @@ unprotected function without emitting an event.
 Looks for scalar `int` and `uint` state variables that are:
 
 1. written by a public or external state-mutating function with access control;
-2. assigned from function input, directly or through local aliases or internal helpers;
+2. assigned from function input, directly or through local aliases or internal helpers, or changed
+   with an arithmetic assignment or increment/decrement;
 3. used in arithmetic by an unprotected public or external function; and
 4. changed along a path that does not emit an event.
 
 The lint intentionally skips fixed-value writes, constructors, unprotected setters, mappings,
-arrays, and functions that emit any event directly or through an internal helper. These limits keep
-the rule focused on configuration-style arithmetic parameters and avoid noisy warnings for updates
-that are not clearly part of an externally visible calculation.
+arrays, and update paths that emit an event directly or through an internal helper. These limits
+keep the rule focused on configuration-style arithmetic parameters and avoid noisy warnings for
+updates that are not clearly part of an externally visible calculation.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/missing-events-arithmetic.mdx
+++ b/src/pages/forge/linting/missing-events-arithmetic.mdx
@@ -1,0 +1,80 @@
+---
+description: Missing events for arithmetic state changes
+---
+
+## Missing events for arithmetic state changes
+
+**Severity**: `Low`
+**ID**: `missing-events-arithmetic`
+
+Flags protected entry-point functions that update tainted integer state used in arithmetic by an
+unprotected function without emitting an event.
+
+### What it does
+
+Looks for scalar `int` and `uint` state variables that are:
+
+1. written by a public or external state-mutating function with access control;
+2. assigned from function input, directly or through local aliases or internal helpers;
+3. used in arithmetic by an unprotected public or external function; and
+4. changed along a path that does not emit an event.
+
+The lint intentionally skips fixed-value writes, constructors, unprotected setters, mappings,
+arrays, and functions that emit any event directly or through an internal helper. These limits keep
+the rule focused on configuration-style arithmetic parameters and avoid noisy warnings for updates
+that are not clearly part of an externally visible calculation.
+
+### Why is this bad?
+
+Off-chain monitors, users, and auditors often rely on events to track changes to critical contract
+parameters such as prices, fees, caps, and rates. If a protected function silently changes a
+parameter used in calculations, downstream behavior can change without an easy audit trail.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Market {
+    address public owner = msg.sender;
+    uint256 public buyPrice;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+        buyPrice = newBuyPrice;
+    }
+
+    function quote(uint256 amount) external view returns (uint256) {
+        return amount / buyPrice;
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract Market {
+    address public owner = msg.sender;
+    uint256 public buyPrice;
+
+    event BuyPriceUpdated(uint256 newBuyPrice);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+        buyPrice = newBuyPrice;
+        emit BuyPriceUpdated(newBuyPrice);
+    }
+
+    function quote(uint256 amount) external view returns (uint256) {
+        return amount / buyPrice;
+    }
+}
+```


### PR DESCRIPTION
## Summary
- add the Book page for `missing-events-arithmetic`
- link the lint from the low-severity lint index and sidebar

## Verification
- `bun run build`