### PR TITLE
docs(lint): add missing events access control lint docs

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -81,6 +81,7 @@ const docs = [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "delegatecall-loop", link: "/forge/linting/delegatecall-loop" },
+              { text: "missing-events-access-control", link: "/forge/linting/missing-events-access-control" },
               { text: "missing-events-arithmetic", link: "/forge/linting/missing-events-arithmetic" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
               { text: "reentrancy-events", link: "/forge/linting/reentrancy-events" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -184,6 +184,7 @@ navigation on the right to browse by severity.
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`delegatecall-loop`](/forge/linting/delegatecall-loop) — Flags `delegatecall` operations inside loops in externally callable payable functions.
+- [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags access-controlled updates to state used for authorization when the update function does not emit an event.
 - [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags access-controlled updates to integer state used in arithmetic when the update path does not emit an event.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 - [`reentrancy-events`](/forge/linting/reentrancy-events) — Flags `emit` statements reachable after an external call, where a reentrant callee can reorder or fabricate logs that off-chain consumers rely on.

--- a/src/pages/forge/linting/missing-events-access-control.mdx
+++ b/src/pages/forge/linting/missing-events-access-control.mdx
@@ -16,13 +16,15 @@ Looks for mutable state variables that are:
 
 1. read by an access-control check involving `msg.sender` or `tx.origin`;
 2. written by a public or external state-mutating function with access control;
-3. assigned from function input, directly or through local aliases or internal helpers; and
-4. changed by a function that does not emit any event directly or through an internal helper.
+3. assigned from function input, sender data, access-control state, or indexed mapping keys,
+   directly or through local aliases or internal helpers; and
+4. changed without a related event that covers the updated access-control state.
 
 The lint intentionally skips constructors, unprotected setters, variables not used in authorization
-checks, fixed writes, and functions that emit any event directly or through an internal helper.
-These limits keep the rule focused on authority-bearing state and avoid noisy warnings for updates
-that are not clearly part of access control.
+checks, and fixed writes that are not clearing access-control state used by the active guard. Events
+must be related to the updated state, so unrelated logging does not suppress the warning. These
+limits keep the rule focused on authority-bearing state and avoid noisy warnings for updates that
+are not clearly part of access control.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/missing-events-access-control.mdx
+++ b/src/pages/forge/linting/missing-events-access-control.mdx
@@ -1,0 +1,71 @@
+---
+description: Missing events for access control changes
+---
+
+## Missing events for access control changes
+
+**Severity**: `Low`
+**ID**: `missing-events-access-control`
+
+Flags protected entry-point functions that update state used for access control without emitting an
+event.
+
+### What it does
+
+Looks for mutable state variables that are:
+
+1. read by an access-control check involving `msg.sender` or `tx.origin`;
+2. written by a public or external state-mutating function with access control;
+3. assigned from function input, directly or through local aliases or internal helpers; and
+4. changed by a function that does not emit any event directly or through an internal helper.
+
+The lint intentionally skips constructors, unprotected setters, variables not used in authorization
+checks, fixed writes, and functions that emit any event directly or through an internal helper.
+These limits keep the rule focused on authority-bearing state and avoid noisy warnings for updates
+that are not clearly part of access control.
+
+### Why is this bad?
+
+Off-chain monitors, users, and auditors often rely on events to track changes to owners, guardians,
+roles, and other authority-bearing state. If a protected function silently changes access control,
+critical permission updates are harder to review and investigate.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Owned {
+    address public owner = msg.sender;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        owner = newOwner;
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract Owned {
+    address public owner = msg.sender;
+
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        address oldOwner = owner;
+        owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+}
+```


### PR DESCRIPTION
## Summary

- add the `missing-events-access-control` linting page
- include the lint in the Forge linting index and sidebar

## Validation

- `bun run build`
