### PR TITLE
docs(lint): add empty-block page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -91,6 +91,7 @@ const docs = [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "delegatecall-loop", link: "/forge/linting/delegatecall-loop" },
+              { text: "empty-block", link: "/forge/linting/empty-block" },
               { text: "incorrect-modifier", link: "/forge/linting/incorrect-modifier" },
               { text: "missing-events-access-control", link: "/forge/linting/missing-events-access-control" },
               { text: "missing-events-arithmetic", link: "/forge/linting/missing-events-arithmetic" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -194,6 +194,7 @@ navigation on the right to browse by severity.
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`delegatecall-loop`](/forge/linting/delegatecall-loop) — Flags `delegatecall` operations inside loops in externally callable payable functions.
+- [`empty-block`](/forge/linting/empty-block) — Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
 - [`incorrect-modifier`](/forge/linting/incorrect-modifier) — Flags modifiers that can finish without executing the modified function body or reverting.
 - [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags access-controlled updates to state used for authorization when the update function does not emit an event.
 - [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags access-controlled updates to integer state used in arithmetic when the update path does not emit an event.

--- a/src/pages/forge/linting/empty-block.mdx
+++ b/src/pages/forge/linting/empty-block.mdx
@@ -1,0 +1,43 @@
+---
+description: Empty function body
+---
+
+## Empty block
+
+**Severity**: `Low`
+**ID**: `empty-block`
+
+Flags regular functions whose body is empty, which is dead or unfinished code.
+
+### What it does
+
+Reports a function whose body is `{}` (a comment does not make a body non-empty). This mirrors Aderyn's `empty-block` detector, restricted to function bodies.
+
+Bodies whose emptiness is the behavior are exempt:
+
+- constructors: an empty body is how a contract calls base constructors (`constructor() Base(1) {}`) or is simply made deployable;
+- `receive` and `fallback`: the empty body is what accepts plain ether transfers or unknown calls;
+- `virtual` functions: an empty body is the intentional default of an extension hook meant to be overridden;
+- `payable` functions: an empty body is an intentional ether sink (`function deposit() external payable {}`).
+
+Functions without a body (interface members, abstract declarations) never fire, and an empty modifier body is a solc compile error (2883), so it never reaches the linter. Empty blocks nested inside a non-empty body (`if (x) {}`) are out of scope.
+
+### Why is this bad?
+
+An empty body on a regular function does nothing: either the implementation was forgotten, or the function is dead code that bloats the contract surface and misleads readers and integrators. An empty override can also silently disable behavior a parent contract intended to provide.
+
+### Example
+
+#### Bad
+
+```solidity
+function withdraw() external {}
+```
+
+#### Good
+
+```solidity
+function withdraw() external {
+    payable(msg.sender).transfer(address(this).balance);
+}
+```

--- a/src/pages/forge/linting/empty-block.mdx
+++ b/src/pages/forge/linting/empty-block.mdx
@@ -18,7 +18,8 @@ Bodies whose emptiness is the behavior are exempt:
 - constructors: an empty body is how a contract calls base constructors (`constructor() Base(1) {}`) or is simply made deployable;
 - `receive` and `fallback`: the empty body is what accepts plain ether transfers or unknown calls;
 - `virtual` functions: an empty body is the intentional default of an extension hook meant to be overridden;
-- `payable` functions: an empty body is an intentional ether sink (`function deposit() external payable {}`).
+- functions with modifiers: the modifier carries the behavior, as in `initialize() external initializer {}` or `_authorizeUpgrade(address) internal override onlyOwner {}`;
+- `payable` functions without return values: an empty body is an intentional ether sink (`function deposit() external payable {}`). With a return value the body silently returns the default, which reads as an unfinished stub and is reported.
 
 Functions without a body (interface members, abstract declarations) never fire, and an empty modifier body is a solc compile error (2883), so it never reaches the linter. Empty blocks nested inside a non-empty body (`if (x) {}`) are out of scope.
 


### PR DESCRIPTION
Adds the Foundry Book page for the `empty-block` lint and wires it into the linting index and sidebar under low severity.

This gives `https://getfoundry.sh/forge/linting/empty-block` a published page for the lint added in foundry-rs/foundry#15540 (from the parity checklist foundry-rs/foundry#14381), so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
