### PR TITLE
docs: default isolate mode

### DIFF
--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -395,8 +395,9 @@ memory_limit = 134217728
 
 # Whether to enable call isolation
 # Useful for more correct gas accounting and EVM behavior
-# Default: false
-isolate = false
+# Disable with `isolate = false` or `--no-isolate`
+# Default: true
+isolate = true
 
 # Whether to disable the block gas limit checks
 # Default: false

--- a/src/pages/forge/testing.mdx
+++ b/src/pages/forge/testing.mdx
@@ -52,6 +52,12 @@ Key conventions:
 - Test functions start with `test_` or `test`
 - `setUp()` runs before each test
 
+### Call isolation
+
+Forge runs tests with call isolation enabled by default. In isolation mode, each top-level external call made by a test is executed as a separate transaction in a separate EVM context. This gives more precise gas accounting and transaction state changes for each call.
+
+Because those calls use separate transaction contexts, a test function is not always equivalent to one normal transaction with warmed accounts or storage slots shared across every external call in the function body. For example, repeated calls to the same contract can be charged as cold again under isolation. If a test intentionally asserts behavior that depends on warm accounts or slots carrying across repeated calls in one transaction, run it with `--no-isolate` or set `isolate = false` in `foundry.toml`.
+
 ### Traces
 
 Traces show a tree of all calls made during a test, helping you understand execution flow and debug failures.

--- a/src/pages/reference/cheatcodes/gas-snapshots.mdx
+++ b/src/pages/reference/cheatcodes/gas-snapshots.mdx
@@ -90,11 +90,7 @@ function testSnapshotBytecodeSize() public {
 ### Gotchas
 
 :::warning
-Gas snapshots are not accurate unless using isolated test mode. Enable isolation with the `--isolate` flag or add this to your test:
-
-```solidity
-/// forge-config: default.isolate = true
-```
+Gas snapshots are not accurate unless using isolated test mode. Isolation is enabled by default; do not disable it when collecting or checking gas snapshots.
 :::
 
 :::note


### PR DESCRIPTION
Documents that call isolation is now enabled by default for Forge tests and clarifies the main semantic difference: top-level external calls run in separate transaction contexts, so repeated calls may not share warmed account or storage-slot state the way a single normal transaction would.

This also updates the default config reference to show `isolate = true`, notes how to disable isolation with `isolate = false` or `--no-isolate`, and refreshes the gas snapshots warning so it no longer describes isolation as opt-in.

Closes OSS-458
