### PR TITLE
Fix invariant max_time_delay TOML example

### DIFF
--- a/src/pages/guides/invariant-testing.mdx
+++ b/src/pages/guides/invariant-testing.mdx
@@ -218,7 +218,7 @@ Use `max_time_delay` and `max_block_delay` when bugs depend on elapsed time or b
 
 ```toml [foundry.toml]
 [invariant]
-max_time_delay = 1 days
+max_time_delay = 86400 # 1 day, in seconds
 max_block_delay = 1000
 ```
 


### PR DESCRIPTION
## Summary
- replace invalid `max_time_delay = 1 days` TOML with `max_time_delay = 86400`
- add an inline comment clarifying the value is one day in seconds

## Validation
- parsed the corrected snippet with Python `tomllib`
- `bun install --frozen-lockfile && bun run build` was attempted; dependency install and benchmark generation completed, but `vocs build` hung during search-index/client-reference analysis and was stopped after several minutes

Prompted by: @DaniPopes