### PR TITLE
docs(lint): add reentrancy-no-eth page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -67,6 +67,7 @@ const docs = [
               { text: "incorrect-strict-equality", link: "/forge/linting/incorrect-strict-equality" },
               { text: "locked-ether", link: "/forge/linting/locked-ether" },
               { text: "low-level-calls", link: "/forge/linting/low-level-calls" },
+              { text: "reentrancy-no-eth", link: "/forge/linting/reentrancy-no-eth" },
               { text: "tx-origin", link: "/forge/linting/tx-origin" },
               { text: "type-based-tautology", link: "/forge/linting/type-based-tautology" },
               { text: "uninitialized-local", link: "/forge/linting/uninitialized-local" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -173,6 +173,7 @@ navigation on the right to browse by severity.
 - [`incorrect-erc721-interface`](/forge/linting/incorrect-erc721-interface) — Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by name and parameters but use the wrong return type.
 - [`locked-ether`](/forge/linting/locked-ether) — Flags contracts that can receive Ether (via `payable` functions, `receive()`, or a payable `fallback()`) but expose no code path that can send Ether out, permanently trapping user funds.
 - [`low-level-calls`](/forge/linting/low-level-calls) — Flags direct use of Solidity low-level calls (`call`, `delegatecall`, and `staticcall`).
+- [`reentrancy-no-eth`](/forge/linting/reentrancy-no-eth) — Flags non-ETH external calls when state read before the call is written after the call.
 - [`tx-origin`](/forge/linting/tx-origin) — Flags use of `tx.origin` inside authorization-like predicates, which can be exploited by a malicious contract acting on behalf of a legitimate owner.
 - [`type-based-tautology`](/forge/linting/type-based-tautology) — Flags comparison expressions that are always true or always false due to the numeric range of the variable's type.
 - [`uninitialized-local`](/forge/linting/uninitialized-local) — Flags local variables that are declared without an initializer and read before any explicit assignment, where the silent zero-default is almost certainly unintentional.

--- a/src/pages/forge/linting/reentrancy-no-eth.mdx
+++ b/src/pages/forge/linting/reentrancy-no-eth.mdx
@@ -1,0 +1,50 @@
+---
+description: No-ETH read-before-write reentrancy
+---
+
+## No-ETH read-before-write reentrancy
+
+**Severity**: `Medium`
+**ID**: `reentrancy-no-eth`
+
+Flags external calls that do not transfer ETH when state read before the call is written after the
+call on the same reachable path.
+
+### What it does
+
+Warns when a public or external entry point reads a state variable, performs a reentrant external
+call that does not send ETH, and later writes the same state variable. Local internal helper calls
+and modifiers are analyzed when their bodies are available. This uses Slither's
+`reentrancy-no-eth` detector name.
+
+### Why is this bad?
+
+Even without ETH transfer, an external call can invoke attacker-controlled code. If that code
+re-enters before later state changes occur, the original function may continue with stale state and
+overwrite or reuse values that changed during the reentrant execution.
+
+This lint is intentionally conservative to avoid noisy findings: it does not report ETH-transferring
+calls, view or pure interface calls, unrelated state writes, or constructor-time calls. It does not
+attempt to prove custom guard modifiers are effective.
+
+### Example
+
+#### Bad
+
+```solidity
+function claim(IHook hook) external {
+    uint256 amount = balances[msg.sender];
+    hook.notify(amount);
+    balances[msg.sender] = 0;
+}
+```
+
+#### Good
+
+```solidity
+function claim(IHook hook) external {
+    uint256 amount = balances[msg.sender];
+    balances[msg.sender] = 0;
+    hook.notify(amount);
+}
+```


### PR DESCRIPTION
## Summary
- add the `reentrancy-no-eth` lint reference page
- add `reentrancy-no-eth` to the Forge linting index and Medium severity sidebar

Companion to foundry-rs/foundry#15000.

## Testing
- `bun install --frozen-lockfile`
- `bun run build`