### PR TITLE
doc(lint): add incorrect-exp

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -50,6 +50,7 @@ const docs = [
               { text: "controlled-delegatecall", link: "/forge/linting/controlled-delegatecall" },
               { text: "encode-packed-collision", link: "/forge/linting/encode-packed-collision" },
               { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },
+              { text: "incorrect-exp", link: "/forge/linting/incorrect-exp" },
               { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },
               { text: "reentrancy-eth", link: "/forge/linting/reentrancy-eth" },
               { text: "rtlo", link: "/forge/linting/rtlo" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -160,6 +160,7 @@ navigation on the right to browse by severity.
 - [`controlled-delegatecall`](/forge/linting/controlled-delegatecall) — Flags `delegatecall` targets that are not provably trusted.
 - [`encode-packed-collision`](/forge/linting/encode-packed-collision) — Flags `abi.encodePacked()` calls with two or more dynamic-type arguments (`string`, `bytes`, `T[]`) that can produce hash collisions.
 - [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
+- [`incorrect-exp`](/forge/linting/incorrect-exp) — Flags `^` (bitwise xor) used between integer literals where `**` (exponentiation) was almost certainly intended.
 - [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.
 - [`reentrancy-eth`](/forge/linting/reentrancy-eth) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.
 - [`rtlo`](/forge/linting/rtlo) — Flags the presence of Unicode bidirectional override characters in source code, which can be used to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).

--- a/src/pages/forge/linting/incorrect-exp.mdx
+++ b/src/pages/forge/linting/incorrect-exp.mdx
@@ -11,13 +11,14 @@ Flags `^` used between integer literals where `**` (exponentiation) was almost c
 
 ### What it does
 
-Reports `a ^ b` when the base `a` is `2` or `10` and both operands are decimal integer literals
-(looking through casts such as `uint256(10)`). In Solidity `^` is the bitwise xor operator, not
-exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
+Reports `a ^ b` when the base `a` is `2` or `10` and both operands are plain decimal integer
+literals, looking through integer casts such as `uint256(10)`. In Solidity `^` is the bitwise xor
+operator, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
 
 The base is restricted to the values people write as powers (`2` for bit widths, `10` for
-decimals), and operands written in hex are left alone. This mirrors GCC's and Clang's
-`-Wxor-used-as-pow`, so legitimate decimal bitmask xors such as `255 ^ 128` are not flagged.
+decimals). Operands written in hex (`0xff`), in scientific notation (`1e1`), or behind a
+non-integer cast (`bytes32(...)`) are left alone: the lint prefers a false negative to a false
+positive that would annoy developers. This mirrors GCC's and Clang's `-Wxor-used-as-pow`.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/incorrect-exp.mdx
+++ b/src/pages/forge/linting/incorrect-exp.mdx
@@ -1,0 +1,37 @@
+---
+description: Incorrect exponentiation
+---
+
+## Incorrect exponentiation
+
+**Severity**: `High`
+**ID**: `incorrect-exp`
+
+Flags `^` used between integer literals where `**` (exponentiation) was almost certainly intended.
+
+### What it does
+
+Warns when both operands of `^` are non-hex integer literals, such as `10 ^ 18`. In Solidity `^` is
+the bitwise xor operator, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`. Hex
+literals are left alone, since xor of a bit pattern is a legitimate operation, and a `^` with a
+variable operand is not flagged.
+
+### Why is this bad?
+
+Developers coming from languages where `^` means exponentiation (Python, many calculators) write
+`10 ^ 18` expecting `10 ** 18`. The contract compiles and silently uses the wrong constant, which
+can corrupt amounts, decimals, or limits.
+
+### Example
+
+#### Bad
+
+```solidity
+uint256 constant WAD = 10 ^ 18; // evaluates to 24, not 1e18
+```
+
+#### Good
+
+```solidity
+uint256 constant WAD = 10 ** 18;
+```

--- a/src/pages/forge/linting/incorrect-exp.mdx
+++ b/src/pages/forge/linting/incorrect-exp.mdx
@@ -11,10 +11,13 @@ Flags `^` used between integer literals where `**` (exponentiation) was almost c
 
 ### What it does
 
-Warns when both operands of `^` are non-hex integer literals, such as `10 ^ 18`. In Solidity `^` is
-the bitwise xor operator, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`. Hex
-literals are left alone, since xor of a bit pattern is a legitimate operation, and a `^` with a
-variable operand is not flagged.
+Reports `a ^ b` when the base `a` is `2` or `10` and both operands are decimal integer literals
+(looking through casts such as `uint256(10)`). In Solidity `^` is the bitwise xor operator, not
+exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
+
+The base is restricted to the values people write as powers (`2` for bit widths, `10` for
+decimals), and operands written in hex are left alone. This mirrors GCC's and Clang's
+`-Wxor-used-as-pow`, so legitimate decimal bitmask xors such as `255 ^ 128` are not flagged.
 
 ### Why is this bad?
 


### PR DESCRIPTION
## Motivation

Companion docs page for the `incorrect-exp` lint added in foundry-rs/foundry#15213, from the `forge lint` parity checklist (foundry-rs/foundry#14381).

The `ensure_lint_rule_docs` test in foundry fetches `https://getfoundry.sh/forge/linting/<id>` for every registered lint, so the new lint needs this page published here.

## Solution

Adds `src/pages/forge/linting/incorrect-exp.mdx` and registers it in the linting index (`linting.mdx`, High severity) and the sidebar, mirroring the existing `incorrect-shift` page. The page explains that `^` is bitwise xor (so `10 ^ 18` evaluates to `24`, not `10 ** 18`) and shows the bad/good forms.
