### PR TITLE
docs(lint): add reentrancy-eth page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -48,7 +48,7 @@ const docs = [
               { text: "encode-packed-collision", link: "/forge/linting/encode-packed-collision" },
               { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },
               { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },
-              { text: "reentrancy-unlimited-gas", link: "/forge/linting/reentrancy-unlimited-gas" },
+              { text: "reentrancy-eth", link: "/forge/linting/reentrancy-eth" },
               { text: "rtlo", link: "/forge/linting/rtlo" },
               { text: "unchecked-call", link: "/forge/linting/unchecked-call" },
               { text: "unprotected-initializer", link: "/forge/linting/unprotected-initializer" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -158,7 +158,7 @@ navigation on the right to browse by severity.
 - [`encode-packed-collision`](/forge/linting/encode-packed-collision) — Flags `abi.encodePacked()` calls with two or more dynamic-type arguments (`string`, `bytes`, `T[]`) that can produce hash collisions.
 - [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
 - [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.
-- [`reentrancy-unlimited-gas`](/forge/linting/reentrancy-unlimited-gas) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.
+- [`reentrancy-eth`](/forge/linting/reentrancy-eth) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.
 - [`rtlo`](/forge/linting/rtlo) — Flags the presence of Unicode bidirectional override characters in source code, which can be used to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).
 - [`unchecked-call`](/forge/linting/unchecked-call) — Flags low-level calls (`call`, `delegatecall`, `staticcall`, `callcode`) whose `success` return value is ignored.
 - [`unprotected-initializer`](/forge/linting/unprotected-initializer) — Flags upgradeable initializers that can be called directly on an implementation contract with a destructive entry point.

--- a/src/pages/forge/linting/reentrancy-eth.mdx
+++ b/src/pages/forge/linting/reentrancy-eth.mdx
@@ -1,11 +1,11 @@
 ---
-description: Reentrancy through unlimited-gas ETH calls
+description: ETH reentrancy through uncapped calls
 ---
 
-## Reentrancy through unlimited-gas ETH calls
+## ETH reentrancy through uncapped calls
 
 **Severity**: `High`
-**ID**: `reentrancy-unlimited-gas`
+**ID**: `reentrancy-eth`
 
 Flags uncapped ETH-transferring low-level `call` operations when state read before the call is
 written after the call.
@@ -15,7 +15,8 @@ written after the call.
 Warns when a function performs `.call{value: ...}(...)` without a concrete gas cap, or with
 `gas: gasleft()`, and later writes a state variable that was read before the call on the same
 reachable path. Local internal helper calls and modifiers are analyzed when their bodies are
-available.
+available. This uses Slither's `reentrancy-eth` detector name, while intentionally narrowing
+reporting to uncapped ETH-transferring low-level calls.
 
 ### Why is this bad?
 

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,7 @@
 
     { "source": "/forge/reference/forge-lint/", "destination": "/forge/linting" },
     { "source": "/forge/reference/forge-lint", "destination": "/forge/linting" },
+    { "source": "/forge/linting/reentrancy-unlimited-gas", "destination": "/forge/linting/reentrancy-eth" },
 
     { "source": "/cast/overview", "destination": "/cast" },
 


### PR DESCRIPTION
## Summary
- rename the lint docs page from `reentrancy-unlimited-gas` to `reentrancy-eth`
- update the lint index and sidebar link
- add a redirect from the old lint URL to the new page
- document the conservative ETH-only behavior from foundry-rs/foundry#14970

## Testing
- `bun run build`