### PR TITLE
docs(lint): add unsafe-oz-erc721-mint page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -79,6 +79,7 @@ const docs = [
               { text: "type-based-tautology", link: "/forge/linting/type-based-tautology" },
               { text: "uninitialized-local", link: "/forge/linting/uninitialized-local" },
               { text: "uninitialized-state", link: "/forge/linting/uninitialized-state" },
+              { text: "unsafe-oz-erc721-mint", link: "/forge/linting/unsafe-oz-erc721-mint" },
               { text: "unsafe-typecast", link: "/forge/linting/unsafe-typecast" },
               { text: "unused-return", link: "/forge/linting/unused-return" },
               { text: "weak-prng", link: "/forge/linting/weak-prng" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -185,6 +185,7 @@ navigation on the right to browse by severity.
 - [`type-based-tautology`](/forge/linting/type-based-tautology) — Flags comparison expressions that are always true or always false due to the numeric range of the variable's type.
 - [`uninitialized-local`](/forge/linting/uninitialized-local) — Flags local variables that are declared without an initializer and read before any explicit assignment, where the silent zero-default is almost certainly unintentional.
 - [`uninitialized-state`](/forge/linting/uninitialized-state) — Flags state variables that are read in a contract's inheritance chain but never assigned, leaving them silently equal to their type's zero default.
+- [`unsafe-oz-erc721-mint`](/forge/linting/unsafe-oz-erc721-mint) — Flags calls resolving to `ERC721._mint`, which does not check that the recipient can receive the token; use `_safeMint`.
 - [`unsafe-typecast`](/forge/linting/unsafe-typecast) — Flags explicit numeric typecasts that can silently truncate or alter the value.
 - [`unused-return`](/forge/linting/unused-return) — Flags external calls whose return value is silently discarded.
 - [`weak-prng`](/forge/linting/weak-prng) — Flags randomness-like expressions that directly derive entropy from predictable on-chain values.

--- a/src/pages/forge/linting/unsafe-oz-erc721-mint.mdx
+++ b/src/pages/forge/linting/unsafe-oz-erc721-mint.mdx
@@ -1,0 +1,41 @@
+---
+description: ERC721 _mint without receiver check
+---
+
+## Unsafe OZ ERC721 mint
+
+**Severity**: `Med`
+**ID**: `unsafe-oz-erc721-mint`
+
+Flags calls that resolve to `ERC721._mint`, which credits a token without checking that the recipient can receive it.
+
+### What it does
+
+Reports a call whose callee resolves to a function named `_mint` declared in a non-library contract whose name contains `ERC721` (`ERC721`, `ERC721Upgradeable`, `ERC721Enumerable`, ...), wherever that contract sits in the caller's inheritance chain. The plain `_mint(to, id)`, the qualified `ERC721._mint(to, id)` and `super._mint(to, id)` forms are all covered. Overload sets are filtered by arity, so a call that can only dispatch to a same-name local overload of a non-ERC721 contract stays clean.
+
+Two exemptions:
+
+- calls to `_safeMint` are the recommended fix and never fire;
+- calls made inside a function named `_safeMint` are the wrapper implementation itself, which legitimately calls `_mint` next to its receiver check.
+
+### Why is this bad?
+
+`ERC721._mint` assigns the token without calling `onERC721Received` on the recipient. Minting to a contract that does not implement the receiver interface permanently locks the token. `_safeMint` performs the check and reverts instead.
+
+### Example
+
+#### Bad
+
+```solidity
+function mint(address to, uint256 id) external {
+    _mint(to, id);
+}
+```
+
+#### Good
+
+```solidity
+function mint(address to, uint256 id) external {
+    _safeMint(to, id);
+}
+```


### PR DESCRIPTION
Adds the Foundry Book page for the `unsafe-oz-erc721-mint` lint and wires it into the linting index and sidebar under medium severity.

This gives `https://getfoundry.sh/forge/linting/unsafe-oz-erc721-mint` a published page for the lint added in foundry-rs/foundry#15551 (from the parity checklist foundry-rs/foundry#14381), so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
