### PR TITLE
docs: add Tempo navbar link

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -63,6 +63,11 @@ export default defineConfig({
       text: "Guides",
     },
     {
+      link: "/guides/tempo",
+      match: "/guides/tempo",
+      text: "Tempo",
+    },
+    {
       text: "Reference",
       items: [
         {


### PR DESCRIPTION
This follows up #1918 by making the new Tempo workflow hub easier to discover from the global navigation. The header now includes a direct Tempo link, matching the pattern used by viem while keeping the existing Guides sidebar and MPP guide structure unchanged.

This should make the Tempo and MPP docs less buried for users who are specifically looking for Tempo support in Foundry.

AI assistance was used to prepare this documentation update.
