### PR TITLE
docs(lint): add function-init-state page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -107,6 +107,7 @@ const docs = [
             items: [
               { text: "boolean-equal", link: "/forge/linting/boolean-equal" },
               { text: "event-fields", link: "/forge/linting/event-fields" },
+              { text: "function-init-state", link: "/forge/linting/function-init-state" },
               { text: "inline-assembly", link: "/forge/linting/inline-assembly" },
               { text: "interface-file-naming", link: "/forge/linting/interface-file-naming" },
               { text: "interface-naming", link: "/forge/linting/interface-naming" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -207,6 +207,7 @@ navigation on the right to browse by severity.
 
 - [`boolean-equal`](/forge/linting/boolean-equal) — Flags expressions of the form `x == true`, `x == false`, `x != true`, `x != false`, which can be simplified.
 - [`event-fields`](/forge/linting/event-fields) — Flags event parameters of type `address`, `address payable`, or id-like `uint256`/`bytes32` that are not declared `indexed`.
+- [`function-init-state`](/forge/linting/function-init-state) — Flags state variables whose initializer depends on a non-pure function or another state variable; initializers run before the constructor body.
 - [`inline-assembly`](/forge/linting/inline-assembly) — Flags every `assembly { ... }` block; inline assembly bypasses Solidity safety features and should be reviewed deliberately.
 - [`interface-file-naming`](/forge/linting/interface-file-naming) — Flags Solidity files whose only top-level declaration is an interface but whose filename is not prefixed with `I`.
 - [`interface-naming`](/forge/linting/interface-naming) — Flags `interface` declarations whose names are not prefixed with `I`.

--- a/src/pages/forge/linting/function-init-state.mdx
+++ b/src/pages/forge/linting/function-init-state.mdx
@@ -1,0 +1,52 @@
+---
+description: State variable initializer depends on state
+---
+
+## Function init state
+
+**Severity**: `Info`
+**ID**: `function-init-state`
+
+Flags state variables whose initializer depends on a non-pure function or on another state variable.
+
+### What it does
+
+Reports a state variable whose inline initializer references a non-constant state variable or a non-pure function (called or referenced, including inside the arguments of a nested call). A public variable referenced through its synthesized getter counts as a read of the variable itself, so references to public constants stay clean, and qualified (`Base.viewFn()`) or external (`Oracle(addr).price()`) accesses are resolved as well. This mirrors Slither's `function-init-state` detector.
+
+References to constants, calls to pure functions and plain literal expressions are fine, and assignments made inside the constructor body are out of scope.
+
+### Why is this bad?
+
+State variable initializers run at construction, before the constructor body, in base-to-derived order. An initializer that reads another state variable or calls a function that does may observe default values or an ordering the author did not intend, so the computed value is rarely the expected one, and silently so.
+
+### Example
+
+#### Bad
+
+```solidity
+contract C {
+    uint256 internal seed = 77;
+    uint256 public value = compute(); // runs before the constructor sets anything
+
+    function compute() internal view returns (uint256) {
+        return seed * 2;
+    }
+}
+```
+
+#### Good
+
+```solidity
+contract C {
+    uint256 internal seed = 77;
+    uint256 public value;
+
+    constructor() {
+        value = compute();
+    }
+
+    function compute() internal view returns (uint256) {
+        return seed * 2;
+    }
+}
+```


### PR DESCRIPTION
Adds the Foundry Book page for the `function-init-state` lint and wires it into the linting index and sidebar under Informational.

This gives `https://getfoundry.sh/forge/linting/function-init-state` a published page for the lint added in foundry-rs/foundry#15553 (from the parity checklist foundry-rs/foundry#14381), so the Foundry `ensure_lint_rule_docs` check has matching book coverage.
