### PR TITLE
docs: update Tempo setup guidance

### DIFF
--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -153,9 +153,9 @@ evm_version = "osaka"
 
 # Runtime hardfork for tests and scripts.
 # Can be a plain Ethereum hardfork (for example "osaka") or a namespaced
-# network hardfork such as "optimism:holocene" or "tempo:T3".
+# network hardfork such as "optimism:holocene" or "tempo:T6".
 # Default: none
-# hardfork = "tempo:T3"
+# hardfork = "tempo:T6"
 
 # Whether to activate optimizer
 # Default: None

--- a/src/pages/config/reference/testing.mdx
+++ b/src/pages/config/reference/testing.mdx
@@ -104,14 +104,16 @@ Sets the runtime hardfork for tests and scripts.
 This can be either:
 
 - A plain Ethereum hardfork such as `osaka` or `cancun`
-- A namespaced hardfork such as `optimism:holocene` or `tempo:T3`
+- A namespaced hardfork such as `optimism:holocene` or `tempo:T6`
 
 When you use a namespaced hardfork, Foundry also infers the matching network automatically.
 
 ```toml
 [profile.default]
-hardfork = "tempo:T3"
+hardfork = "tempo:T6"
 ```
+
+For Tempo projects, prefer `network = "tempo"` or a live Tempo fork for normal current behavior. Pin a Tempo hardfork only when you need deterministic behavior for a specific activation point or regression test.
 
 ##### `gas_limit`
 

--- a/src/pages/guides/tempo.mdx
+++ b/src/pages/guides/tempo.mdx
@@ -41,6 +41,8 @@ tempo = "https://rpc.tempo.xyz/"
 moderato = "https://rpc.moderato.tempo.xyz/"
 ```
 
+The legacy `tempo = true` form is still accepted for back-compat, but new projects should use `network = "tempo"`.
+
 Use the RPC aliases with `--rpc-url` and `--fork-url`:
 
 ```bash


### PR DESCRIPTION
This updates the Tempo setup guidance to make upstream Foundry the normal supported path, clarify `forge init --network tempo`, and explain when `network = "tempo"` is needed versus when live Tempo RPC forks can infer network semantics.

Hardfork pinning is now presented as explicit opt-in behavior for deterministic activation-point testing, using current T6 behavior as the example.

Closes OSS-441.