### PR TITLE
docs: add Tempo keychain cheatcode references

### DIFF
--- a/sidebar/cmd-reference.ts
+++ b/sidebar/cmd-reference.ts
@@ -55,6 +55,8 @@ export const cmdReference: SidebarItem[] = [
           { text: 'expectRevert', link: '/reference/cheatcodes/expect-revert' },
           { text: 'expectEmit', link: '/reference/cheatcodes/expect-emit' },
           { text: 'expectCall', link: '/reference/cheatcodes/expect-call' },
+          { text: 'expectKeychainVerified', link: '/reference/cheatcodes/expect-keychain-verified' },
+          { text: 'expectKeychainAdminVerified', link: '/reference/cheatcodes/expect-keychain-admin-verified' },
         ],
       },
       {
@@ -119,6 +121,8 @@ export const cmdReference: SidebarItem[] = [
         items: [
           { text: 'sign', link: '/reference/cheatcodes/sign' },
           { text: 'signDelegation', link: '/reference/cheatcodes/sign-delegation' },
+          { text: 'signKeychain', link: '/reference/cheatcodes/sign-keychain' },
+          { text: 'signKeychainAdmin', link: '/reference/cheatcodes/sign-keychain-admin' },
         ],
       },
       {

--- a/src/pages/reference/cheatcodes/expect-keychain-admin-verified.mdx
+++ b/src/pages/reference/cheatcodes/expect-keychain-admin-verified.mdx
@@ -1,0 +1,47 @@
+---
+description: Asserts that a SignatureVerifier.verifyKeychainAdmin call is made
+---
+
+## `expectKeychainAdminVerified`
+
+### Signature
+
+```solidity
+function expectKeychainAdminVerified(address account, bytes32 digest, bytes calldata signature) external;
+```
+
+### Description
+
+Expects a call to `SignatureVerifier.verifyKeychainAdmin(account, digest, signature)` during test execution.
+
+Use this to assert that the code under test calls the `SignatureVerifier` precompile with the expected `account`, `digest`, and `signature` (a root/admin verification). This only asserts the **call is made** — it does not assert that the verifier returned `true`. If the test terminates without the expected call being made, the test fails.
+
+### Parameters
+
+| Parameter   | Type      | Description                                                  |
+|-------------|-----------|-------------------------------------------------------------|
+| `account`   | `address` | The account whose root/admin key is expected to be verified |
+| `digest`    | `bytes32` | The expected digest passed to `verifyKeychainAdmin`         |
+| `signature` | `bytes`   | The expected encoded keychain signature                     |
+
+### Examples
+
+```solidity [test/ExpectKeychainAdminVerified.t.sol]
+bytes32 digest = keccak256(abi.encode(block.chainid, address(target), account, action));
+bytes memory signature = vm.signKeychainAdmin(adminPk, account, digest);
+
+vm.expectKeychainAdminVerified(account, digest, signature);
+target.doPrivilegedAction(account, digest, signature);
+```
+
+### Gotchas
+
+:::warning[Domain-separate the digest]
+`verifyKeychainAdmin` does **not** bind the `account` argument into the signed `digest`. Ensure the `digest` you expect is domain-separated with a replay domain such as chain ID, contract address, and account address.
+:::
+
+### Related Cheatcodes
+
+- [`expectKeychainVerified`](/reference/cheatcodes/expect-keychain-verified) - Assert a `verifyKeychain` call is made
+- [`signKeychainAdmin`](/reference/cheatcodes/sign-keychain-admin) - Signs a keychain digest with a root or admin key
+- [`expectCall`](/reference/cheatcodes/expect-call) - Assert that a specific call is made

--- a/src/pages/reference/cheatcodes/expect-keychain-verified.mdx
+++ b/src/pages/reference/cheatcodes/expect-keychain-verified.mdx
@@ -1,0 +1,40 @@
+---
+description: Asserts that a SignatureVerifier.verifyKeychain call is made
+---
+
+## `expectKeychainVerified`
+
+### Signature
+
+```solidity
+function expectKeychainVerified(address account, bytes32 digest, bytes calldata signature) external;
+```
+
+### Description
+
+Expects a call to `SignatureVerifier.verifyKeychain(account, digest, signature)` during test execution.
+
+Use this to assert that the code under test calls the `SignatureVerifier` precompile with the expected `account`, `digest`, and `signature` (an access-key verification). This only asserts the **call is made** — it does not assert that the verifier returned `true`. If the test terminates without the expected call being made, the test fails.
+
+### Parameters
+
+| Parameter   | Type      | Description                                              |
+|-------------|-----------|---------------------------------------------------------|
+| `account`   | `address` | The account whose access key is expected to be verified |
+| `digest`    | `bytes32` | The expected digest passed to `verifyKeychain`          |
+| `signature` | `bytes`   | The expected encoded keychain signature                 |
+
+### Examples
+
+```solidity [test/ExpectKeychainVerified.t.sol]
+bytes memory signature = vm.signKeychain(accessPk, account, digest);
+
+vm.expectKeychainVerified(account, digest, signature);
+target.doAuthenticatedAction(account, digest, signature);
+```
+
+### Related Cheatcodes
+
+- [`expectKeychainAdminVerified`](/reference/cheatcodes/expect-keychain-admin-verified) - Assert a `verifyKeychainAdmin` call is made
+- [`signKeychain`](/reference/cheatcodes/sign-keychain) - Signs a keychain digest with an access key
+- [`expectCall`](/reference/cheatcodes/expect-call) - Assert that a specific call is made

--- a/src/pages/reference/cheatcodes/sign-keychain-admin.mdx
+++ b/src/pages/reference/cheatcodes/sign-keychain-admin.mdx
@@ -1,0 +1,59 @@
+---
+description: Signs a digest as a Tempo keychain signature using a root or admin key
+---
+
+## `signKeychainAdmin`
+
+### Signature
+
+```solidity
+function signKeychainAdmin(uint256 privateKey, address account, bytes32 digest) external pure returns (bytes memory signature);
+```
+
+### Description
+
+Signs `digest` as a Tempo V2 keychain signature for `account` using a secp256k1 **root or admin key** `privateKey`.
+
+Returns the encoded signature bytes accepted by `SignatureVerifier.verifyKeychainAdmin`. This is the admin counterpart to [`signKeychain`](/reference/cheatcodes/sign-keychain) (T6, [TIP-1049](https://tips.sh/1049)). `verifyKeychainAdmin` returns `true` only when the signer is the account **root key** or an **active admin key** for `account`.
+
+This is useful for testing Tempo contracts that gate key-management or privileged actions behind `SignatureVerifier.verifyKeychainAdmin`.
+
+Like [`signKeychain`](/reference/cheatcodes/sign-keychain), this cheatcode does not check key status — a signature produced with a non-admin or revoked key is still encoded, but `verifyKeychainAdmin` returns `false`.
+
+### Parameters
+
+| Parameter    | Type      | Description                                                |
+|--------------|-----------|-----------------------------------------------------------|
+| `privateKey` | `uint256` | The root or admin-key private key to sign with            |
+| `account`    | `address` | The account whose root/admin key is signing               |
+| `digest`     | `bytes32` | The message digest to sign (see warning below)            |
+
+### Returns
+
+| Type              | Description                                                       |
+|-------------------|------------------------------------------------------------------|
+| `bytes signature` | Encoded Tempo keychain signature accepted by `verifyKeychainAdmin` |
+
+### Examples
+
+```solidity [test/SignKeychainAdmin.t.sol]
+// Domain-separate the application digest yourself: include chain ID,
+// contract address, and account address in the digest the key signs.
+bytes32 digest = keccak256(abi.encode(block.chainid, address(this), account, action));
+bytes memory signature = vm.signKeychainAdmin(adminPk, account, digest);
+
+bool ok = signatureVerifier.verifyKeychainAdmin(account, digest, signature);
+assertTrue(ok); // [PASS]
+```
+
+### Gotchas
+
+:::warning[Domain-separate the digest]
+`verifyKeychainAdmin` does **not** bind the `account` argument into the signed `digest`. To prevent replay across chains, contracts, and accounts, include a replay domain — such as the chain ID, contract address, and account address — in the `digest` you sign.
+:::
+
+### Related Cheatcodes
+
+- [`signKeychain`](/reference/cheatcodes/sign-keychain) - Signs a keychain digest with an access key
+- [`expectKeychainAdminVerified`](/reference/cheatcodes/expect-keychain-admin-verified) - Assert a `verifyKeychainAdmin` call is made
+- [`sign`](/reference/cheatcodes/sign) - Signs a digest with a private key, returning `(v, r, s)`

--- a/src/pages/reference/cheatcodes/sign-keychain.mdx
+++ b/src/pages/reference/cheatcodes/sign-keychain.mdx
@@ -1,0 +1,59 @@
+---
+description: Signs a digest as a Tempo keychain signature using an access key
+---
+
+## `signKeychain`
+
+### Signature
+
+```solidity
+function signKeychain(uint256 privateKey, address account, bytes32 digest) external pure returns (bytes memory signature);
+```
+
+### Description
+
+Signs `digest` as a Tempo V2 keychain signature for `account` using a secp256k1 **access key** `privateKey`.
+
+Returns the encoded signature bytes accepted by `SignatureVerifier.verifyKeychain`. Unlike [`sign`](/reference/cheatcodes/sign), the result is an encoded Tempo keychain signature (not a raw `(v, r, s)` tuple), and it verifies only as an **active access key** of `account` — never the root key.
+
+This is useful for testing Tempo contracts that authenticate callers through `SignatureVerifier.verifyKeychain` against `AccountKeychain` state.
+
+`signKeychain` does not query `AccountKeychain` or prove that `privateKey` is authorized — it only encodes the keychain signature. The on-chain active-access-key check happens in `SignatureVerifier.verifyKeychain`, which returns `false` for an unknown or revoked key.
+
+### Parameters
+
+| Parameter    | Type      | Description                                                  |
+|--------------|-----------|-------------------------------------------------------------|
+| `privateKey` | `uint256` | The access-key private key to sign with                     |
+| `account`    | `address` | The root account that the access key is authorized under    |
+| `digest`     | `bytes32` | The message digest to sign                                  |
+
+### Returns
+
+| Type             | Description                                                            |
+|------------------|-----------------------------------------------------------------------|
+| `bytes signature` | Encoded Tempo keychain signature accepted by `verifyKeychain`        |
+
+### Examples
+
+```solidity [test/SignKeychain.t.sol]
+// `account` has authorized `accessPk` as an access key on-chain.
+bytes32 digest = keccak256("authorize this action");
+bytes memory signature = vm.signKeychain(accessPk, account, digest);
+
+// Verifies against the account's active access keys via the SignatureVerifier precompile.
+bool ok = signatureVerifier.verifyKeychain(account, digest, signature);
+assertTrue(ok); // [PASS]
+```
+
+### Gotchas
+
+:::warning[Access keys only]
+`signKeychain` produces a signature that verifies as an **active access key**, never the root key. Use [`signKeychainAdmin`](/reference/cheatcodes/sign-keychain-admin) for root or admin keys.
+:::
+
+### Related Cheatcodes
+
+- [`signKeychainAdmin`](/reference/cheatcodes/sign-keychain-admin) - Signs a keychain digest with a root or admin key
+- [`expectKeychainVerified`](/reference/cheatcodes/expect-keychain-verified) - Assert a `verifyKeychain` call is made
+- [`sign`](/reference/cheatcodes/sign) - Signs a digest with a private key, returning `(v, r, s)`


### PR DESCRIPTION
Adds reference pages for the four Tempo T6 keychain cheatcodes (from foundry#15216):

- `signKeychain`
- `signKeychainAdmin`
- `expectKeychainVerified`
- `expectKeychainAdminVerified`

Wired into the cheatcode sidebar under Assertions and Signing.

Part of OSS-436