### PR TITLE
docs(lint): update severity default

### DIFF
--- a/src/pages/config/reference/linter.mdx
+++ b/src/pages/config/reference/linter.mdx
@@ -13,7 +13,7 @@ Whether to run linting during `forge build`. Set to `false` to disable automatic
 ##### `severity`
 
 - Type: array of strings
-- Default: `["high", "medium", "low"]`
+- Default: `[]`
 - Environment: `FOUNDRY_LINT_SEVERITY`
 
 Specifies which lints to run based on severity. Valid values are:
@@ -24,6 +24,10 @@ Specifies which lints to run based on severity. Valid values are:
 - `info`
 - `gas`
 - `code-size` (or `codesize`, `size`)
+
+An empty list means no severity filter is applied, so all severity buckets are
+enabled. To run only warning-level lints, set this explicitly to
+`["high", "medium", "low"]`.
 
 ##### `exclude_lints`
 


### PR DESCRIPTION
## Summary

Updates the documented default for `[lint].severity` to match the current Foundry behavior after foundry-rs/foundry#15331.

An empty severity list now means no severity filter is applied, so all severity buckets are enabled by default. The docs now also note how users can opt back into only warning-level lints explicitly.

Fixes #1910.

## Validation

- `git diff --check`
- Verified the Foundry behavior locally with:

```bash
cargo test -p forge --test cli default_lint_severity_includes_info -- --nocapture
```
