### PR TITLE
docs: document FOUNDRY_DIR and XDG directory variables

### DIFF
--- a/src/pages/config/reference/overview.mdx
+++ b/src/pages/config/reference/overview.mdx
@@ -69,15 +69,15 @@ By default, Foundry manages its toolchain, global configuration, cache, and keys
 | **Global Configuration** | `~/.foundry/foundry.toml` | [`FOUNDRY_CONFIG`](#configuration-file-discovery) environment variable |
 | **Project Build Cache** | `<project_root>/cache/` | `cache_path` config option or `FOUNDRY_CACHE_PATH` |
 | **Global RPC Cache** | `~/.foundry/cache/rpc/` | Not configurable |
-| **Keystores** | `~/.foundry/keystores/` | `--keystore-dir` / `--dir` CLI flags (for management), `--keystore` CLI flag (for signing) |
+| **Keystores** | `~/.foundry/keystores/` | Positional path argument (`cast wallet new`), `--keystore-dir` / `--dir` CLI flags, or `--keystore` CLI flag (for signing) |
 | **Solidity Compiler (`svm`)** | `~/.svm/` | Platform data directory (when `~/.svm` is absent and the data directory exists) |
 
 #### Toolchain Installation (`FOUNDRY_DIR`)
 
 `foundryup` installs the Foundry binaries (`forge`, `cast`, `anvil`, and `chisel`), manual pages, and versioned toolchains.
-- **Default path:** `~/.foundry/`
+- **Default path:** `~/.foundry/` (if neither `FOUNDRY_DIR` nor `XDG_CONFIG_HOME` is set).
 - **Customization:** Set the `FOUNDRY_DIR` environment variable to install to a custom directory.
-- **XDG Fallback:** If `FOUNDRY_DIR` is not set, `foundryup` will respect the `XDG_CONFIG_HOME` environment variable (defaulting to `$HOME` if unset) and install to `$XDG_CONFIG_HOME/.foundry/`. If `FOUNDRY_DIR` is set, it overrides this path completely.
+- **XDG Behavior:** If `FOUNDRY_DIR` is not set but `XDG_CONFIG_HOME` is set, `foundryup` will install to `$XDG_CONFIG_HOME/.foundry/`. If `FOUNDRY_DIR` is set, it takes precedence and overrides this path completely.
 
 #### CLI Configuration, Cache, and Keystores
 
@@ -85,7 +85,11 @@ The Foundry CLI tools currently store their global configuration, cache, and key
 - **Global Configuration:** Configured in `~/.foundry/foundry.toml`. This can be overridden by setting the `FOUNDRY_CONFIG` environment variable to a custom file path.
 - **Project Build Cache:** Compilation artifacts and build caches are stored in the project's local directory (defaulting to `cache/`). This can be overridden on a project-level using the `cache_path` config option in `foundry.toml` or the `FOUNDRY_CACHE_PATH` environment variable.
 - **Global RPC Cache:** Fork cache and other global RPC-related data are stored in `~/.foundry/cache/rpc/` and are not configurable.
-- **Keystores:** Encrypted private keys are stored in `~/.foundry/keystores/` by default. You can customize the storage directory during wallet creation/import using the `--keystore-dir` flag, query it using `--dir` or `--keystore-dir` flags, and specify a specific keystore file for signing via the `--keystore` flag.
+- **Keystores:** Encrypted private keys are stored in `~/.foundry/keystores/` by default. You can customize this directory by command family:
+  - **Creation:** `cast wallet new` takes the target directory as a positional path argument.
+  - **Importing/Management:** `cast wallet import`, `cast wallet decrypt-keystore`, and `cast wallet change-password` support the `--keystore-dir` flag to specify a custom directory.
+  - **Listing/Removal:** `cast wallet list` and `cast wallet remove` use the `--dir` flag.
+  - **Signing:** For CLI commands that require signing (like `cast send` or `forge script`), specify the path to a specific keystore file via the `--keystore` flag.
 
 #### Solidity Version Manager (`svm`)
 

--- a/src/pages/config/reference/overview.mdx
+++ b/src/pages/config/reference/overview.mdx
@@ -59,6 +59,40 @@ Exceptions are:
 - `DAPP_TEST_FUZZ_RUNS`
 - `DAPP_TEST_FUZZ_DEPTH`
 
+### Directory Layout
+
+By default, Foundry manages its toolchain, global configuration, cache, and keystore data under the user's home directory.
+
+| Component | Default Location | Override / Customization |
+| :--- | :--- | :--- |
+| **`foundryup` Installation** | `~/.foundry/` | `FOUNDRY_DIR` (or `${XDG_CONFIG_HOME:-$HOME}/.foundry/` as fallback) |
+| **Global Configuration** | `~/.foundry/foundry.toml` | [`FOUNDRY_CONFIG`](#configuration-file-discovery) environment variable |
+| **RPC Cache** | `~/.foundry/cache/` | `cache_path` config option or `FOUNDRY_CACHE_PATH` |
+| **Keystores** | `~/.foundry/keystores/` | `--keystore` CLI flag |
+| **Solidity Compiler (`svm`)** | `~/.svm/` | `XDG_DATA_HOME` / OS-specific data directory (when `~/.svm` is absent) |
+
+#### Toolchain Installation (`FOUNDRY_DIR`)
+
+`foundryup` installs the Foundry binaries (`forge`, `cast`, `anvil`, and `chisel`), manual pages, and versioned toolchains.
+- **Default path:** `~/.foundry/`
+- **Customization:** Set the `FOUNDRY_DIR` environment variable to install to a custom directory.
+- **XDG Fallback:** If `FOUNDRY_DIR` is not set, `foundryup` will respect the `XDG_CONFIG_HOME` environment variable (defaulting to `$HOME` if unset) and install to `$XDG_CONFIG_HOME/.foundry/`. If `FOUNDRY_DIR` is set, it overrides this path completely.
+
+#### CLI Configuration, Cache, and Keystores
+
+The Foundry CLI tools currently store their global configuration, cache, and keystore data under the traditional `~/.foundry` directory. These locations are configurable through existing Foundry-specific options rather than the XDG Base Directory environment variables:
+- **Global Configuration:** Configured in `~/.foundry/foundry.toml`. This can be overridden by setting the `FOUNDRY_CONFIG` environment variable to a custom file path.
+- **RPC Cache:** Fork cache and other non-essential data are stored in `~/.foundry/cache/`. This can be overridden on a project-level using the `cache_path` config option in `foundry.toml` or the `FOUNDRY_CACHE_PATH` environment variable.
+- **Keystores:** Encrypted private keys are stored in `~/.foundry/keystores/`. This can be overridden by passing a custom path using the `--keystore` CLI flag.
+
+#### Solidity Version Manager (`svm`)
+
+The Solidity Version Manager (`svm-rs`), which downloads and manages different compiler (`solc`) versions, adheres to standard platform-specific directories:
+- **Fallback behavior:** It first checks if the legacy `~/.svm/` directory exists. If it does, `svm-rs` continues to use `~/.svm` for compatibility.
+- **XDG Support:** If `~/.svm/` does not exist, it falls back to:
+  - **Linux/Unix:** `$XDG_DATA_HOME/svm/` (which defaults to `~/.local/share/svm/` if `XDG_DATA_HOME` is unset).
+  - **macOS:** `~/Library/Application Support/svm/`.
+
 ### Configuration format
 
 Configuration files are written in the [TOML format](https://toml.io), with simple key-value pairs inside of sections.

--- a/src/pages/config/reference/overview.mdx
+++ b/src/pages/config/reference/overview.mdx
@@ -67,9 +67,10 @@ By default, Foundry manages its toolchain, global configuration, cache, and keys
 | :--- | :--- | :--- |
 | **`foundryup` Installation** | `~/.foundry/` | `FOUNDRY_DIR` (or `${XDG_CONFIG_HOME:-$HOME}/.foundry/` as fallback) |
 | **Global Configuration** | `~/.foundry/foundry.toml` | [`FOUNDRY_CONFIG`](#configuration-file-discovery) environment variable |
-| **RPC Cache** | `~/.foundry/cache/` | `cache_path` config option or `FOUNDRY_CACHE_PATH` |
-| **Keystores** | `~/.foundry/keystores/` | `--keystore` CLI flag |
-| **Solidity Compiler (`svm`)** | `~/.svm/` | `XDG_DATA_HOME` / OS-specific data directory (when `~/.svm` is absent) |
+| **Project Build Cache** | `<project_root>/cache/` | `cache_path` config option or `FOUNDRY_CACHE_PATH` |
+| **Global RPC Cache** | `~/.foundry/cache/rpc/` | Not configurable |
+| **Keystores** | `~/.foundry/keystores/` | `--keystore-dir` / `--dir` CLI flags (for management), `--keystore` CLI flag (for signing) |
+| **Solidity Compiler (`svm`)** | `~/.svm/` | Platform data directory (when `~/.svm` is absent and the data directory exists) |
 
 #### Toolchain Installation (`FOUNDRY_DIR`)
 
@@ -82,16 +83,18 @@ By default, Foundry manages its toolchain, global configuration, cache, and keys
 
 The Foundry CLI tools currently store their global configuration, cache, and keystore data under the traditional `~/.foundry` directory. These locations are configurable through existing Foundry-specific options rather than the XDG Base Directory environment variables:
 - **Global Configuration:** Configured in `~/.foundry/foundry.toml`. This can be overridden by setting the `FOUNDRY_CONFIG` environment variable to a custom file path.
-- **RPC Cache:** Fork cache and other non-essential data are stored in `~/.foundry/cache/`. This can be overridden on a project-level using the `cache_path` config option in `foundry.toml` or the `FOUNDRY_CACHE_PATH` environment variable.
-- **Keystores:** Encrypted private keys are stored in `~/.foundry/keystores/`. This can be overridden by passing a custom path using the `--keystore` CLI flag.
+- **Project Build Cache:** Compilation artifacts and build caches are stored in the project's local directory (defaulting to `cache/`). This can be overridden on a project-level using the `cache_path` config option in `foundry.toml` or the `FOUNDRY_CACHE_PATH` environment variable.
+- **Global RPC Cache:** Fork cache and other global RPC-related data are stored in `~/.foundry/cache/rpc/` and are not configurable.
+- **Keystores:** Encrypted private keys are stored in `~/.foundry/keystores/` by default. You can customize the storage directory during wallet creation/import using the `--keystore-dir` flag, query it using `--dir` or `--keystore-dir` flags, and specify a specific keystore file for signing via the `--keystore` flag.
 
 #### Solidity Version Manager (`svm`)
 
-The Solidity Version Manager (`svm-rs`), which downloads and manages different compiler (`solc`) versions, adheres to standard platform-specific directories:
+The Solidity Version Manager (`svm-rs`), which downloads and manages different compiler (`solc`) versions, resolves its storage directory as follows:
 - **Fallback behavior:** It first checks if the legacy `~/.svm/` directory exists. If it does, `svm-rs` continues to use `~/.svm` for compatibility.
-- **XDG Support:** If `~/.svm/` does not exist, it falls back to:
+- **Platform Data Directory Fallback:** If `~/.svm/` does not exist **and** the system's platform-specific data directory exists, it will use:
   - **Linux/Unix:** `$XDG_DATA_HOME/svm/` (which defaults to `~/.local/share/svm/` if `XDG_DATA_HOME` is unset).
   - **macOS:** `~/Library/Application Support/svm/`.
+- **Otherwise:** If neither of the above conditions is met (e.g., the platform-specific data directory does not exist on disk), it defaults back to creating and using `~/.svm/`.
 
 ### Configuration format
 

--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -28,6 +28,10 @@ $ foundryup
 
 This installs the latest stable versions of `forge`, `cast`, `anvil`, and `chisel`.
 
+:::tip
+By default, Foundry is installed to `~/.foundry`. You can customize the installation path by setting the `FOUNDRY_DIR` environment variable before running `foundryup`. For details on the directory layout and environment variables, see the [Config Reference Overview](/config/reference/overview#directory-layout).
+:::
+
 :::warning[Windows]
 Foundryup requires [Git Bash](https://gitforwindows.org/) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). PowerShell and Command Prompt are not supported.
 :::

--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -29,7 +29,7 @@ $ foundryup
 This installs the latest stable versions of `forge`, `cast`, `anvil`, and `chisel`.
 
 :::tip
-By default, Foundry is installed to `~/.foundry`. You can customize the installation path by setting the `FOUNDRY_DIR` environment variable before running `foundryup`. For details on the directory layout and environment variables, see the [Config Reference Overview](/config/reference/overview#directory-layout).
+By default, if neither `FOUNDRY_DIR` nor `XDG_CONFIG_HOME` is set, Foundry is installed to `~/.foundry`. If `XDG_CONFIG_HOME` is set, it defaults to `$XDG_CONFIG_HOME/.foundry`. You can override both defaults by setting the `FOUNDRY_DIR` environment variable before running `foundryup`. For details on the directory layout and environment variables, see the [Config Reference Overview](/config/reference/overview#directory-layout).
 :::
 
 :::warning[Windows]


### PR DESCRIPTION
# Summary

Closes #1712.

This PR documents the directory layout and environment variable behavior introduced in `foundry-rs/foundry#4738`.

## Changes

* Documented `FOUNDRY_DIR` and its precedence over `XDG_CONFIG_HOME` in `foundryup`.
* Added a brief note to the installation guide pointing users to the configuration reference.
* Extended the Configuration Reference Overview with a new **Directory Layout** section.
* Documented the default locations and customization options for:

  * Global configuration
  * RPC cache
  * Keystores
  * Solidity compiler installations (`svm`)
* Added a quick reference table summarizing the default directory layout and available customization options.
* Clarified that Foundry CLI tools use their traditional directory layout, while `svm` follows the XDG Base Directory specification when appropriate.

## Verification

* Verified all documented behavior against the current implementations of:

  * `foundryup`
  * `svm-rs`
* Confirmed environment variable precedence and directory resolution logic from the source code.
* Reviewed the rendered documentation for clarity, formatting, and consistency with the existing Foundry Book.
