### PR TITLE
docs(lint): add non-reentrant-not-first page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -71,6 +71,7 @@ const docs = [
               { text: "locked-ether", link: "/forge/linting/locked-ether" },
               { text: "low-level-calls", link: "/forge/linting/low-level-calls" },
               { text: "mapping-deletion", link: "/forge/linting/mapping-deletion" },
+              { text: "non-reentrant-not-first", link: "/forge/linting/non-reentrant-not-first" },
               { text: "reentrancy-no-eth", link: "/forge/linting/reentrancy-no-eth" },
               { text: "tautological-compare", link: "/forge/linting/tautological-compare" },
               { text: "tx-origin", link: "/forge/linting/tx-origin" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -177,6 +177,7 @@ navigation on the right to browse by severity.
 - [`locked-ether`](/forge/linting/locked-ether) — Flags contracts that can receive Ether (via `payable` functions, `receive()`, or a payable `fallback()`) but expose no code path that can send Ether out, permanently trapping user funds.
 - [`low-level-calls`](/forge/linting/low-level-calls) — Flags direct use of Solidity low-level calls (`call`, `delegatecall`, and `staticcall`).
 - [`mapping-deletion`](/forge/linting/mapping-deletion) — Flags `delete` applied to a value whose type contains a `mapping`, because mapping entries are left in storage.
+- [`non-reentrant-not-first`](/forge/linting/non-reentrant-not-first) — Flags functions where a `nonReentrant` modifier appears after another modifier.
 - [`reentrancy-no-eth`](/forge/linting/reentrancy-no-eth) — Flags non-ETH external calls when state read before the call is written after the call.
 - [`tautological-compare`](/forge/linting/tautological-compare) — Flags relational or equality comparisons whose two sides are the same side-effect-free expression.
 - [`tx-origin`](/forge/linting/tx-origin) — Flags use of `tx.origin` inside authorization-like predicates, which can be exploited by a malicious contract acting on behalf of a legitimate owner.

--- a/src/pages/forge/linting/non-reentrant-not-first.mdx
+++ b/src/pages/forge/linting/non-reentrant-not-first.mdx
@@ -1,0 +1,44 @@
+---
+description: nonReentrant modifier is not first
+---
+
+## nonReentrant modifier is not first
+
+**Severity**: `Med`
+**ID**: `non-reentrant-not-first`
+
+Flags functions where an OpenZeppelin-style `nonReentrant` modifier is present but is not the
+first modifier in the modifier list.
+
+### What it does
+
+Reports a function, fallback, or receive function when a modifier named `nonReentrant` appears
+after another modifier.
+
+The lint is intentionally narrow: it checks modifier ordering only and only matches a modifier
+named `nonReentrant`.
+
+### Why is this bad?
+
+Solidity applies modifiers in the order they are written. If another modifier runs before
+`nonReentrant`, that modifier's pre-body logic executes before the reentrancy guard is entered.
+For guarded external entry points, placing `nonReentrant` first keeps the reentrancy lock as the
+first modifier logic.
+
+### Example
+
+#### Bad
+
+```solidity
+function withdraw(uint256 amount) external onlyOwner nonReentrant {
+    _withdraw(amount);
+}
+```
+
+#### Good
+
+```solidity
+function withdraw(uint256 amount) external nonReentrant onlyOwner {
+    _withdraw(amount);
+}
+```


### PR DESCRIPTION
Adds the missing `non-reentrant-not-first` lint page and registers it in the linting index/sidebar.

This documents the new Foundry lint added in foundry-rs/foundry#15248 and gives `https://getfoundry.sh/forge/linting/non-reentrant-not-first` a real page, unblocking the Foundry `ensure_lint_rule_docs` check.