### PR TITLE
docs(lint): add todo-comment page

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -136,6 +136,7 @@ const docs = [
               { text: "incorrect-using-for", link: "/forge/linting/incorrect-using-for" },
               { text: "unused-error", link: "/forge/linting/unused-error" },
               { text: "unused-import", link: "/forge/linting/unused-import" },
+              { text: "todo-comment", link: "/forge/linting/todo-comment" },
             ],
           },
           {

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -236,6 +236,7 @@ navigation on the right to browse by severity.
 - [`incorrect-using-for`](/forge/linting/incorrect-using-for) — Flags `using ... for` directives naming a library with no function applicable to the type: they attach nothing.
 - [`unused-error`](/forge/linting/unused-error) — Flags custom error declarations that are never referenced anywhere in the compiled sources.
 - [`unused-import`](/forge/linting/unused-import) — Flags imported symbols (or whole import statements) whose imported names are not referenced anywhere in the source unit.
+- [`todo-comment`](/forge/linting/todo-comment) — Flags `TODO` and `FIXME` markers left in comments, which signal unfinished work or known bugs that have not been resolved before the code reached production.
 
 #### Gas optimization
 

--- a/src/pages/forge/linting/todo-comment.mdx
+++ b/src/pages/forge/linting/todo-comment.mdx
@@ -1,0 +1,52 @@
+---
+description: TODO and FIXME markers left in comments
+---
+
+## TODO/FIXME comments
+
+**Severity**: `Info`
+**ID**: `todo`
+
+Flags `TODO` and `FIXME` markers left in comments, which signal unfinished work or known
+bugs that have not been resolved before the code reached production.
+
+### What it does
+
+Scans every comment in the source file (single-line `//`, block `/* */`, and NatSpec `///`)
+and reports any comment containing a `TODO` or `FIXME` word, matched case-insensitively
+(e.g. `todo`, `ToDo`, `FixMe` all match).
+
+A comment is reported once, even if it contains multiple markers; the diagnostic lists
+each marker using the exact casing written in the source.
+
+### Why is this bad?
+
+`TODO` and `FIXME` comments are development notes. Shipping them into production contracts signals incomplete work.
+
+### Example
+
+### Bad
+
+```solidity
+contract Vault {
+    // TODO: implement access control
+    function withdraw() public {}
+
+    // FIXME this check is wrong
+    function deposit(uint256 amount) public {
+        require(amount > 0);
+    }
+}
+```
+
+### Good
+
+```solidity
+contract Vault {
+    function withdraw() public onlyOwner {}
+
+    function deposit(uint256 amount) public {
+        require(amount > 0, "zero amount");
+    }
+}
+```


### PR DESCRIPTION
Documentation page for the `todo comment` lint (https://github.com/foundry-rs/foundry/pull/15518)