### PR TITLE
docs(lint): add incorrect-using-for page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -127,6 +127,7 @@ const docs = [
               { text: "too-many-digits", link: "/forge/linting/too-many-digits" },
               { text: "unaliased-plain-import", link: "/forge/linting/unaliased-plain-import" },
               { text: "unsafe-cheatcode", link: "/forge/linting/unsafe-cheatcode" },
+              { text: "incorrect-using-for", link: "/forge/linting/incorrect-using-for" },
               { text: "unused-error", link: "/forge/linting/unused-error" },
               { text: "unused-import", link: "/forge/linting/unused-import" },
             ],

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -227,6 +227,7 @@ navigation on the right to browse by severity.
 - [`too-many-digits`](/forge/linting/too-many-digits) — Flags numeric literals containing five or more consecutive zeros, which are easy to misread.
 - [`unaliased-plain-import`](/forge/linting/unaliased-plain-import) — Flags `import "path";` statements that pull in every top-level symbol from another file without an alias.
 - [`unsafe-cheatcode`](/forge/linting/unsafe-cheatcode) — Flags use of Foundry cheatcodes that perform dangerous side effects (filesystem access, network activity, environment variable reads, etc.) so they cannot slip into production code unnoticed.
+- [`incorrect-using-for`](/forge/linting/incorrect-using-for) — Flags `using ... for` directives naming a library with no function applicable to the type: they attach nothing.
 - [`unused-error`](/forge/linting/unused-error) — Flags custom error declarations that are never referenced anywhere in the compiled sources.
 - [`unused-import`](/forge/linting/unused-import) — Flags imported symbols (or whole import statements) whose imported names are not referenced anywhere in the source unit.
 

--- a/src/pages/forge/linting/incorrect-using-for.mdx
+++ b/src/pages/forge/linting/incorrect-using-for.mdx
@@ -1,0 +1,49 @@
+---
+description: using-for directive that attaches nothing
+---
+
+## Incorrect using-for
+
+**Severity**: `Info`
+**ID**: `incorrect-using-for`
+
+Flags `using L for T` directives whose library has no function applicable to the type: they attach nothing.
+
+### What it does
+
+Reports a `using ... for` directive, file-level or contract-level, when no function of the named library accepts the target type as its bound first parameter. Attachment follows the type checker, implicit conversions included: a `uint8` binds to a `uint256` parameter, a derived contract to a base parameter, and a storage reference to a memory one. `using L for *` and the braced form `using {f} for T` are out of scope, the latter because the compiler already rejects a function that cannot attach. This mirrors Slither's `incorrect-using-for` detector.
+
+### Why is this bad?
+
+A directive that attaches nothing is dead code, and usually a typo: the wrong library, or the wrong type. The compiler accepts it silently, so the mistake surfaces later as a confusing `Member "f" not found` error at the call site, or never surfaces at all.
+
+### Example
+
+### Bad
+
+```solidity
+library CounterLib {
+    function increment(uint256 v) internal pure returns (uint256) {
+        return v + 1;
+    }
+}
+
+contract C {
+    // no function of CounterLib takes an address
+    using CounterLib for address;
+}
+```
+
+### Good
+
+```solidity
+contract C {
+    using CounterLib for uint256;
+
+    uint256 internal counter;
+
+    function bump() internal view returns (uint256) {
+        return counter.increment();
+    }
+}
+```


### PR DESCRIPTION
Documentation page for the incorrect-using-for lint (foundry-rs/foundry#15581).