### PR TITLE
docs(lint): add dangerous-unary-operator page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -64,6 +64,7 @@ const docs = [
             items: [
               { text: "assert-state-change", link: "/forge/linting/assert-state-change" },
               { text: "boolean-cst", link: "/forge/linting/boolean-cst" },
+              { text: "dangerous-unary-operator", link: "/forge/linting/dangerous-unary-operator" },
               { text: "divide-before-multiply", link: "/forge/linting/divide-before-multiply" },
               { text: "incorrect-erc20-interface", link: "/forge/linting/incorrect-erc20-interface" },
               { text: "incorrect-erc721-interface", link: "/forge/linting/incorrect-erc721-interface" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -171,6 +171,7 @@ navigation on the right to browse by severity.
 
 - [`assert-state-change`](/forge/linting/assert-state-change) — Flags expressions inside `assert()` that modify contract state.
 - [`boolean-cst`](/forge/linting/boolean-cst) — Flags expressions where a boolean constant (`true`/`false`) is used as a control-flow condition or operand of a boolean operator, which usually indicates dead code or a leftover debug toggle.
+- [`dangerous-unary-operator`](/forge/linting/dangerous-unary-operator) — Flags assignments whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment rather than the compound assignment it resembles.
 - [`divide-before-multiply`](/forge/linting/divide-before-multiply) — Flags arithmetic expressions where division is performed before multiplication, which can cause unintended precision loss in integer arithmetic.
 - [`incorrect-erc20-interface`](/forge/linting/incorrect-erc20-interface) — Flags interfaces or contracts whose function signatures match an ERC20 method by name and parameters but use the wrong return type.
 - [`incorrect-erc721-interface`](/forge/linting/incorrect-erc721-interface) — Flags interfaces or contracts whose function signatures match an ERC721 (or ERC165) method by name and parameters but use the wrong return type.

--- a/src/pages/forge/linting/dangerous-unary-operator.mdx
+++ b/src/pages/forge/linting/dangerous-unary-operator.mdx
@@ -1,0 +1,41 @@
+---
+description: Unary operator fused to assignment
+---
+
+## Dangerous unary operator
+
+**Severity**: `Med`
+**ID**: `dangerous-unary-operator`
+
+Flags assignments whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment of a unary expression rather than the compound assignment it resembles.
+
+### What it does
+
+Warns when the source writes `=` directly against a leading unary `-` or `~` on the right-hand side:
+
+```solidity
+x =- y;
+x =~ y;
+```
+
+These expressions parse as `x = -y` and `x = ~y`, not as compound assignments. The lint also reports fused unary operators that lead larger right-hand sides, such as `x =- y + 1`, because that still parses as a plain assignment.
+
+Spaced unary assignments (`x = -y`, `x = ~y`) and real compound assignments (`x -= y`) are left alone.
+
+### Why is this bad?
+
+`x =- 1` silently assigns `-1` instead of decrementing `x`. Developers intending to write `-=` can transpose the operator into `=-`, and the code still compiles and runs with the wrong value.
+
+### Example
+
+#### Bad
+
+```solidity
+x =- 1; // assigns -1, does not subtract 1 from x
+```
+
+#### Good
+
+```solidity
+x -= 1;
+```


### PR DESCRIPTION
Adds the Foundry Book page for the new `dangerous-unary-operator` lint and wires it into the linting index and sidebar under medium severity.

This gives `https://getfoundry.sh/forge/linting/dangerous-unary-operator` a published page for the lint added in foundry-rs/foundry#15526, so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
