### PR TITLE
docs: document Podman usage

### DIFF
--- a/src/pages/guides/docker.mdx
+++ b/src/pages/guides/docker.mdx
@@ -22,6 +22,21 @@ Available tags:
 | `nightly` | Nightly build |
 | `v1.0.0` | Specific version |
 
+### Using Podman
+
+The official Foundry container image is OCI-compatible and can also be used with Podman.
+
+Pull the image:
+
+```bash
+$ podman pull ghcr.io/foundry-rs/foundry:latest
+```
+Podman is an OCI-compatible container engine and can be used with the official Foundry container image.
+
+> **Note**
+>
+> On some rootless Podman configurations, commands that write to bind-mounted directories (such as `forge init`) may require additional user namespace configuration (for example, `--userns=keep-id`) to avoid permission issues.
+
 ### Running Foundry commands
 
 ```bash

--- a/src/pages/guides/docker.mdx
+++ b/src/pages/guides/docker.mdx
@@ -31,7 +31,13 @@ Pull the image:
 ```bash
 $ podman pull ghcr.io/foundry-rs/foundry:latest
 ```
-Podman is an OCI-compatible container engine and can be used with the official Foundry container image.
+
+The Docker commands described below can be run with Podman by replacing `docker` with `podman`. For example:
+
+```bash
+# Run forge build using Podman
+$ podman run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge build
+```
 
 > **Note**
 >


### PR DESCRIPTION
## Summary

Fixes #1691

- Add a `Using Podman` section to the Docker guide.
- Document pulling the official Foundry container image with Podman.
- Add a note about rootless Podman configurations that may require additional user namespace configuration when writing to bind-mounted directories.

## Testing

Tested on:
- Ubuntu 24.04 (WSL)
- Podman 4.9.3

Verified:
- `podman pull`
- `forge build`
- `forge test`
- `forge init` (required `--userns=keep-id` on this rootless Podman configuration)