### PR TITLE
docs(lint): add enumerable-loop-removal page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -49,6 +49,7 @@ const docs = [
               { text: "arbitrary-send-eth", link: "/forge/linting/arbitrary-send-eth" },
               { text: "controlled-delegatecall", link: "/forge/linting/controlled-delegatecall" },
               { text: "encode-packed-collision", link: "/forge/linting/encode-packed-collision" },
+              { text: "enumerable-loop-removal", link: "/forge/linting/enumerable-loop-removal" },
               { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },
               { text: "incorrect-exp", link: "/forge/linting/incorrect-exp" },
               { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -159,6 +159,7 @@ navigation on the right to browse by severity.
 - [`arbitrary-send-eth`](/forge/linting/arbitrary-send-eth) — Flags functions that send ETH (via `transfer` / `send` / `{value:}` calls / `selfdestruct` / known OZ + Solady helpers) to a caller-controlled destination without restricting who can call them.
 - [`controlled-delegatecall`](/forge/linting/controlled-delegatecall) — Flags `delegatecall` targets that are not provably trusted.
 - [`encode-packed-collision`](/forge/linting/encode-packed-collision) — Flags `abi.encodePacked()` calls with two or more dynamic-type arguments (`string`, `bytes`, `T[]`) that can produce hash collisions.
+- [`enumerable-loop-removal`](/forge/linting/enumerable-loop-removal) — Flags `remove` on an EnumerableSet inside a loop that also iterates a set with `at`; swap-and-pop removal corrupts the iteration.
 - [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
 - [`incorrect-exp`](/forge/linting/incorrect-exp) — Flags `^` (bitwise xor) used between integer literals where `**` (exponentiation) was almost certainly intended.
 - [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.

--- a/src/pages/forge/linting/enumerable-loop-removal.mdx
+++ b/src/pages/forge/linting/enumerable-loop-removal.mdx
@@ -1,0 +1,49 @@
+---
+description: EnumerableSet removal while iterating with at
+---
+
+## Enumerable loop removal
+
+**Severity**: `High`
+**ID**: `enumerable-loop-removal`
+
+Flags `remove` on an EnumerableSet inside a loop that also iterates a set with `at`.
+
+### What it does
+
+Reports a call `set.remove(...)` where the receiver is a struct declared in a library named `EnumerableSet` (OpenZeppelin's `AddressSet`, `UintSet`, `Bytes32Set`), when an enclosing loop also contains a call `at(...)` on an EnumerableSet, not necessarily the same instance.
+
+Only the combination is dangerous, so neither half fires alone:
+
+- `remove` in a loop without `at` is the recommended collect-then-remove pattern;
+- `at` in a loop without `remove` is a plain read;
+- `remove` outside a loop is fine;
+- the same method names on a type that is not an EnumerableSet are out of scope.
+
+Calls reached indirectly through a function invoked from the loop are not analyzed.
+
+### Why is this bad?
+
+`EnumerableSet.remove` is swap-and-pop: it moves the last element into the removed slot and shrinks the set. Iterating by index with `at` while removing skips the swapped-in elements or reads out-of-bounds indices, so some elements are silently never visited.
+
+### Example
+
+#### Bad
+
+```solidity
+for (uint256 i = 0; i < set.length(); i++) {
+    set.remove(set.at(i));
+}
+```
+
+#### Good
+
+```solidity
+address[] memory toRemove = new address[](set.length());
+for (uint256 i = 0; i < set.length(); i++) {
+    toRemove[i] = set.at(i);
+}
+for (uint256 i = 0; i < toRemove.length; i++) {
+    set.remove(toRemove[i]);
+}
+```


### PR DESCRIPTION
Adds the Foundry Book page for the `enumerable-loop-removal` lint and wires it into the linting index and sidebar under high severity.

This gives `https://getfoundry.sh/forge/linting/enumerable-loop-removal` a published page for the lint added in foundry-rs/foundry#15542 (from the parity checklist foundry-rs/foundry#14381), so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
