### PR TITLE
docs(lint): arbitrary-send-erc20-permit page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -45,6 +45,7 @@ const docs = [
             collapsed: true,
             items: [
               { text: "arbitrary-send-erc20", link: "/forge/linting/arbitrary-send-erc20" },
+              { text: "arbitrary-send-erc20-permit", link: "/forge/linting/arbitrary-send-erc20-permit" },
               { text: "arbitrary-send-eth", link: "/forge/linting/arbitrary-send-eth" },
               { text: "encode-packed-collision", link: "/forge/linting/encode-packed-collision" },
               { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -155,6 +155,7 @@ navigation on the right to browse by severity.
 #### High severity
 
 - [`arbitrary-send-erc20`](/forge/linting/arbitrary-send-erc20) — Flags `transferFrom` / `safeTransferFrom` calls whose `from` argument is not provably equal to `msg.sender` or `address(this)`.
+- [`arbitrary-send-erc20-permit`](/forge/linting/arbitrary-send-erc20-permit) — Flags `transferFrom` calls with an arbitrary `from` after a `permit(owner, address(this), …)` on the same `(token, owner)`.
 - [`arbitrary-send-eth`](/forge/linting/arbitrary-send-eth) — Flags functions that send ETH (via `transfer` / `send` / `{value:}` calls / `selfdestruct` / known OZ + Solady helpers) to a caller-controlled destination without restricting who can call them.
 - [`encode-packed-collision`](/forge/linting/encode-packed-collision) — Flags `abi.encodePacked()` calls with two or more dynamic-type arguments (`string`, `bytes`, `T[]`) that can produce hash collisions.
 - [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.

--- a/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
@@ -1,0 +1,117 @@
+---
+description: Arbitrary ERC20 send with permit
+---
+
+## Arbitrary ERC20 send with permit
+
+**Severity**: `High`
+**ID**: `arbitrary-send-erc20-permit`
+
+Flags `transferFrom` / `safeTransferFrom` calls whose `from` argument is not provably
+`msg.sender` (or `address(this)`) when the function also calls
+`token.permit(owner, address(this), …)` for the same token and owner beforehand.
+
+### What it does
+
+Detects, within a single function, the combination of:
+
+1. A preceding `permit(owner, spender, value, deadline, v, r, s)` on `token` with
+   `spender == address(this)`, and
+2. A subsequent ERC20-style transfer of the same token from the same `owner`, where
+   `owner` cannot be proven equal to `msg.sender` or `address(this)`.
+
+Both common sink shapes are recognised:
+
+- Member calls: `token.transferFrom(owner, to, amount)` and
+  `token.safeTransferFrom(owner, to, amount)`.
+- Library calls: `Lib.safeTransferFrom(token, owner, to, amount)`, including the
+  Solady-shaped `using SafeTransferLib for address` form.
+
+The lint does **not** require the transfer `amount` to equal the permit `value`,
+nor does it inspect deadlines or signatures — the dangerous combination is the
+permit-then-arbitrary-`transferFrom` pattern itself, not the specific amounts.
+
+Matching EIP-3156 flash-loan repayments (`onFlashLoan` followed by a pull-back of
+`amount + fee`) are excluded.
+
+#### Scope
+
+The check is intraprocedural and same-variable. It flags one
+permit-then-`transferFrom` flow inside a single function body and correlates the
+token, owner, and spender by the underlying variable, with the following
+normalisations applied to both sides of the correlation:
+
+- elementary type casts (`address(x)`), interface / contract casts
+  (`IERC20(rawToken)`), `payable(...)` wraps, and parentheses are stripped;
+- local aliases of `address(this)` (e.g.
+  `address self = address(this); permit(..., self, ...)`) are recognised as the
+  permit spender;
+- the `using SafeTransferLib for address` member form is treated as a sink.
+
+Dead code after a definite exit (`return` / `revert`) is skipped, and inline
+`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)` suppresses a single sink.
+
+Patterns the check does **not** classify as the permit-variant (the underlying call
+may still be reported by [`arbitrary-send-erc20`](/forge/linting/arbitrary-send-erc20)
+when the sink itself is unguarded) include: copies of the token or owner into another
+variable (`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
+struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through a
+library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called helper /
+modifier / parent contract, permits inside `for` or `while` loop bodies (whose
+execution count the analyzer treats as possibly zero), and permits whose success is
+verified by reading `nonces(owner)` before and after.
+
+### Why is this bad?
+
+A `permit` only authorizes pulling from `owner`. A contract that follows the permit
+with `transferFrom` and an arbitrary `from` lets an attacker submit a victim's permit
+signature and drain the victim's balance.
+
+The same pattern is also exploitable on tokens that don't implement `permit` but have
+a `fallback` (e.g. WETH): the `permit` call silently no-ops while the unconstrained
+`transferFrom` still executes, draining any pre-existing allowance from another user.
+
+### Example
+
+#### Bad
+
+```solidity
+function pullWithPermit(
+    address from,
+    address to,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external {
+    token.permit(from, address(this), value, deadline, v, r, s);
+    token.transferFrom(from, to, value); // arbitrary-send-erc20-permit
+}
+```
+
+#### Good
+
+```solidity
+function pullWithPermit(
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external {
+    // `from` is implicitly the caller — permit + transferFrom only touch the
+    // caller's own balance, even if `token` is a non-permit token with a fallback.
+    token.permit(msg.sender, address(this), value, deadline, v, r, s);
+    token.transferFrom(msg.sender, address(this), value);
+}
+```
+
+### Recommendation
+
+Constrain the sink's `from` to `msg.sender` (or `address(this)`), or restrict the
+sink to a vetted, deploy-time token allowlist whose `permit` implementation is
+verified. If your code separately proves the `permit` succeeded (for example by
+reading `token.nonces(owner)` before and after and reverting on no change), review
+the finding and suppress it locally with
+`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)`.

--- a/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
@@ -57,9 +57,8 @@ when the sink itself is unguarded) include: copies of the token or owner into an
 variable (`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
 struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through a
 library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called helper /
-modifier / parent contract, permits inside `for` or `while` loop bodies (whose
-execution count the analyzer treats as possibly zero), and permits whose success is
-verified by reading `nonces(owner)` before and after.
+modifier / parent contract, and permits inside `for` or `while` loop bodies (whose
+execution count the analyzer treats as possibly zero).
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/arbitrary-send-erc20.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20.mdx
@@ -35,14 +35,17 @@ Safety is established by:
   conjunctions thereof.
 - Inline equality guards in the prefix of a modifier body (statements strictly before its single
   top-level `_;` placeholder), mapped back to the caller's argument variables.
-- A prior EIP-2612 `permit(owner, address(this), …)` on the same token variable, on the **same
-  execution path** as the sink, with the sink's `from` variable matching the permit's `owner`. The
-  record is invalidated if either the token variable or the owner variable is reassigned before the
-  sink.
 
 Branch joins recognise `return`, custom-error `revert`, the `revert(...)` builtin, and
 `assert(false)` / `require(false, ...)` as always-exiting: facts proven on the surviving branch
 propagate past the `if`.
+
+### Related
+
+A prior EIP-2612 `permit(owner, address(this), …)` does **not** suppress this lint — the sink
+is instead reported as
+[`arbitrary-send-erc20-permit`](/forge/linting/arbitrary-send-erc20-permit), since non-EIP-2612
+tokens with a fallback can silently accept the permit and let any prior allowance be drained.
 
 ### Why is this bad?
 


### PR DESCRIPTION
Adds the docs page for the new `arbitrary-send-erc20-permit` lint and updates the `arbitrary-send-erc20` page (a prior permit no longer suppresses it).

https://github.com/foundry-rs/foundry/pull/15037