### PR TITLE
docs(lint): add solmate-safe-transfer-lib page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -102,6 +102,7 @@ const docs = [
               { text: "reentrancy-events", link: "/forge/linting/reentrancy-events" },
               { text: "require-revert-in-loop", link: "/forge/linting/require-revert-in-loop" },
               { text: "return-bomb", link: "/forge/linting/return-bomb" },
+              { text: "solmate-safe-transfer-lib", link: "/forge/linting/solmate-safe-transfer-lib" },
             ],
           },
           {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -205,6 +205,7 @@ navigation on the right to browse by severity.
 - [`reentrancy-events`](/forge/linting/reentrancy-events) — Flags `emit` statements reachable after an external call, where a reentrant callee can reorder or fabricate logs that off-chain consumers rely on.
 - [`require-revert-in-loop`](/forge/linting/require-revert-in-loop) — Flags `require` calls and `revert` statements that execute inside loops, including checks reached through internal helpers.
 - [`return-bomb`](/forge/linting/return-bomb) — Flags external calls that set an explicit gas limit while copying unbounded dynamic returndata.
+- [`solmate-safe-transfer-lib`](/forge/linting/solmate-safe-transfer-lib) — Flags solmate `SafeTransferLib` token operations: the released library does not check that the token has code.
 
 #### Informational
 

--- a/src/pages/forge/linting/solmate-safe-transfer-lib.mdx
+++ b/src/pages/forge/linting/solmate-safe-transfer-lib.mdx
@@ -1,0 +1,43 @@
+---
+description: Solmate SafeTransferLib does not check token code
+---
+
+## Solmate SafeTransferLib
+
+**Severity**: `Low`
+**ID**: `solmate-safe-transfer-lib`
+
+Flags token operations of solmate's `SafeTransferLib`, which does not check that the token has code in its released version.
+
+### What it does
+
+Reports a reference, called or used as a value, that resolves to `safeTransfer`, `safeTransferFrom` or `safeApprove` declared in a library named exactly `SafeTransferLib`. Resolution goes through the type checker, so the `using for` method form, the library-qualified form and import aliases are all recognized, while same-name functions declared in other libraries (Uniswap's `TransferHelper` style) stay out of scope. `safeTransferETH` involves no token code and stays clean.
+
+Aderyn's detector of the same name flags the import directive whose path contains `solmate` and `SafeTransferLib`; resolving the calls instead anchors the warning where the risk sits, skips files that import the library without using it, and keeps vendored or re-exported copies covered.
+
+### Why is this bad?
+
+In the released solmate v6, a token call that returns no data is treated as a success without checking that the token has code (`success := 1` on the empty-return path), unlike OpenZeppelin's `SafeERC20`. A token operation against an address with no code, a wrong address, a not-yet-deployed or a self-destructed token, is therefore a silent no-op that looks like a successful transfer. The unreleased solmate main branch has since added a code check to the empty-return path; on a released version, the mitigation is to verify the token has code, or to use OpenZeppelin's `SafeERC20`.
+
+### Example
+
+### Bad
+
+```solidity
+using SafeTransferLib for ERC20;
+
+function pay(ERC20 token, address to, uint256 amount) internal {
+    token.safeTransfer(to, amount);
+}
+```
+
+### Good
+
+```solidity
+using SafeTransferLib for ERC20;
+
+function pay(ERC20 token, address to, uint256 amount) internal {
+    require(address(token).code.length > 0, "token has no code");
+    token.safeTransfer(to, amount);
+}
+```


### PR DESCRIPTION
Documentation page for the solmate-safe-transfer-lib lint (foundry-rs/foundry#15580).