### PR TITLE
Clarify foundryup specific version docs

### DIFF
--- a/src/pages/help/faq.mdx
+++ b/src/pages/help/faq.mdx
@@ -38,7 +38,7 @@ $ foundryup
 To install a specific version:
 
 ```bash
-$ foundryup --version nightly-abc123
+$ foundryup --install nightly-abc123
 ```
 
 #### How do I get help with a command?

--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -54,8 +54,8 @@ $ foundryup --install nightly
 $ foundryup --install 1.0.0
 ```
 
-```bash [Install from a specific commit]
-$ foundryup --install abc1234
+```bash [Install a specific nightly build]
+$ foundryup --install nightly-abc1234
 ```
 
 ```bash [Install from a branch]


### PR DESCRIPTION
## Summary
- replace the `foundryup --install abc1234` commit example with a specific nightly tag example
- update the FAQ example to use `--install` instead of `--version` for specific versions

## Tests
- `bun run build` *(exited 0; Vocs logged a static-generation fetch timeout after bundling)*

Prompted by: @DaniPopes