### PR TITLE
chore(meta): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danipopes @mattsse @grandizzy @0xrusowsky @mablr @figtracer @stevencartavia
+* @mattsse @mablr @figtracer @stevencartavia


### PR DESCRIPTION
Removes @danipopes, @grandizzy, @0xrusowsky from CODEOWNERS.