### PR TITLE
docs: clarify fork retry backoff units

### DIFF
--- a/src/pages/guides/fork-testing.mdx
+++ b/src/pages/guides/fork-testing.mdx
@@ -242,6 +242,8 @@ If your RPC provider rate-limits requests:
 $ forge test --fork-url $RPC_URL --fork-retry-backoff 1000
 ```
 
+The value is the initial retry delay in milliseconds, so `1000` starts retries with a one-second backoff. If omitted, Foundry uses the provider default.
+
 Or use a dedicated RPC provider with higher limits.
 
 #### Stale cache

--- a/src/pages/reference/anvil/anvil.mdx
+++ b/src/pages/reference/anvil/anvil.mdx
@@ -282,7 +282,8 @@ Fork config:
           See --fork-url.
 
       --fork-retry-backoff <BACKOFF>
-          Initial retry backoff on encountering errors.
+          Initial retry backoff, in milliseconds, when fork RPC requests encounter errors.
+          If omitted, the provider default is used.
           
           See --fork-url.
 


### PR DESCRIPTION
## Summary
- clarify that `--fork-retry-backoff` is an initial delay in milliseconds
- note that Foundry uses the provider default when the option is omitted

Fixes #900