### PR TITLE
docs: add require-revert-in-loop lint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -96,6 +96,7 @@ const docs = [
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },
               { text: "msg-value-loop", link: "/forge/linting/msg-value-loop" },
               { text: "reentrancy-events", link: "/forge/linting/reentrancy-events" },
+              { text: "require-revert-in-loop", link: "/forge/linting/require-revert-in-loop" },
               { text: "return-bomb", link: "/forge/linting/return-bomb" },
             ],
           },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -199,6 +199,7 @@ navigation on the right to browse by severity.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 - [`msg-value-loop`](/forge/linting/msg-value-loop) — Flags `msg.value` reads inside loops reachable from externally callable payable functions.
 - [`reentrancy-events`](/forge/linting/reentrancy-events) — Flags `emit` statements reachable after an external call, where a reentrant callee can reorder or fabricate logs that off-chain consumers rely on.
+- [`require-revert-in-loop`](/forge/linting/require-revert-in-loop) — Flags `require` calls and `revert` statements that execute inside loops, including checks reached through internal helpers.
 - [`return-bomb`](/forge/linting/return-bomb) — Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.
 
 #### Informational

--- a/src/pages/forge/linting/require-revert-in-loop.mdx
+++ b/src/pages/forge/linting/require-revert-in-loop.mdx
@@ -1,0 +1,81 @@
+---
+description: require or revert inside loops
+---
+
+## Require or revert inside loops
+
+**Severity**: `Low`
+**ID**: `require-revert-in-loop`
+
+Flags `require` calls and `revert` statements that execute inside loops.
+
+### What it does
+
+Reports `require` and `revert` operations reachable from a `for`, `while`, or `do-while` loop. This
+includes checks in loop bodies, loop conditions, loop update expressions, modifier placeholders,
+internal helpers, internal library extension calls, and inline assembly `revert` instructions.
+
+Calls through an external interface are not followed; this lint reports the `require` or `revert`
+operation itself when Foundry can see that it executes as part of the loop.
+
+### Why is this bad?
+
+A single invalid item can revert the entire loop. In batched operations, that can make one bad
+entry deny service to every later entry and force users to retry the whole batch.
+
+This is especially risky when invalid items are expected or caller-controlled, because a caller can
+make the batch unusable by including one value that fails validation.
+
+### Example
+
+#### Bad
+
+```solidity
+error BadItem(uint256 index);
+
+contract Batch {
+    function process(uint256[] calldata values) external {
+        for (uint256 i; i < values.length; ++i) {
+            if (values[i] == 0) {
+                revert BadItem(i);
+            }
+
+            _process(values[i]);
+        }
+    }
+
+    function _process(uint256 value) internal {
+        // ...
+    }
+}
+```
+
+#### Good
+
+```solidity
+event SkippedZero(uint256 index);
+
+contract Batch {
+    function process(uint256[] calldata values) external {
+        for (uint256 i; i < values.length; ++i) {
+            if (values[i] == 0) {
+                emit SkippedZero(i);
+                continue;
+            }
+
+            _process(values[i]);
+        }
+    }
+
+    function _process(uint256 value) internal {
+        // ...
+    }
+}
+```
+
+### Recommendation
+
+Prefer batch designs where one invalid item does not revert the whole loop: skip invalid entries
+explicitly, record per-item failures, or split the work into separate transactions. When every item
+must be valid, validate batch-level invariants before the loop and consider exposing a per-item
+entry point so callers can isolate failures.


### PR DESCRIPTION
## Summary

- Add the `require-revert-in-loop` lint documentation page.
- Link the new page from the Forge linting sidebar.
- Add the lint to the Forge linting overview index.

## Validation

- `bun install --frozen-lockfile`
- `bun run build`