### PR TITLE
feat: add foundryup install redirect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ Use `::::steps` for sequential instructions:
 ### Install foundryup
 
 ```bash
-$ curl -L https://foundry.paradigm.xyz | bash
+$ curl -L https://getfoundry.sh/install | bash
 ```
 
 ### Install Foundry

--- a/src/pages/help/faq.mdx
+++ b/src/pages/help/faq.mdx
@@ -21,7 +21,7 @@ Foundry is a fast, portable, and modular toolkit for Ethereum development writte
 Use `foundryup`:
 
 ```bash
-$ curl -L https://foundry.paradigm.xyz | bash
+$ curl -L https://getfoundry.sh/install | bash
 $ foundryup
 ```
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -17,7 +17,7 @@ import { SponsorCards } from './components/Sponsors'
 
 <div className="max-md:-mx-[var(--vocs-content_horizontalPadding,24px)] max-md:[&_[data-v-code-container]]:!rounded-none max-md:[&_pre]:!whitespace-pre-wrap max-md:[&_pre]:!overflow-x-hidden max-md:[&_pre]:!break-all max-md:[&_code]:!block max-md:[&_code]:!whitespace-pre-wrap max-md:[&_code]:!break-all max-md:[&_.line]:!whitespace-pre-wrap max-md:[&_.line]:!break-all">
 ```bash
-curl -L https://foundry.paradigm.xyz | bash && foundryup
+curl -L https://getfoundry.sh/install | bash && foundryup
 ```
 </div>
 

--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -11,7 +11,7 @@ Foundry is installed using **foundryup**, the official installer and version man
 ### Install foundryup
 
 ```bash
-$ curl -L https://foundry.paradigm.xyz | bash
+$ curl -L https://getfoundry.sh/install | bash
 ```
 
 ### Restart your terminal

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "redirects": [
+    { "source": "/install", "destination": "https://raw.githubusercontent.com/foundry-rs/foundryup/HEAD/foundryup-init.sh" },
+
     { "source": "/getting-started/installation", "destination": "/introduction/installation" },
     { "source": "/getting-started/introduction", "destination": "/introduction/getting-started" },
     { "source": "/getting-started/first-steps", "destination": "/introduction/getting-started" },


### PR DESCRIPTION
## Summary
- add a Vercel redirect from `/install` to the Rust `foundryup-init.sh` script
- update install snippets to use `https://getfoundry.sh/install` instead of `https://foundry.paradigm.xyz`

## Validation
- `jq empty vercel.json`
- `rg -n "foundry\.paradigm\.xyz" CONTRIBUTING.md src/pages/index.mdx src/pages/help/faq.mdx src/pages/introduction/installation.md vercel.json` returned no matches
- `bun install --frozen-lockfile` did not complete because Bun 1.3.13 wants to rewrite `bun.lock`; build was not run to avoid lockfile churn

Prompted by: @DaniPopes
