### PR TITLE
docs(lint): add deprecated-oz-function page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -93,6 +93,7 @@ const docs = [
               { text: "block-timestamp", link: "/forge/linting/block-timestamp" },
               { text: "calls-loop", link: "/forge/linting/calls-loop" },
               { text: "delegatecall-loop", link: "/forge/linting/delegatecall-loop" },
+              { text: "deprecated-oz-function", link: "/forge/linting/deprecated-oz-function" },
               { text: "empty-block", link: "/forge/linting/empty-block" },
               { text: "incorrect-modifier", link: "/forge/linting/incorrect-modifier" },
               { text: "missing-events-access-control", link: "/forge/linting/missing-events-access-control" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -196,6 +196,7 @@ navigation on the right to browse by severity.
 - [`block-timestamp`](/forge/linting/block-timestamp) — Flags use of `block.timestamp` as an operand of a comparison, where its value can be slightly manipulated by the block proposer.
 - [`calls-loop`](/forge/linting/calls-loop) — Flags external calls made from inside loops, which can cause denial-of-service if a callee reverts or exhausts gas.
 - [`delegatecall-loop`](/forge/linting/delegatecall-loop) — Flags `delegatecall` operations inside loops in externally callable payable functions.
+- [`deprecated-oz-function`](/forge/linting/deprecated-oz-function) — Flags references to functions OpenZeppelin deprecated: `SafeERC20.safeApprove` and `AccessControl._setupRole`.
 - [`empty-block`](/forge/linting/empty-block) — Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
 - [`incorrect-modifier`](/forge/linting/incorrect-modifier) — Flags modifiers that can finish without executing the modified function body or reverting.
 - [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags access-controlled updates to state used for authorization when the update function does not emit an event.

--- a/src/pages/forge/linting/deprecated-oz-function.mdx
+++ b/src/pages/forge/linting/deprecated-oz-function.mdx
@@ -1,0 +1,51 @@
+---
+description: Deprecated OpenZeppelin function
+---
+
+## Deprecated OpenZeppelin function
+
+**Severity**: `Low`
+**ID**: `deprecated-oz-function`
+
+Flags references to OpenZeppelin functions the library has deprecated: `SafeERC20.safeApprove` and `AccessControl._setupRole`.
+
+### What it does
+
+Reports a reference, called or used as a value, that resolves to a function named `safeApprove` declared in a library named `SafeERC20` / `SafeERC20Upgradeable`, or to a function named `_setupRole` declared in a contract named `AccessControl` / `AccessControlUpgradeable`. Resolution goes through the type checker, so the `using for` method form, the library-qualified form, import aliases and inheritance through extensions are all recognized, while same-name functions declared elsewhere stay out of scope. This mirrors Aderyn's `deprecated-oz-function` detector, which matches any identifier or member with those names in files importing an OpenZeppelin path.
+
+### Why is this bad?
+
+OpenZeppelin deprecated both functions in the 4.x line and removed them in 5.0, so they are dead ends for upgrades:
+
+- `safeApprove` reverts when changing a non-zero allowance to another non-zero value; `safeIncreaseAllowance` / `safeDecreaseAllowance` are the replacements its deprecation note documents, and `forceApprove` (added in 4.9 for tokens behaving like USDT) sets an exact allowance safely.
+- `_setupRole` was only intended for constructor setup and bypasses the role-admin checks; `_grantRole` is the supported replacement.
+
+### Example
+
+#### Bad
+
+```solidity
+using SafeERC20 for IERC20;
+
+function approveSpender(IERC20 token, address spender, uint256 amount) internal {
+    token.safeApprove(spender, amount);
+}
+
+constructor(address admin) {
+    _setupRole(DEFAULT_ADMIN_ROLE, admin);
+}
+```
+
+#### Good
+
+```solidity
+using SafeERC20 for IERC20;
+
+function approveSpender(IERC20 token, address spender, uint256 amount) internal {
+    token.forceApprove(spender, amount);
+}
+
+constructor(address admin) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin);
+}
+```


### PR DESCRIPTION
Documentation page for the deprecated-oz-function lint (foundry-rs/foundry#15579).