### PR TITLE
docs(lint): add unused-error page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -123,6 +123,7 @@ const docs = [
               { text: "too-many-digits", link: "/forge/linting/too-many-digits" },
               { text: "unaliased-plain-import", link: "/forge/linting/unaliased-plain-import" },
               { text: "unsafe-cheatcode", link: "/forge/linting/unsafe-cheatcode" },
+              { text: "unused-error", link: "/forge/linting/unused-error" },
               { text: "unused-import", link: "/forge/linting/unused-import" },
             ],
           },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -223,6 +223,7 @@ navigation on the right to browse by severity.
 - [`too-many-digits`](/forge/linting/too-many-digits) — Flags numeric literals containing five or more consecutive zeros, which are easy to misread.
 - [`unaliased-plain-import`](/forge/linting/unaliased-plain-import) — Flags `import "path";` statements that pull in every top-level symbol from another file without an alias.
 - [`unsafe-cheatcode`](/forge/linting/unsafe-cheatcode) — Flags use of Foundry cheatcodes that perform dangerous side effects (filesystem access, network activity, environment variable reads, etc.) so they cannot slip into production code unnoticed.
+- [`unused-error`](/forge/linting/unused-error) — Flags custom error declarations that are never referenced anywhere in the compiled sources.
 - [`unused-import`](/forge/linting/unused-import) — Flags imported symbols (or whole import statements) whose imported names are not referenced anywhere in the source unit.
 
 #### Gas optimization

--- a/src/pages/forge/linting/unused-error.mdx
+++ b/src/pages/forge/linting/unused-error.mdx
@@ -1,0 +1,42 @@
+---
+description: Custom error is never used
+---
+
+## Unused error
+
+**Severity**: `Info`
+**ID**: `unused-error`
+
+Flags a custom error declaration that is never referenced anywhere in the compiled sources.
+
+### What it does
+
+Reports each `error` declaration whose symbol is never referenced. Any resolved reference counts as a use: a `revert Err(...)` statement (including the qualified `revert Lib.Err(...)`), `require(cond, Err(...))` (Solidity 0.8.26+), and `Err.selector` (including through `abi.encodeWithSelector`). Uses are collected across the whole compilation unit, so an error declared in a shared file and reverted elsewhere in the project is not reported.
+
+Errors declared in interfaces and abstract contracts are not reported: they are ABI surface meant for implementers and off-chain consumers, which may live outside the compiled sources.
+
+### Why is this bad?
+
+An unused error is dead code. It suggests a missing revert path or a leftover from a refactor.
+
+### Example
+
+#### Bad
+
+```solidity
+error Unauthorized(); // declared but never referenced
+```
+
+#### Good
+
+```solidity
+error Unauthorized();
+
+function withdraw() external {
+    if (msg.sender != owner) revert Unauthorized();
+}
+```
+
+### Limitations
+
+A selector hardcoded in inline assembly or built with `abi.encodeWithSignature("Err(...)")` does not reference the declaration and is not seen as a use.


### PR DESCRIPTION
Adds the Foundry Book page for the `unused-error` lint and wires it into the linting index and sidebar under Informational.

This gives `https://getfoundry.sh/forge/linting/unused-error` a published page for the lint added in foundry-rs/foundry#15539 (from the parity checklist foundry-rs/foundry#14381), so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
