### PR TITLE
chore: verify Vocs v2 setup

### DIFF
--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -1,7 +1,7 @@
 // deno-fmt-ignore-file
 // biome-ignore format: generated types do not need formatting
 // prettier-ignore
-import type { PathsForPages, GetConfigResponse } from 'waku/router';
+import type { PathsForPages } from 'waku/router';
 
 
 // prettier-ignore


### PR DESCRIPTION
## Summary
- Confirm the book is already using the current Vocs v2 release (2.0.10)
- Remove an unused generated Waku type import that blocks TypeScript with noUnusedLocals

## Validation
- bun install
- bunx tsc --noEmit

Note: bun run build reached Vocs/Vite transform and stayed CPU-bound without output for ~5 minutes in the sandbox, so it was stopped.