### PR TITLE
chore(lint): resync lint reference pages

### DIFF
--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -199,8 +199,8 @@ navigation on the right to browse by severity.
 - [`deprecated-oz-function`](/forge/linting/deprecated-oz-function) — Flags references to functions OpenZeppelin deprecated: `SafeERC20.safeApprove` and `AccessControl._setupRole`.
 - [`empty-block`](/forge/linting/empty-block) — Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
 - [`incorrect-modifier`](/forge/linting/incorrect-modifier) — Flags modifiers that can finish without executing the modified function body or reverting.
-- [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags access-controlled updates to state used for authorization when the update function does not emit an event.
-- [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags access-controlled updates to integer state used in arithmetic when the update path does not emit an event.
+- [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags protected entry-point functions that update state used for access control without emitting an event.
+- [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags protected entry-point functions that update tainted integer state used in arithmetic by an unprotected function without emitting an event.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.
 - [`msg-value-loop`](/forge/linting/msg-value-loop) — Flags `msg.value` reads inside loops reachable from externally callable payable functions.
 - [`reentrancy-events`](/forge/linting/reentrancy-events) — Flags `emit` statements reachable after an external call, where a reentrant callee can reorder or fabricate logs that off-chain consumers rely on.
@@ -211,7 +211,7 @@ navigation on the right to browse by severity.
 #### Informational
 
 - [`boolean-equal`](/forge/linting/boolean-equal) — Flags expressions of the form `x == true`, `x == false`, `x != true`, `x != false`, which can be simplified.
-- [`event-fields`](/forge/linting/event-fields) — Flags event parameters of type `address`, `address payable`, or id-like `uint256`/`bytes32` that are not declared `indexed`.
+- [`event-fields`](/forge/linting/event-fields) — Flags events whose `address` parameters are not declared `indexed`.
 - [`function-init-state`](/forge/linting/function-init-state) — Flags state variables whose initializer depends on a non-pure function or another state variable; initializers run before the constructor body.
 - [`inline-assembly`](/forge/linting/inline-assembly) — Flags every `assembly { ... }` block; inline assembly bypasses Solidity safety features and should be reviewed deliberately.
 - [`interface-file-naming`](/forge/linting/interface-file-naming) — Flags Solidity files whose only top-level declaration is an interface but whose filename is not prefixed with `I`.
@@ -241,7 +241,7 @@ navigation on the right to browse by severity.
 #### Gas optimization
 
 - [`asm-keccak256`](/forge/linting/asm-keccak256) — Flags calls to the high-level `keccak256(...)` builtin that can be cheaply rewritten with inline assembly.
-- [`cache-array-length`](/forge/linting/cache-array-length) — Flags `for` loop conditions that read a dynamic array or `bytes` value's `.length` on every iteration instead of comparing against a cached local length.
+- [`cache-array-length`](/forge/linting/cache-array-length) — Flags `for` loop conditions that read a storage dynamic array's `.length` on every iteration instead of comparing against a cached local length.
 - [`costly-loop`](/forge/linting/costly-loop) — Flags storage variable writes inside loops, where each SSTORE multiplies gas cost by the number of iterations.
 - [`could-be-constant`](/forge/linting/could-be-constant) — Flags state variables with a compile-time-constant inline initializer that are never written — making them eligible to be declared `constant`.
 - [`could-be-immutable`](/forge/linting/could-be-immutable) — Flags state variables that are assigned only in the constructor and never written to afterward — making them eligible to be declared `immutable`.

--- a/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20-permit.mdx
@@ -2,7 +2,7 @@
 description: Arbitrary ERC20 send with permit
 ---
 
-## Arbitrary ERC20 send with permit
+## Arbitrary `from` in `transferFrom` used with `permit`
 
 **Severity**: `High`
 **ID**: `arbitrary-send-erc20-permit`
@@ -29,46 +29,73 @@ Both common sink shapes are recognised:
 
 The lint does **not** require the transfer `amount` to equal the permit `value`,
 nor does it inspect deadlines or signatures — the dangerous combination is the
-permit-then-arbitrary-`transferFrom` pattern itself, not the specific amounts.
+permit-then-arbitrary-transferFrom pattern itself, not the specific amounts.
 
 Matching EIP-3156 flash-loan repayments (`onFlashLoan` followed by a pull-back of
 `amount + fee`) are excluded.
 
 #### Scope
 
-The check is intraprocedural and same-variable. It flags one
-permit-then-`transferFrom` flow inside a single function body and correlates the
-token, owner, and spender by the underlying variable, with the following
-normalisations applied to both sides of the correlation:
+The check is intraprocedural. It flags one permit-then-`transferFrom` flow inside a
+single function body and correlates the token, owner, and spender by the underlying
+variable, with the following normalisations applied to both sides of the correlation:
 
-- elementary type casts (`address(x)`), interface / contract casts
-  (`IERC20(rawToken)`), `payable(...)` wraps, and parentheses are stripped;
-- local aliases of `address(this)` (e.g.
-  `address self = address(this); permit(..., self, ...)`) are recognised as the
-  permit spender;
+- elementary type casts (`address(x)`), interface / contract casts (`IERC20(rawToken)`),
+  `payable(...)` wraps, and parentheses are stripped;
+- local var-to-var copies (`IERC20 t = token; ...`, `address from2 = from; ...`) are
+  tracked as aliases, so the permit and the sink still correlate when one side is a copy;
+- local aliases of `address(this)` (e.g. `address self = address(this); permit(..., self, ...)`)
+  and no-arg helpers whose body is `return address(this);` are recognised as the permit
+  spender;
 - the `using SafeTransferLib for address` member form is treated as a sink.
 
-Dead code after a definite exit (`return` / `revert`) is skipped, and inline
+Dead code after a top-level `return` / `revert` is skipped — including function bodies
+whose modifier prefix definitely exits before `_;`. Inline
 `// forge-lint: disable-next-line(arbitrary-send-erc20-permit)` suppresses a single sink.
 
-Patterns the check does **not** classify as the permit-variant (the underlying call
-may still be reported by [`arbitrary-send-erc20`](/forge/linting/arbitrary-send-erc20)
-when the sink itself is unguarded) include: copies of the token or owner into another
-variable (`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
-struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through a
-library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called helper /
-modifier / parent contract, and permits inside `for` or `while` loop bodies (whose
-execution count the analyzer treats as possibly zero).
+Additionally supported correlations:
+
+- struct-field token receivers (`cfg.token.permit(...)` then `cfg.token.transferFrom(...)`)
+  match via a `(base var, field name)` key;
+- the library wrapper `SafeERC20.safePermit(token, ...)` is treated as an EIP-2612
+  permit on the `token` argument when the receiver is a library;
+- immutable / constant state vars proven equal to `address(this)` or `msg.sender`
+  by their declaration initializer or constructor body are recognised as such at
+  the start of every function;
+- internal calls to functions of the same contract drop facts about every state
+  variable the callee (or one nested level of internal callees) assigns to, so a
+  prior permit is no longer trusted after the receiver may have been swapped.
+
+Patterns the check still does **not** classify as the permit-variant (the
+underlying call may still be reported by `arbitrary-send-erc20` when the sink
+itself is unguarded) include permits issued inside a called helper / modifier /
+parent contract.
+
+Permits inside `for` / `while` loop bodies do **not** establish facts visible after
+the loop (the analyzer treats their execution count as possibly zero), so a
+`transferFrom` placed after the loop is not classified as the permit variant. A
+`transferFrom` inside the same iteration as the permit is still flagged.
 
 ### Why is this bad?
 
-A `permit` only authorizes pulling from `owner`. A contract that follows the permit
-with `transferFrom` and an arbitrary `from` lets an attacker submit a victim's permit
-signature and drain the victim's balance.
+A `permit` followed by `transferFrom` is the textbook EIP-2612 flow, so it looks
+safe. It is **not** safe when the token does not actually implement `permit` but
+has a fallback function (the canonical example is WETH). On such tokens:
 
-The same pattern is also exploitable on tokens that don't implement `permit` but have
-a `fallback` (e.g. WETH): the `permit` call silently no-ops while the unconstrained
-`transferFrom` still executes, draining any pre-existing allowance from another user.
+- `permit(...)` is forwarded to the fallback and silently succeeds without
+  authorizing anything.
+- Any pre-existing allowance from another user to this contract can then be drained
+  by anyone, because the contract trusts the (no-op) permit and forwards the
+  attacker-supplied `from` straight into `transferFrom`.
+
+The recommendation is to pin the supported token(s) at deploy time and verify they
+implement `permit` correctly, or to require `from == msg.sender` so that, even if
+the permit silently no-ops, only the caller's own balance is at risk.
+
+If your code separately proves that `permit` succeeded (for example by reading
+`token.nonces(owner)` before and after and reverting on no change) or restricts the
+sink to a vetted token allowlist, review the finding and suppress with
+`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)`.
 
 ### Example
 
@@ -105,12 +132,3 @@ function pullWithPermit(
     token.transferFrom(msg.sender, address(this), value);
 }
 ```
-
-### Recommendation
-
-Constrain the sink's `from` to `msg.sender` (or `address(this)`), or restrict the
-sink to a vetted, deploy-time token allowlist whose `permit` implementation is
-verified. If your code separately proves the `permit` succeeded (for example by
-reading `token.nonces(owner)` before and after and reverting on no change), review
-the finding and suppress it locally with
-`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)`.

--- a/src/pages/forge/linting/arbitrary-send-erc20.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20.mdx
@@ -7,52 +7,59 @@ description: Arbitrary ERC20 send
 **Severity**: `High`
 **ID**: `arbitrary-send-erc20`
 
-`transferFrom` (and `safeTransferFrom`) move tokens from any address that has previously approved
-this contract. If the `from` argument is taken from user-controlled input without being constrained
-to `msg.sender` or `address(this)`, an attacker can pull tokens from any wallet that has an
+`transferFrom` (and `safeTransferFrom`) move tokens from any address that has
+previously approved this contract. If the `from` argument is taken from
+user-controlled input without being constrained to `msg.sender` or
+`address(this)`, an attacker can pull tokens from any wallet that has an
 outstanding allowance to the vulnerable contract.
 
 ### What it does
 
-Flags ERC20 transfer calls whose `from` argument is not provably equal to `msg.sender` or
-`address(this)`. The lint inspects three call shapes:
+Flags ERC20 transfer calls whose `from` argument is not provably equal to
+`msg.sender` or `address(this)`. The lint inspects three call shapes:
 
-- `token.transferFrom(from, to, amount)` (member call on an ERC20-typed receiver).
-- `token.safeTransferFrom(from, to, amount)` (member call, including `using SafeERC20 for IERC20`
-  extensions).
-- `Lib.safeTransferFrom(token, from, to, amount)` (library call with the 4-argument SafeERC20
-  signature).
+- `token.transferFrom(from, to, amount)` (member call on an ERC20-typed
+  receiver).
+- `token.safeTransferFrom(from, to, amount)` (member call, including
+  `using SafeERC20 for IERC20` extensions).
+- `Lib.safeTransferFrom(token, from, to, amount)` (library call with the
+  4-argument SafeERC20 signature).
 
 Safety is established by:
 
-- Direct use of `msg.sender` / `address(this)` (incl. `address(...)`, `payable(...)`, parens, and
-  ternary in which both branches are safe).
-- Calls to no-arg helpers whose body is `return X;` where `X` is itself statically safe — recognises
-  OpenZeppelin's `_msgSender()` and chains of similar wrappers up to a small bounded depth.
-- Local variables (and `immutable` / `constant` state variables) initialized or last-assigned from a
-  safe expression, or proven equal to one via an equality guard.
-- Equality guards in `require(...)`, `assert(...)`, and `if (... != safe) revert ...;`, including
-  conjunctions thereof.
-- Inline equality guards in the prefix of a modifier body (statements strictly before its single
-  top-level `_;` placeholder), mapped back to the caller's argument variables.
+- Direct use of `msg.sender` / `address(this)` (incl. `address(...)`,
+  `payable(...)`, parens, and ternary in which both branches are safe).
+- Calls to no-arg helpers whose body is `return X;` where `X` is itself
+  statically safe — recognises OpenZeppelin's `_msgSender()` and chains of
+  similar wrappers up to a small bounded depth.
+- Local variables (and `immutable` / `constant` state variables)
+  initialized or last-assigned from a safe expression, or proven equal to
+  one via an equality guard.
+- Equality guards in `require(...)`, `assert(...)`, and
+  `if (... != safe) revert ...;`, including conjunctions thereof.
+- Inline equality guards in the prefix of a modifier body (statements
+  strictly before its single top-level `_;` placeholder), mapped back to
+  the caller's argument variables.
 
-Branch joins recognise `return`, custom-error `revert`, the `revert(...)` builtin, and
-`assert(false)` / `require(false, ...)` as always-exiting: facts proven on the surviving branch
-propagate past the `if`.
+Branch joins recognise `return`, custom-error `revert`, the `revert(...)`
+builtin, and `assert(false)` / `require(false, ...)` as always-exiting:
+facts proven on the surviving branch propagate past the `if`.
 
 ### Related
 
-A prior EIP-2612 `permit(owner, address(this), …)` does **not** suppress this lint — the sink
-is instead reported as
-[`arbitrary-send-erc20-permit`](/forge/linting/arbitrary-send-erc20-permit), since non-EIP-2612
-tokens with a fallback can silently accept the permit and let any prior allowance be drained.
+A prior EIP-2612 `permit(owner, address(this), …)` does **not** suppress
+this lint — the sink is instead reported as
+[`arbitrary-send-erc20-permit`](./arbitrary-send-erc20-permit), since
+non-EIP-2612 tokens with a fallback can silently accept the permit and
+let any prior allowance be drained.
 
 ### Why is this bad?
 
-If a user has approved the contract to spend their tokens (e.g. for a swap or deposit they expect
-to perform later), an attacker can call a function that takes an arbitrary `from` and instruct the
-contract to transfer those tokens to themselves. This is one of the most common ways funds are
-drained from DeFi protocols.
+If a user has approved the contract to spend their tokens (e.g. for a swap or
+deposit they expect to perform later), an attacker can call a function that
+takes an arbitrary `from` and instruct the contract to transfer those tokens
+to themselves. This is one of the most common ways funds are drained from
+DeFi protocols.
 
 ### Example
 

--- a/src/pages/forge/linting/arbitrary-send-eth.mdx
+++ b/src/pages/forge/linting/arbitrary-send-eth.mdx
@@ -2,57 +2,76 @@
 description: Arbitrary ETH send
 ---
 
-## Arbitrary ETH send
+## Arbitrary Send ETH
 
 **Severity**: `High`
 **ID**: `arbitrary-send-eth`
 
-Detects functions that send ETH to a destination the caller controls. When the destination of
-`transfer` / `send` / a `{value: …}` low-level call / `selfdestruct` is reachable from a function
-parameter or mutable storage that any caller can rewrite, an attacker can redirect the contract's
-funds.
+Detects functions that send ETH to a destination the caller controls. When the
+destination of `transfer` / `send` / a `{value: …}` low-level call /
+`selfdestruct` is reachable from a function parameter or mutable storage that
+any caller can rewrite, an attacker can redirect the contract's funds.
 
 ### What it does
 
-For each non-`view` / non-`pure`, non-constructor, non-library function, the lint flags
-ETH-sending sinks whose destination is not provably safe and whose function is not
-caller-restricted. Sinks inside a modifier body are reported at the modifier definition.
+For each non-`view` / non-`pure`, non-constructor, non-library function, the
+lint flags ETH-sending sinks whose destination is not provably safe and the
+function is not caller-restricted. Sinks inside modifier bodies are reported
+at the modifier definition.
 
 Sinks recognised:
 
-- `addr.transfer(amount)` / `addr.send(amount)`.
-- `recv.method{value: x}(...)` (including `recv.call{value: x}(...)` and function-pointer
-  `f{value: x}()`).
-- `selfdestruct(addr)`.
-- Known ETH helpers — OpenZeppelin `Address.{sendValue, functionCallWithValue}` and Solady
-  `SafeTransferLib.{safeTransferETH, forceSafeTransferETH, safeTransferAllETH,
-  forceSafeTransferAllETH, trySafeTransferETH, trySafeTransferAllETH, safeMoveETH}`. Both
-  positional and named-arg calls are recognised; static `Base.method(...)` is only matched on
-  `library` bases.
+- `addr.transfer(amount)` / `addr.send(amount)`
+- `recv.method{value: x}(...)` (including `recv.call{value: x}(...)` and
+  function-pointer `f{value: x}()`)
+- `selfdestruct(addr)`
+- Known ETH helpers — OpenZeppelin `Address.{sendValue, functionCallWithValue}`
+  and Solady `SafeTransferLib.{safeTransferETH, forceSafeTransferETH,
+  safeTransferAllETH, forceSafeTransferAllETH, trySafeTransferETH,
+  trySafeTransferAllETH, safeMoveETH}`. Both positional and named-arg calls
+  are recognised; static `Base.method(...)` is only matched on `library` bases.
 
-A destination is safe when it is `msg.sender` (also through OpenZeppelin-style `_msgSender()`
-helpers), `tx.origin`, `address(this)`, a fixed address or numeric literal (including
-`address(0)`), an `immutable` / `constant` address, a local proven equal to a safe value on the
-current path, or a modifier parameter validated against `msg.sender`. Flow-sensitive facts are
-collected from assignments, `require`, `assert`, `if`/`else` (including ternaries), `&&` / `||`
-of equality checks, and `address(...)` / `payable(...)` casts.
+A destination is safe when it is `msg.sender` (also through OZ-style
+`_msgSender()` helpers), `tx.origin`, `address(this)`, a fixed literal
+(including `address(0)`), an `immutable` / `constant` address, a local proven
+equal to a safe value on the current path, or a modifier parameter validated
+against `msg.sender`. Flow-sensitive facts come from assignments, `require`,
+`assert`, `if`/`else` (incl. ternaries), `&&` / `||` of equality checks, and
+`address(...)` / `payable(...)` casts.
 
-Caller-restriction is detected for equality guards (`require(msg.sender == trusted)`,
-`if (msg.sender != trusted) revert(...)`, and their De Morgan equivalents) in modifier prefixes
-or function bodies. Trusted principals include state variables, `immutable` / `constant`
-addresses, fixed address literals, and zero-arg helpers returning such. `address(this)` is **not**
-trusted (a sibling function can route arbitrary callers via `this.guarded(userArg)`); state
-variables that may alias `address(this)` are likewise rejected.
+Caller-restriction is detected for equality guards (`require(msg.sender ==
+trusted)`, `if (msg.sender != trusted) revert()`, De-Morgan equivalents) in
+modifier prefixes or function bodies. Trusted principals include state
+variables, `immutable` / `constant` addresses, fixed address literals, and
+zero-arg helpers returning such. `address(this)` is **not** trusted (a
+sibling can route arbitrary callers via `this.guarded(userArg)`); state vars
+that *may* alias `address(this)` — through any initializer, constructor,
+runtime assignment, alias chain, struct/mapping/array slot, ternary, helper
+call (positional or named), base-constructor argument, or identity helper —
+are likewise rejected.
 
-Branch joins recognise `return`, custom-error `revert`, the `revert(...)` builtin, and
-`assert(false)` / `require(false, ...)` as always-exiting: facts proven on the surviving branch
-propagate past the `if`.
+### Known limitations
+
+- No general inter-procedural taint: a wrapper forwarding an arbitrary
+  destination may be missed. Library bodies are skipped; lint call sites.
+- Internal/private helpers are linted in isolation; a sink inside one is
+  reported even when every caller is protected.
+- Code after `_;` in a modifier is analysed without knowing whether each
+  callsite is itself caller-restricted.
+- Constructors are not analysed.
+- Caller-restriction is heuristic and only recognises equality guards.
+  Role-library helpers (`_checkRole`, `hasRole`) and parameterized
+  `only(who)` modifiers are not modelled.
+- Trusted-principal helpers are recognised only for bare-ident zero-arg
+  calls whose body is `return expr;`.
+- Mutable state vars are accepted as trusted principals: a mutable `owner`
+  plus an unprotected `setOwner` is not flagged. Prefer `immutable`.
 
 ### Why is this bad?
 
-If an attacker can choose the recipient of ETH transfers they can drain the contract balance,
-redirect user funds, or trivially bypass weak access controls. This is one of the most direct
-funds-loss bugs in Solidity contracts.
+If an attacker can choose the recipient of ETH transfers they can drain the
+contract balance, redirect user funds, or trivially bypass weak access
+controls.
 
 ### Example
 
@@ -85,10 +104,3 @@ contract Vault {
     }
 }
 ```
-
-### Recommendation
-
-Restrict who can call any function that sends ETH (a deploy-time-fixed `immutable` owner or
-role-based check), or constrain the destination to a deploy-time-fixed principal, `msg.sender`,
-or `address(this)`. Avoid mutable `owner` state without a corresponding access-controlled
-`setOwner` — the lint accepts it as trusted, but a public setter erases the guarantee.

--- a/src/pages/forge/linting/assert-state-change.mdx
+++ b/src/pages/forge/linting/assert-state-change.mdx
@@ -2,7 +2,7 @@
 description: State-modifying expression inside assert()
 ---
 
-## Assert State Change
+## Assert state change
 
 **Severity**: `Med`
 **ID**: `assert-state-change`
@@ -11,16 +11,16 @@ Flags expressions inside `assert()` that modify contract state.
 
 ### What it does
 
-Warns when an `assert()` argument contains a state-mutating operation: a pre- or post-increment/decrement (`++`/`--`) on a state variable, an assignment (`=`, `+=`, etc.) to a state variable, a `delete` of a state variable, or a call to a function that writes state variables.
+Warns when an `assert()` argument contains a state-mutating operation: a pre- or post-increment/decrement (`++`/`--`) on a state variable, an assignment (`=`, `+=`,etc.) to a state variable, a `delete` of a state variable, or a call to a function that writes state variables.
 
 ### Why is this bad?
 
-`assert()` is meant for invariant checking — conditions that should *never* be false if the contract is correct. `require()` is for input validation and conditions that may legitimately fail at runtime. Mixing a state mutation into an `assert()` argument conflates these two concerns:
+`assert()` is meant for invariant checking, conditions that should *never* be false if the contract is correct. `require()` is for input validation and conditions that may legitimately fail at runtime. Mixing a state mutation into an `assert()` argument conflates these two concerns:
 
 - If the assertion fails, the mutation is reverted, but the failure indicates a bug in the contract itself, not a recoverable condition.
 - If the assertion passes, the mutation happens as a side effect of the check, making the code harder to reason about.
 
-The correct pattern is to perform the mutation first, then assert the post-condition as a true invariant. For user-facing validation, use `require()` instead.
+The correct pattern is to perform the mutation first, then assert the post-condition as a true invariant. For user-facing validation use `require()` instead.
 
 ### Example
 

--- a/src/pages/forge/linting/cache-array-length.mdx
+++ b/src/pages/forge/linting/cache-array-length.mdx
@@ -7,25 +7,27 @@ description: Array length not cached
 **Severity**: `Gas`
 **ID**: `cache-array-length`
 
-Flags `for` loop conditions that read a dynamic array or `bytes` value's `.length` on every
-iteration instead of comparing against a cached local length.
+Flags `for` loop conditions that read a storage dynamic array's `.length` on every iteration
+instead of comparing against a cached local length.
 
 ### What it does
 
 Reports comparison expressions in `for` loop conditions when either side reads `.length` from a
-dynamic array-like value, such as `i < values.length`, `values.length > i`, or compound conditions
-that repeat the same pattern.
+state dynamic array, such as `i < values.length` or `values.length > i`, including comparisons
+nested inside `&&` / `||` conditions.
 
 The lint does not report loops that already compare against a local cached length variable.
-It is also intentionally conservative: it skips loops where caching the length could change
-semantics, including loops that mutate an array length, call a state-mutating helper, or read
-`.length` from a receiver that changes as the loop progresses.
+It also skips loops that mutate an array length in the loop body, such as calling `push()` or
+`pop()`, because aliases can make caching the length change the loop semantics.
+
+Fixed-size arrays are excluded because their length is a compile-time constant instead of a repeated
+dynamic length lookup. This lint currently checks `for` loops.
 
 ### Why is this bad?
 
-Reading `.length` in the loop condition repeats the length lookup for every iteration. Caching the
-length once before entering the loop avoids repeated storage, memory, or calldata reads and can
-reduce gas for hot loops.
+Reading `.length` in the loop condition repeats the storage length lookup for every iteration.
+Caching the length once before entering the loop avoids repeated storage reads and can reduce gas
+for hot loops.
 
 ### Example
 
@@ -60,8 +62,4 @@ contract C {
 
 ### Notes
 
-This is a `Gas`-severity lint and is not applied to test or script files.
-
-The lint will not report loop-variant reads like `values[i].length`, or loops where the body or
-post expression can change an array's length with `push`, `pop`, or a state-mutating call. In
-those cases, keeping the `.length` read in the loop condition preserves the original behavior.
+This is a `Gas`-severity lint and is **not** applied to test or script files.

--- a/src/pages/forge/linting/calls-loop.mdx
+++ b/src/pages/forge/linting/calls-loop.mdx
@@ -2,29 +2,25 @@
 description: External calls inside loops
 ---
 
-## External calls inside loops
+## External call inside a loop
 
 **Severity**: `Low`
 **ID**: `calls-loop`
 
-Flags external calls made from inside loops.
+Flags external calls made from inside loops, including calls reached through modifiers or internal
+helper functions.
 
 ### What it does
 
-Reports external calls that are reachable from a `for`, `while`, or `do-while` loop body. This
-includes low-level calls, ETH `send`/`transfer`, contract or interface calls, calls through
-`this`, and external calls reached through an internal helper called from inside the loop.
-
-Library-style member calls on non-contract values are ignored.
+Reports high-level contract calls, low-level `call`/`delegatecall`/`staticcall`, Ether
+`send`/`transfer`, external self-calls through `this`, and contract creation inside a loop. Internal
+and private library calls and `super` dispatch are not treated as external calls.
 
 ### Why is this bad?
 
-External calls can revert or consume enough gas to prevent the loop from completing. If the loop
-must process many recipients or contracts in one transaction, one failing callee can deny service
-to every later iteration.
-
-This is especially risky for push-payment patterns where every recipient must accept ETH before the
-function can finish.
+External calls inside loops can turn one reverting or gas-heavy callee into a denial-of-service for
+the whole loop. This is especially risky for push-payment patterns where every recipient must accept
+ETH or where every external contract must respond successfully before the function can complete.
 
 ### Example
 
@@ -46,21 +42,12 @@ contract Payouts {
 
 ```solidity
 contract Payouts {
-    mapping(address => uint256) public owed;
-
-    function queuePayment(address recipient, uint256 amount) external {
-        owed[recipient] += amount;
-    }
+    mapping(address recipient => uint256 amount) public claimable;
 
     function claim() external {
-        uint256 amount = owed[msg.sender];
-        owed[msg.sender] = 0;
+        uint256 amount = claimable[msg.sender];
+        claimable[msg.sender] = 0;
         payable(msg.sender).transfer(amount);
     }
 }
 ```
-
-### Recommendation
-
-Favor pull-based accounting: record what each recipient can claim, then let each recipient claim in
-a separate transaction.

--- a/src/pages/forge/linting/controlled-delegatecall.mdx
+++ b/src/pages/forge/linting/controlled-delegatecall.mdx
@@ -19,10 +19,10 @@ guards against trusted values, and modifier guards that refine the target argume
 Function parameters, `msg.sender`, mutable state variables, mapping and array reads, local aliases of
 those values, and all immutables are treated conservatively as untrusted.
 
-This lint does not attempt to prove trust through access-control modifiers such as `onlyOwner`, role
-checks, allowlist mappings, implementation-slot reads, assembly, external/library predicate helpers,
-codehash checks, or constructor-initialized immutables. Those patterns may be safe in a specific
-system, but they are intentionally outside this lint's proof model and can still warn.
+This lint does not attempt to prove trust through access-control modifiers such as `onlyOwner`,
+role checks, allowlist mappings, implementation-slot reads, assembly, external/library predicate
+helpers, codehash checks, or constructor-initialized immutables. Those patterns may be safe in a
+specific system, but they are intentionally outside this lint's proof model and can still warn.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/costly-loop.mdx
+++ b/src/pages/forge/linting/costly-loop.mdx
@@ -2,7 +2,7 @@
 description: Costly operations inside a loop
 ---
 
-## Costly Operations Inside a Loop
+## Costly operations inside a loop
 
 **Severity**: `Gas`
 **ID**: `costly-loop`

--- a/src/pages/forge/linting/could-be-constant.mdx
+++ b/src/pages/forge/linting/could-be-constant.mdx
@@ -12,12 +12,15 @@ anywhere — making them eligible to be declared `constant`.
 
 ### What it does
 
-Reports each non-`constant`, non-`immutable` state variable whose type accepts `constant` (any
-elementary type, including `string` and `bytes`, plus contract types) when it has an inline
-initializer composed only of literals, type casts, allowed pure builtin calls (`keccak256`,
-`sha256`, `ripemd160`, `ecrecover`, `addmod`, `mulmod`), `type(T).{min,max,interfaceId}`, and
-references to other `constant` variables — and is not written by the constructor body or by any
-other function.
+Reports each non-`constant`, non-`immutable` state variable when **all** of the following hold:
+
+- Its type is constant-compatible: any elementary type (value types, `string`, `bytes`) or a
+  contract type.
+- It has an inline initializer composed only of literals, type casts (`address(...)`,
+  `uint160(...)`, contract/interface casts like `IToken(...)`), `type(T).{min,max,interfaceId}`,
+  allowed pure builtin calls (`keccak256`, `sha256`, `ripemd160`, `ecrecover`, `addmod`,
+  `mulmod`), and references to other `constant` variables.
+- It is never written by the constructor body or by any other function.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/custom-errors.mdx
+++ b/src/pages/forge/linting/custom-errors.mdx
@@ -7,13 +7,13 @@ description: Prefer custom errors over revert strings
 **Severity**: `Gas`
 **ID**: `custom-errors`
 
-Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing
-them with a `revert CustomError(...)`.
+Flags `require(cond)`, `require(cond, "message")`, `revert("message")`, and `revert()` calls;
+suggests replacing them with a `revert CustomError(...)`.
 
 ### What it does
 
-Reports `require` calls whose second argument is a string literal, and `revert(...)` calls that
-are either bare or have a string-literal argument.
+Reports `require` calls with no reason or whose second argument is a string literal, and
+`revert(...)` calls that are either bare or have a string-literal argument.
 
 ### Why is this bad?
 
@@ -30,6 +30,7 @@ Solidity 0.8.4+ supports custom errors natively.
 
 ```solidity
 require(amount > 0, "amount must be > 0");
+require(amount > 0);
 revert("not authorized");
 revert();
 ```

--- a/src/pages/forge/linting/cyclomatic-complexity.mdx
+++ b/src/pages/forge/linting/cyclomatic-complexity.mdx
@@ -19,7 +19,7 @@ A function with many independent paths is hard to read, hard to review and hard 
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 // complexity 12: eleven branching points plus one
@@ -30,7 +30,7 @@ function dispatch(uint256 kind) internal {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
 function dispatch(uint256 kind) internal {

--- a/src/pages/forge/linting/dangerous-unary-operator.mdx
+++ b/src/pages/forge/linting/dangerous-unary-operator.mdx
@@ -7,31 +7,24 @@ description: Unary operator fused to assignment
 **Severity**: `Med`
 **ID**: `dangerous-unary-operator`
 
-Flags assignments whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment of a unary expression rather than the compound assignment it resembles.
+Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment of a unary expression rather than the compound assignment it resembles.
 
 ### What it does
 
-Warns when the source writes `=` directly against a leading unary `-` or `~` on the right-hand side:
+Reports `x =- y` and `x =~ y` when the source writes `=` directly against the unary operator, with no space. `x =- 1` lexes as `x` `=` `-` `1` and parses as `x = -1`, identical to the intentional spaced form, but it is a common typo for the compound `x -= 1`. The fused unary is also reported when it only leads a larger right-hand side: `x =- a + 1` parses as `x = (-a) + 1`, still a plain assignment rather than the `x -= a + 1` it resembles. The spaced forms (`x = -1`, `x = ~y`) and the real compound operators (`x -= 1`) are left alone. This mirrors Slither's `incorrect-unary` (Dangerous unary expressions).
 
-```solidity
-x =- y;
-x =~ y;
-```
-
-These expressions parse as `x = -y` and `x = ~y`, not as compound assignments. The lint also reports fused unary operators that lead larger right-hand sides, such as `x =- y + 1`, because that still parses as a plain assignment.
-
-Spaced unary assignments (`x = -y`, `x = ~y`) and real compound assignments (`x -= y`) are left alone.
+`=+` is not reported: unary `+` was removed in Solidity 0.5.0, so `x =+ 1` is a parse error and never reaches the linter.
 
 ### Why is this bad?
 
-`x =- 1` silently assigns `-1` instead of decrementing `x`. Developers intending to write `-=` can transpose the operator into `=-`, and the code still compiles and runs with the wrong value.
+`x =- 1` silently assigns `-1` instead of decrementing `x`. Developers reaching for `-=` can transpose the operator into `=-`, and because the code compiles and runs, the wrong value is used with no warning.
 
 ### Example
 
 #### Bad
 
 ```solidity
-x =- 1; // assigns -1, does not subtract 1 from x
+x =- 1; // parses as `x = -1`, not `x -= 1`
 ```
 
 #### Good

--- a/src/pages/forge/linting/delegatecall-loop.mdx
+++ b/src/pages/forge/linting/delegatecall-loop.mdx
@@ -2,7 +2,7 @@
 description: Delegatecall inside payable loops
 ---
 
-## Delegatecall inside payable loops
+## Delegatecall inside payable loop
 
 **Severity**: `Low`
 **ID**: `delegatecall-loop`
@@ -11,14 +11,14 @@ Flags `delegatecall` operations inside loops in externally callable payable func
 
 ### What it does
 
-Reports `delegatecall` expressions that appear in the body of a `for`, `while`, or `do-while`
+Reports `delegatecall` expressions that appear in the body of a `for`, `while`, or `do while`
 loop when the enclosing function is `public payable` or `external payable`.
 
 ### Why is this bad?
 
-`delegatecall` executes another contract's code in the caller's storage context and preserves the
-original `msg.sender` and `msg.value`. In a payable function, a loop can therefore expose the same
-`msg.value` to multiple delegatecalls even though Ether was only transferred once.
+`delegatecall` executes another contract's code in the caller's storage context and preserves
+the original `msg.sender` and `msg.value`. In a payable function, a loop can therefore expose the
+same `msg.value` to multiple delegatecalls even though Ether was only transferred once.
 
 If the delegated code accounts for `msg.value`, one transaction can credit the same payment
 multiple times or repeatedly mutate the caller's storage in unexpected ways.
@@ -30,10 +30,7 @@ multiple times or repeatedly mutate the caller's storage in unexpected ways.
 ```solidity
 function batch(address[] calldata receivers) external payable {
     for (uint256 i; i < receivers.length; ++i) {
-        (bool ok,) = address(this).delegatecall(
-            abi.encodeWithSignature("credit(address)", receivers[i])
-        );
-        require(ok);
+        address(this).delegatecall(abi.encodeWithSignature("credit(address)", receivers[i]));
     }
 }
 ```
@@ -49,10 +46,7 @@ function batch(address[] calldata receivers) external payable {
 }
 ```
 
-### Recommendation
+### Notes
 
-Avoid `delegatecall` in payable loops. Prefer direct internal logic, or calculate the per-iteration
-value explicitly before the loop and pass that value to code that performs the accounting.
-
-If `delegatecall` is required, review the delegated code carefully and make sure it cannot reuse
-the same `msg.value` or unexpectedly modify caller storage across loop iterations.
+Review each occurrence manually. If `delegatecall` is required, ensure delegated code cannot
+reuse `msg.value` or unexpectedly modify caller storage across loop iterations.

--- a/src/pages/forge/linting/deprecated-oz-function.mdx
+++ b/src/pages/forge/linting/deprecated-oz-function.mdx
@@ -11,7 +11,7 @@ Flags references to OpenZeppelin functions the library has deprecated: `SafeERC2
 
 ### What it does
 
-Reports a reference, called or used as a value, that resolves to a function named `safeApprove` declared in a library named `SafeERC20` / `SafeERC20Upgradeable`, or to a function named `_setupRole` declared in a contract named `AccessControl` / `AccessControlUpgradeable`. Resolution goes through the type checker, so the `using for` method form, the library-qualified form, import aliases and inheritance through extensions are all recognized, while same-name functions declared elsewhere stay out of scope. This mirrors Aderyn's `deprecated-oz-function` detector, which matches any identifier or member with those names in files importing an OpenZeppelin path.
+Reports a reference, called or used as a value, that resolves to a function named `safeApprove` declared in a library named `SafeERC20` / `SafeERC20Upgradeable`, or to a function named `_setupRole` declared in a contract named `AccessControl` / `AccessControlUpgradeable`. Resolution goes through the type checker, so the `using for` method form, the library-qualified form, import aliases and inheritance through extensions are all recognized, while same-name functions declared elsewhere stay out of scope. The declaration must also come from an OpenZeppelin package path (`lib/openzeppelin-contracts`, `@openzeppelin/...`), so a local library or contract reusing the canonical name is not reported; the flip side is that a vendored OpenZeppelin copy under a path that does not name OpenZeppelin is not recognized. This mirrors Aderyn's `deprecated-oz-function` detector, which matches any identifier or member with those names in files importing an OpenZeppelin path.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/encode-packed-collision.mdx
+++ b/src/pages/forge/linting/encode-packed-collision.mdx
@@ -2,15 +2,12 @@
 description: Hash collision from abi.encodePacked with multiple dynamic arguments
 ---
 
-## Hash collision from abi.encodePacked
+## Encode Packed Collision
 
 **Severity**: `High`
 **ID**: `encode-packed-collision`
 
-`abi.encodePacked()` with multiple dynamic-type arguments produces ambiguous encodings. Because
-packed encoding concatenates values without length prefixes, different inputs can produce the same
-output — for example, `encodePacked("a", "bc") == encodePacked("ab", "c")`. When the result is
-hashed and used as a key or signature, this enables collision attacks.
+`abi.encodePacked()` with multiple dynamic-type arguments produces ambiguous encodings. Because packed encoding concatenates values without length prefixes, different inputs can produce the same output — for example, `encodePacked("a", "bc") == encodePacked("ab", "c")`. When the result is hashed and used as a key or signature, this enables collision attacks.
 
 ### What it does
 
@@ -22,13 +19,15 @@ Flags calls to `abi.encodePacked()` where two or more arguments have dynamic typ
 
 ### Why is this bad?
 
-Hash collisions allow an attacker to craft inputs that hash to an identifier they do not own.
-Common vulnerable patterns include:
+Hash collisions allow an attacker to craft inputs that hash to an identifier they do not own. Common vulnerable patterns include:
 
-- **Merkle leaf construction** — an attacker submits two adjacent leaves concatenated to match a
-  sibling pair.
-- **Signature payloads** — two different messages that produce the same signature hash.
-- **Access-control keys** — two different (user, resource) pairs that map to the same key.
+- Merkle leaf construction: an attacker submits two adjacent leaves concatenated to match a sibling pair
+- Signature payloads: two different messages that produce the same signature hash
+- Access-control keys: two different (user, resource) pairs that map to the same key
+
+This lint is intentionally conservative and flags by argument type, not by proving exploitability.
+Some injective patterns, such as repeating the same dynamic value or manually adding length prefixes,
+may still be reported.
 
 ### Example
 

--- a/src/pages/forge/linting/event-fields.mdx
+++ b/src/pages/forge/linting/event-fields.mdx
@@ -1,35 +1,28 @@
 ---
-description: Address and id event parameters should be indexed
+description: Address event parameters should be indexed
 ---
 
-## Address and id event parameters should be indexed
+## Address event parameters should be indexed
 
 **Severity**: `Info`
 **ID**: `event-fields`
 
-Flags event parameters that are almost always meant to be filterable but are not declared
-`indexed`: `address` / `address payable` parameters, and `uint256` / `bytes32` parameters
-with id-like names. A single diagnostic is emitted per event listing the offending fields.
+Flags events whose `address` parameters are not declared `indexed`.
 
 ### What it does
 
-Reports an event when at least one of its unindexed parameters is filterable, where
-filterable means:
-
-- type `address` or `address payable`, or
-- type `uint256` (or its alias `uint`) and a name matching `id`, `*Id`, `*ID`, `*_id`, or
-  `*_ID`, or
-- type `bytes32` and a name matching `id`, `*Id`, `*ID`, `*_id`, or `*_ID`.
-
-The lint respects the EVM cap on indexed parameters per event (3 for normal events, 4 for
-`anonymous` events) and only suggests changes that are still feasible.
+For each event, identifies unindexed `address` parameters and reports a single warning
+listing them. The lint respects the EVM cap on indexed parameters (3 for normal events,
+4 for `anonymous`) and does not flag events that are already at capacity. Events that
+already have at least one indexed parameter are left alone: the author has clearly chosen
+what to index, so we stay silent.
 
 ### Why is this bad?
 
-Indexed event parameters are stored as topics in the transaction log. Off-chain indexers,
-explorers, and clients use topics to filter events by sender, recipient, token id, order
-id, etc. Leaving filterable fields unindexed forces consumers to scan and decode every
-event of that type, which is slow and brittle.
+Indexed event parameters are stored as topics in the transaction log, which lets
+off-chain indexers, explorers, and clients efficiently filter events by sender or
+recipient. Leaving filterable fields unindexed forces consumers to scan and decode every
+event, which is slow and brittle.
 
 ### Example
 
@@ -38,27 +31,21 @@ event of that type, which is slow and brittle.
 ```solidity
 event Transfer(address from, address to, uint256 value);
 event Mint(address to, uint256 tokenId);
-event Order(bytes32 orderId, uint256 amount);
 ```
 
 #### Good
 
 ```solidity
 event Transfer(address indexed from, address indexed to, uint256 value);
-event Mint(address indexed to, uint256 indexed tokenId);
-event Order(bytes32 indexed orderId, uint256 amount);
+event Mint(address indexed to, uint256 tokenId);
 ```
 
 ### Limitations
 
 This lint is intentionally conservative:
 
-- Only explicit `address`, `address payable`, `uint256`, and `bytes32` parameters
-  are checked. Custom types (contract types, interfaces, user-defined value types)
-  are **not** unwrapped, so e.g. `IERC20 token` or `type UserId is uint256;`
-  parameters are not flagged.
-- For `uint256`/`bytes32`, only names matching `id`, `*Id`, `*ID`, `*_id`, or
-  `*_ID` are flagged. Other names (e.g. `amount`, `hash`, `nonce`) are ignored.
+- Only explicit `address` parameters are checked. `address payable`, custom types,
+  interfaces, and user-defined value types are not unwrapped.
 - Only actionable suggestions are reported. If an event has no remaining indexed
   slots (3 for normal events, 4 for `anonymous`), no warning is emitted. If only
   some slots remain, only the first parameters that could still be indexed are

--- a/src/pages/forge/linting/external-function.mdx
+++ b/src/pages/forge/linting/external-function.mdx
@@ -2,44 +2,46 @@
 description: Public function can be declared external
 ---
 
-## Public function can be declared external
+## External Function
 
 **Severity**: `Gas`
 **ID**: `external-function`
 
-Flags `public` functions that are never called from inside the contract or any of its
-derivatives and that take at least one reference-type parameter currently located in
-`memory`. Such functions can be declared `external` (and their reference parameters moved to
-`calldata`) to avoid copying arguments from `calldata` into `memory` on every call.
+`public` functions that are never called from inside the contract (or any of its
+derivatives) can be declared `external`. External functions read their reference-type
+arguments directly from `calldata` instead of copying them into `memory`, which saves
+gas at every call site.
 
 ### What it does
 
-Reports a `public` function declaration when **all** of the following hold:
+Flags a `public` function declaration when **all** of the following hold:
 
-- It is `public` (not `external`, `internal`, or `private`).
+- The function is `public` (not `external`, `internal`, or `private`).
 - It is an ordinary function (not a constructor, fallback, receive, or modifier).
 - It has at least one parameter that is a reference type (`struct`, array, `bytes`, or
   `string`) currently located in `memory`.
-- It is not an `override` of another function. The base must be migrated first because
-  Solidity only allows widening visibility from `external` to `public`, never the reverse.
-- It has a body (so it is neither abstract nor an interface declaration).
+- It is not an `override` of another function (the base must be migrated first).
+- It has a body (not abstract or interface-only).
 - It does not write to any of its parameters inside the body.
 - It is never called from inside the contract or any contract that derives from it,
-  whether directly (`foo(...)`), via `super.foo(...)`, or as a function-pointer
-  reference (`fn = foo;`).
+  whether directly (`foo()`), via `super.foo(...)`, or via a function-pointer reference
+  (`fn = foo;`).
+
+The lint runs in the `Gas` severity bucket and is automatically skipped on Foundry
+test and script files.
 
 ### Why is this bad?
 
-Calling a `public` function from outside the contract is more expensive than calling the
-equivalent `external` function:
+Calling a `public` function from outside the contract is more expensive than calling
+the equivalent `external` function:
 
-- Every reference-type argument is copied from `calldata` into `memory` before the body
-  executes, even when the only callers are external.
-- The dispatcher includes additional bytecode to support both internal and external entry
-  points, increasing deployment cost and adding a branch on every call.
+- Each reference-type parameter is copied from `calldata` into `memory` before the
+  function body executes, even though `external`-only callers never need that copy.
+- The opcode shim that allows the function to be called both internally and externally
+  adds a few bytes of bytecode and an extra branch on every entry.
 
-When the function is never called internally, switching `public` to `external` removes both
-costs without changing semantics.
+When the function is never called internally, switching `public` to `external` removes
+both costs at no semantic change.
 
 ### Example
 
@@ -74,9 +76,5 @@ contract Vault {
 }
 ```
 
-When migrating `public` to `external`, also change reference-type parameters from `memory`
-to `calldata` to capture the full gas saving.
-
-### Notes
-
-This is a `Gas`-severity lint and is **not** applied to test or script files.
+When you migrate `public` to `external`, also change reference-type parameters from
+`memory` to `calldata` to capture the full gas saving.

--- a/src/pages/forge/linting/function-init-state.mdx
+++ b/src/pages/forge/linting/function-init-state.mdx
@@ -11,7 +11,7 @@ Flags state variables whose initializer depends on a non-pure function or on ano
 
 ### What it does
 
-Reports a state variable whose inline initializer references a non-constant state variable or a non-pure function (called or referenced, including inside the arguments of a nested call). A public variable referenced through its synthesized getter counts as a read of the variable itself, so references to public constants stay clean, and qualified (`Base.viewFn()`) or external (`Oracle(addr).price()`) accesses are resolved as well. This mirrors Slither's `function-init-state` detector.
+Reports a state variable whose inline initializer references a non-constant state variable or a non-pure function (called or referenced, including inside the arguments of a nested call). A public variable referenced through its synthesized getter counts as a read of the variable itself, so references to public constants stay clean. This mirrors Slither's `function-init-state` detector.
 
 References to constants, calls to pure functions and plain literal expressions are fine, and assignments made inside the constructor body are out of scope.
 

--- a/src/pages/forge/linting/incorrect-exp.mdx
+++ b/src/pages/forge/linting/incorrect-exp.mdx
@@ -7,24 +7,17 @@ description: Incorrect exponentiation
 **Severity**: `High`
 **ID**: `incorrect-exp`
 
-Flags `^` used between integer literals where `**` (exponentiation) was almost certainly intended.
+Flags `^` used between integer literals where `**` was almost certainly intended.
 
 ### What it does
 
-Reports `a ^ b` when the base `a` is `2` or `10` and both operands are plain decimal integer
-literals, looking through integer casts such as `uint256(10)`. In Solidity `^` is the bitwise xor
-operator, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
+Reports `a ^ b` when the base `a` is `2` or `10` and both operands are plain decimal integer literals, looking through integer casts such as `uint256(10)`. In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
 
-The base is restricted to the values people write as powers (`2` for bit widths, `10` for
-decimals). Operands written in hex (`0xff`), in scientific notation (`1e1`), or behind a
-non-integer cast (`bytes32(...)`) are left alone: the lint prefers a false negative to a false
-positive that would annoy developers. This mirrors GCC's and Clang's `-Wxor-used-as-pow`.
+The base is restricted to the values people write as powers (`2` for bit widths, `10` for decimals). Operands written in hex (`0xff`), in scientific notation (`1e1`), or behind a non-integer cast (`bytes32(...)`) are left alone: the lint prefers a false negative to a false positive that would annoy developers. This mirrors GCC's and Clang's `-Wxor-used-as-pow`.
 
 ### Why is this bad?
 
-Developers coming from languages where `^` means exponentiation (Python, many calculators) write
-`10 ^ 18` expecting `10 ** 18`. The contract compiles and silently uses the wrong constant, which
-can corrupt amounts, decimals, or limits.
+Developers coming from languages where `^` means exponentiation (Python, many calculators) write `10 ^ 18` expecting `10 ** 18`. The contract compiles and silently uses the wrong constant, which can corrupt amounts, decimals, or limits.
 
 ### Example
 

--- a/src/pages/forge/linting/incorrect-modifier.mdx
+++ b/src/pages/forge/linting/incorrect-modifier.mdx
@@ -2,26 +2,25 @@
 description: Incorrect modifier
 ---
 
-## Incorrect modifier
+## Incorrect Modifier
 
 **Severity**: `Low`
 **ID**: `incorrect-modifier`
 
-Flags modifiers that can finish without executing the modified function body or reverting.
+Reports modifiers that can finish without executing the modified function body or reverting.
 
 ### What it does
 
-Reports Solidity modifiers where at least one path can complete before reaching the `_` placeholder.
+Flags Solidity modifiers where at least one path can complete before reaching the `_` placeholder.
 Paths that revert before `_` are not flagged.
 
-Only paths that provably revert or otherwise halt are treated as safe: an explicit `revert`
-statement or `revert(...)` builtin call. Yul failing halts (`revert` and `invalid`) are also
-treated as safe. Yul successful halts (`return`, `stop`, and `selfdestruct`) are flagged because
-they finish execution without running the modified function body.
-
-A regular function call that might revert, such as `require(...)`, an internal helper, or an
-external call, does not count as a guaranteed revert. A path that performs such a call and then
-returns without reaching `_` is still flagged.
+Only a path that provably reverts or otherwise halts is treated as safe: an explicit `revert`
+statement or `revert(...)` builtin call, and the Yul halting builtins (`revert`/`invalid` to fail,
+and `return`/`stop`/`selfdestruct`, which halt *successfully* without running the function body and
+are therefore flagged). A regular function call that *might* revert (e.g. `require(...)`, an
+internal helper, or an external call) does not count, so a path that performs such a call and then
+returns without reaching `_` is still flagged. This is intentionally stricter than some other
+tools.
 
 ### Why is this bad?
 
@@ -50,9 +49,3 @@ modifier onlyWhenEnabled() {
     _;
 }
 ```
-
-### Recommendation
-
-Make every path in the modifier either execute `_` or explicitly revert before the modifier can
-finish. Avoid relying on helper calls that might revert unless the modifier also has an explicit
-non-reverting path guard.

--- a/src/pages/forge/linting/incorrect-shift.mdx
+++ b/src/pages/forge/linting/incorrect-shift.mdx
@@ -2,40 +2,42 @@
 description: Incorrect shift order
 ---
 
-## Incorrect shift order
+## Incorrect Yul shift order
 
 **Severity**: `High`
 **ID**: `incorrect-shift`
 
-Flags shift operations where a literal appears on the left and a non-literal on the right, which
-is almost always the wrong operand order.
+Flags Yul `shl` and `shr` calls whose operands appear to be reversed.
 
 ### What it does
 
-Warns when the left-hand operand of `<<` or `>>` is a numeric literal and the right-hand operand
-is a non-literal expression (e.g. a variable, function call, or composite expression).
+Warns when the first argument to a Yul `shl` or `shr` call is dynamic and the second argument is a
+literal. Yul shift calls take the shift amount first and the value second, so `shr(value, 8)`
+shifts the literal `8` by `value`; the usual intended expression is `shr(8, value)`.
 
 ### Why is this bad?
 
-Shift expressions like `2 << x` are usually a typo for `x << 2`. In the former, the *value being
-shifted* is a tiny constant and the *shift amount* is dynamic — almost never the intended
-behavior, and a known source of bugs in production contracts.
+Yul's shift argument order is easy to confuse with high-level Solidity operators. Reversing the
+arguments silently changes which value is shifted and can produce incorrect arithmetic,
+bit-packing, or bounds logic.
 
 ### Example
 
 #### Bad
 
 ```solidity
-result = 2 << stateValue;        // shift amount comes from state
-result = 8 >> localValue;        // shift amount comes from a local
-result = 16 << (stateValue + 1); // shift amount is a dynamic expression
+assembly {
+    result := shl(value, 8)
+    result := shr(add(value, 1), 16)
+}
 ```
 
 #### Good
 
 ```solidity
-result = stateValue << 2;
-result = localValue >> 3;
-result = stateValue << localShiftAmount;
-result = 1 << 8; // both literals — fine
+assembly {
+    result := shl(8, value)
+    result := shr(16, add(value, 1))
+    result := shl(8, 1) // both literals
+}
 ```

--- a/src/pages/forge/linting/incorrect-strict-equality.mdx
+++ b/src/pages/forge/linting/incorrect-strict-equality.mdx
@@ -2,7 +2,7 @@
 description: Dangerous strict equality check on an externally-influenced value
 ---
 
-## Incorrect strict equality
+## Incorrect Strict Equality
 
 **Severity**: `Med`
 **ID**: `incorrect-strict-equality`

--- a/src/pages/forge/linting/incorrect-using-for.mdx
+++ b/src/pages/forge/linting/incorrect-using-for.mdx
@@ -11,7 +11,7 @@ Flags `using L for T` directives whose library has no function applicable to the
 
 ### What it does
 
-Reports a `using ... for` directive, file-level or contract-level, when no function of the named library accepts the target type as its bound first parameter. Attachment follows the type checker, implicit conversions included: a `uint8` binds to a `uint256` parameter, a derived contract to a base parameter, and a storage reference to a memory one. `using L for *` and the braced form `using {f} for T` are out of scope, the latter because the compiler already rejects a function that cannot attach. This mirrors Slither's `incorrect-using-for` detector.
+Reports a `using ... for` directive, file-level or contract-level, when no function of the named library accepts the target type as its bound first parameter. Attachment follows the type checker, implicit conversions included: a `uint8` binds to a `uint256` parameter and a derived contract to a base parameter. Reference types are probed under every data location their bound value may live in (`storage`, `memory` and `calldata`), so a library whose only applicable function takes a `calldata` first parameter counts as attaching. Private library functions never count: the library form skips them, even when a braced directive in scope attaches one. `using L for *` and the braced form `using {f} for T` are out of scope, the latter because the compiler already rejects a function that cannot attach. Inspired by Slither's `incorrect-using-for` detector, with a different scope: contract-level directives are covered, attachment follows Solar's member resolution across data locations, and private functions are excluded.
 
 ### Why is this bad?
 
@@ -19,7 +19,7 @@ A directive that attaches nothing is dead code, and usually a typo: the wrong li
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 library CounterLib {
@@ -34,7 +34,7 @@ contract C {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
 contract C {

--- a/src/pages/forge/linting/internal-function-used-once.mdx
+++ b/src/pages/forge/linting/internal-function-used-once.mdx
@@ -13,7 +13,7 @@ Flags internal functions referenced exactly once in the whole compilation unit.
 
 Reports an ordinary internal function, free functions included, that exactly one expression in the unit references, call or value alike. References are resolved through the type checker, so overload selection, the qualified and `using for` forms and import aliases attribute each reference to the right declaration; references are counted across dependencies too, while only functions declared in the project's own sources report.
 
-Out of scope: functions whose name starts with `_` (the hook convention, OpenZeppelin style), `virtual` functions and overrides (they exist for dynamic dispatch, so inlining them is not an option), and functions referenced zero times, which are dead code rather than an inlining candidate. Aderyn's detector of the same name counts identifier references and does not exempt virtual functions or overrides.
+Out of scope: functions whose name starts with `_` (the hook convention, OpenZeppelin style), `virtual` functions and overrides (they exist for dynamic dispatch, so inlining them is not an option), functions referenced zero times, which are dead code rather than an inlining candidate, functions bound as user-defined operators through `using {f as +} for T`: operator uses are not name references, so their count would lie, and the binding requires a named function, so inlining is not an option either, and recursive functions: a self-recursive function cannot be inlined into a caller (self-references do not count toward the reference count), and mutually recursive helpers whose single references only form the cycle have no caller to inline into. Aderyn's detector of the same name counts identifier references and does not exempt virtual functions or overrides.
 
 ### Why is this bad?
 
@@ -21,7 +21,7 @@ A function with a single caller adds a name, a signature and a jump for the read
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 function price(uint256 amount) internal view returns (uint256) {
@@ -33,7 +33,7 @@ function scaled(uint256 amount) internal pure returns (uint256) {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
 function price(uint256 amount) internal view returns (uint256) {

--- a/src/pages/forge/linting/literal-instead-of-constant.mdx
+++ b/src/pages/forge/linting/literal-instead-of-constant.mdx
@@ -11,7 +11,7 @@ Flags literal values appearing more than once in the executable bodies of a cont
 
 ### What it does
 
-Reports every occurrence of a number, address or hex string literal whose value appears more than once in the bodies a contract declares: functions, constructors, modifiers, `receive` and `fallback`. Values are compared semantically, so `100`, `0x64` and `1e2` are one value, and `1 ether` equals `1e18`; Aderyn's detector of the same name compares the source spellings instead. Out of scope: `0`, `1` and `2` (structural values), bare literals indexing an array (positional), string and bool literals, single occurrences, and repetitions split across two contracts.
+Reports every occurrence of a number, address or hex string literal whose value appears more than once in the bodies a contract declares: functions, constructors, modifiers, `receive` and `fallback`. The modifier and base-constructor arguments of a function header are executable expressions too, so a value repeated between a header and a body counts as a repetition. Values are compared semantically, so `100`, `0x64` and `1e2` are one value, and `1 ether` equals `1e18`; Aderyn's detector of the same name compares the source spellings instead. Out of scope: `0`, `1` and `2` (structural values), bare literals indexing an array-like value, bounding a slice or giving a shift amount (positional or structural), fixed array sizes in parameter and return types (type annotations rather than executable expressions), string and bool literals, single occurrences, and repetitions split across two contracts. Mapping keys count, they are configuration data rather than positions, and so do Yul `case` labels, shifted literal values and literals inside a computed shift amount.
 
 ### Why is this bad?
 
@@ -19,7 +19,7 @@ A repeated literal is a configuration value the contract never named: each copy 
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 function deposit(uint256 amount) external {
@@ -32,7 +32,7 @@ function fee() public pure returns (uint256) {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
 uint256 private constant MIN_DEPOSIT = 500;

--- a/src/pages/forge/linting/locked-ether.mdx
+++ b/src/pages/forge/linting/locked-ether.mdx
@@ -8,29 +8,22 @@ description: Contract receives ETH but has no way to send it out
 **ID**: `locked-ether`
 
 Flags contracts that can receive Ether (via `payable` functions, `receive()`, or a payable
-`fallback()`) but expose no code path that can send Ether out. Any Ether sent to such a contract
-is permanently trapped.
+`fallback()`) but expose no code path that can send Ether out. Any Ether sent to such a contract is
+permanently trapped.
 
 ### What it does
 
-For every concrete or abstract contract, the lint:
+For each concrete or abstract contract that has a payable entry point (`receive()`, payable
+`fallback()`, payable constructor, or any payable function — directly or through inheritance),
+the lint looks for an expression that can move Ether out:
 
-1. Checks whether the contract — or any contract in its inheritance chain — has at least one
-   payable entry point (`receive()`, payable `fallback()`, payable constructor, or any payable
-   function).
-2. Walks every function defined in the contract and its linearized bases looking for a code path
-   that can move Ether out. The following are recognized as ETH-sending operations:
-   - `addr.transfer(amount)` and `addr.send(amount)` with a non-literal-zero amount.
-   - Any call carrying a non-zero `{value: x}` option, including
-     `addr.call{value: x}(...)` and `new C{value: x}(...)`.
-   - Low-level `addr.delegatecall(...)` / `addr.callcode(...)` (the callee runs in this contract's
-     context and can `selfdestruct`, draining the balance).
-   - The `selfdestruct(addr)` builtin.
-3. Internal and library calls whose callee statically resolves to a function are followed
-   transitively, so a withdrawal helper buried behind several internal hops is detected. External
-   calls through unresolved member access are not followed, to keep false positives down.
+- `addr.transfer(amount)` / `addr.send(amount)` with a non-zero amount.
+- A call carrying a non-zero `{value: x}` option, such as `addr.call{value: x}(...)` or
+  `new C{value: x}(...)`.
+- `addr.delegatecall(...)` / `addr.callcode(...)`.
+- `selfdestruct(addr)`.
 
-If no ETH-sending path is found, the lint reports the contract as locked at the contract's name.
+If none is found, the contract is reported as locked at the contract's name.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/low-level-calls.mdx
+++ b/src/pages/forge/linting/low-level-calls.mdx
@@ -4,7 +4,7 @@ description: Low-level calls
 
 ## Low-level calls
 
-**Severity**: `Med`
+**Severity**: `Info`
 **ID**: `low-level-calls`
 
 Flags direct use of Solidity low-level calls (`call`, `delegatecall`, and `staticcall`).

--- a/src/pages/forge/linting/mapping-deletion.mdx
+++ b/src/pages/forge/linting/mapping-deletion.mdx
@@ -11,20 +11,16 @@ Flags `delete` applied to a value whose type contains a `mapping`.
 
 ### What it does
 
-Reports `delete x` when `x` is a struct or array whose type holds a `mapping`,
-directly or through a nested struct or array. Deleting a whole mapping is not valid
-Solidity, but deleting a container of one compiles and silently leaves the mapping's
-entries in place.
-
-The lint also detects mapping values and array elements whose type contains a mapping.
-Deleting a single entry of a plain mapping is not flagged.
+Reports `delete x` when `x` is a struct or array whose type holds a `mapping`, directly or through a
+nested struct or array. Deleting a whole mapping is not valid Solidity, but deleting a container of
+one compiles and silently leaves the mapping's entries in place.
 
 ### Why is this bad?
 
-`delete` resets a storage value to its default by zeroing each member, but it cannot
-iterate a mapping's keys. The mapping's existing entries stay in storage, so the value
-is only partially cleared. This is a common source of accounting and access-control
-bugs: the struct looks reset while stale balances or flags remain reachable.
+`delete` resets a storage value to its default by zeroing each member, but it cannot iterate a
+mapping's keys. The mapping's existing entries stay in storage, so the value is only partially
+cleared. This is a common source of accounting and access-control bugs: the struct looks reset while
+stale balances or flags remain reachable.
 
 ### Example
 
@@ -54,8 +50,3 @@ function reset(uint256 id, address[] calldata holders) external {
     acc.total = 0;
 }
 ```
-
-### Recommendation
-
-Clear each known mapping entry explicitly, then reset the non-mapping fields. Keep an
-enumerable list of keys if the contract needs to fully clear mapping-backed state.

--- a/src/pages/forge/linting/missing-events-access-control.mdx
+++ b/src/pages/forge/linting/missing-events-access-control.mdx
@@ -2,7 +2,7 @@
 description: Missing events for access control changes
 ---
 
-## Missing events for access control changes
+## Missing events access control
 
 **Severity**: `Low`
 **ID**: `missing-events-access-control`
@@ -12,19 +12,18 @@ event.
 
 ### What it does
 
-Looks for mutable state variables that are:
+This lint looks for mutable state variables that are:
 
-1. read by an access-control check involving `msg.sender` or `tx.origin`;
-2. written by a public or external state-mutating function with access control;
-3. assigned from function input, sender data, access-control state, or indexed mapping keys,
-   directly or through local aliases or internal helpers; and
-4. changed without a related event that covers the updated access-control state.
+- read by an access-control check involving `msg.sender` or `tx.origin`,
+- written by a public or external state-mutating function with access control, and
+- assigned from function input, `msg.sender`, another access-control state variable, or a keyed
+  mapping write, directly or through local aliases/internal helpers, and
+- changed without a related event that includes the same value or key source.
 
-The lint intentionally skips constructors, unprotected setters, variables not used in authorization
-checks, and fixed writes that are not clearing access-control state used by the active guard. Events
-must be related to the updated state, so unrelated logging does not suppress the warning. These
-limits keep the rule focused on authority-bearing state and avoid noisy warnings for updates that
-are not clearly part of access control.
+It intentionally skips constructors, unprotected setters, variables not used in authorization
+checks, unrelated events, and fixed writes other than clearing the state variable currently used by
+the access guard. Those limits keep the rule focused on Slither's low-severity `events-access` case
+while avoiding common false positives.
 
 ### Why is this bad?
 
@@ -37,37 +36,19 @@ critical permission updates are harder to review and investigate.
 #### Bad
 
 ```solidity
-contract Owned {
-    address public owner = msg.sender;
-
-    modifier onlyOwner() {
-        require(msg.sender == owner, "not owner");
-        _;
-    }
-
-    function transferOwnership(address newOwner) external onlyOwner {
-        owner = newOwner;
-    }
+function transferOwnership(address newOwner) external onlyOwner {
+    owner = newOwner;
 }
 ```
 
 #### Good
 
 ```solidity
-contract Owned {
-    address public owner = msg.sender;
+event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
 
-    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
-
-    modifier onlyOwner() {
-        require(msg.sender == owner, "not owner");
-        _;
-    }
-
-    function transferOwnership(address newOwner) external onlyOwner {
-        address oldOwner = owner;
-        owner = newOwner;
-        emit OwnershipTransferred(oldOwner, newOwner);
-    }
+function transferOwnership(address newOwner) external onlyOwner {
+    address oldOwner = owner;
+    owner = newOwner;
+    emit OwnershipTransferred(oldOwner, newOwner);
 }
 ```

--- a/src/pages/forge/linting/missing-events-arithmetic.mdx
+++ b/src/pages/forge/linting/missing-events-arithmetic.mdx
@@ -2,32 +2,27 @@
 description: Missing events for arithmetic state changes
 ---
 
-## Missing events for arithmetic state changes
+## Missing events arithmetic
 
 **Severity**: `Low`
 **ID**: `missing-events-arithmetic`
 
-Flags protected entry-point functions that update dynamic integer state used in arithmetic by an
-unprotected function without emitting an event on the update path.
+Flags protected entry-point functions that update tainted integer state used in arithmetic by an
+unprotected function without emitting an event.
 
 ### What it does
 
-Looks for scalar `int` and `uint` state variables that are:
+This lint looks for scalar `int`/`uint` state variables that are:
 
-1. written by a public or external state-mutating function with access control;
-2. assigned from a dynamic value, directly or through local aliases or internal helpers, or changed
-   with an arithmetic assignment or increment/decrement;
-3. used in arithmetic by an unprotected public or external function; and
-4. changed along a path where the pending write is not followed by an event.
+- written by a public or external state-mutating function with access control,
+- assigned from function input, directly or through local aliases/internal helpers, or changed with
+  an arithmetic assignment or increment/decrement,
+- used in arithmetic by an unprotected public or external function, and
+- changed along a path that does not emit an event.
 
-Dynamic values include function inputs, mutable state variables, built-ins such as `block.timestamp`,
-and call results.
-
-The lint intentionally skips fixed-value writes, constructors, unprotected setters, mappings,
-arrays, and update paths where the write is followed by an event directly, through an internal
-helper, or after `_` in a modifier. These limits keep the rule focused on configuration-style
-arithmetic parameters and avoid noisy warnings for updates that are not clearly part of an
-externally visible calculation.
+It intentionally skips fixed-value writes, constructors, unprotected setters, mappings/arrays, and
+update paths that emit an event directly or through an internal helper. Those limits keep the rule
+focused on Slither's low-severity `events-maths` case while avoiding common false positives.
 
 ### Why is this bad?
 
@@ -40,46 +35,18 @@ parameter used in calculations, downstream behavior can change without an easy a
 #### Bad
 
 ```solidity
-contract Market {
-    address public owner = msg.sender;
-    uint256 public buyPrice;
-
-    modifier onlyOwner() {
-        require(msg.sender == owner, "not owner");
-        _;
-    }
-
-    function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
-        buyPrice = newBuyPrice;
-    }
-
-    function quote(uint256 amount) external view returns (uint256) {
-        return amount / buyPrice;
-    }
+function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+    buyPrice = newBuyPrice;
 }
 ```
 
 #### Good
 
 ```solidity
-contract Market {
-    address public owner = msg.sender;
-    uint256 public buyPrice;
+event BuyPriceUpdated(uint256 newBuyPrice);
 
-    event BuyPriceUpdated(uint256 newBuyPrice);
-
-    modifier onlyOwner() {
-        require(msg.sender == owner, "not owner");
-        _;
-    }
-
-    function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
-        buyPrice = newBuyPrice;
-        emit BuyPriceUpdated(newBuyPrice);
-    }
-
-    function quote(uint256 amount) external view returns (uint256) {
-        return amount / buyPrice;
-    }
+function setBuyPrice(uint256 newBuyPrice) external onlyOwner {
+    buyPrice = newBuyPrice;
+    emit BuyPriceUpdated(newBuyPrice);
 }
 ```

--- a/src/pages/forge/linting/missing-inheritance.mdx
+++ b/src/pages/forge/linting/missing-inheritance.mdx
@@ -2,27 +2,28 @@
 description: Missing inheritance from an implemented interface
 ---
 
-## Missing inheritance from an implemented interface
+## Missing inheritance
 
 **Severity**: `Info`
 **ID**: `missing-inheritance`
 
-Flags contracts that implement every external function of an interface but do not explicitly
-inherit from it.
+A contract that implements every external function of an interface but does not explicitly inherit
+from it loses compile-time checks (the `override` keyword, signature/return-type validation, and
+`type(I).interfaceId` recognition) and obscures intent for readers and tooling.
 
 ### What it does
 
-For each non-interface contract `C` in the analyzed sources, reports each interface `I` where:
+For each non-interface contract `C` in the analyzed sources, this lint reports each interface `I`
+where:
 
-- `C` does not transitively inherit from `I`,
+- `C` does **not** transitively inherit from `I`,
 - `C` (including its inherited bases) implements every external selector exported by `I`, and
 - no already-inherited base of `C` already covers all of `I`'s selectors.
 
-Candidate interfaces include both user-defined interfaces and those declared in dependencies
-(e.g. OpenZeppelin's `IERC20`). When several candidates overlap (e.g. `IERC20` and
-`IERC20Metadata`), only the maximal one is reported. Signature-only abstract contracts — those
-with no state, no constructor, no modifier bodies, and no function bodies — are also treated as
-candidate interfaces.
+When several candidate interfaces overlap (e.g. `IERC20` and `IERC20Metadata`), only the maximal
+one is reported. "Interface-like" abstract contracts — those with no state, no constructor, no
+modifier bodies, and no function bodies — are also treated as candidate interfaces, mirroring the
+behavior of Slither's `missing-inheritance` detector.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/mixed-case-function.mdx
+++ b/src/pages/forge/linting/mixed-case-function.mdx
@@ -11,9 +11,11 @@ Flags function names that do not follow `mixedCase`.
 
 ### What it does
 
-Reports functions whose names contain underscores, start with an uppercase letter, or otherwise
-deviate from `mixedCase`. Test functions starting with `test`, `invariant_`, or `statefulFuzz`
-and user-defined patterns (e.g. `ERC20`) are exempted.
+Reports functions whose names contain embedded underscores, start with an uppercase letter, or
+otherwise deviate from `mixedCase`. Leading and trailing underscores are preserved, and
+single-character names are not checked. Test functions starting with `test`, `invariant_`, or
+`statefulFuzz`, configured uppercase patterns (for example, `ERC20`), and external constant-style
+getters are exempted.
 
 ### Why is this bad?
 
@@ -33,4 +35,15 @@ function GetBalance()  external view returns (uint256);
 
 ```solidity
 function getBalance() external view returns (uint256);
+```
+
+### Configuration
+
+Set `mixed_case_exceptions` under `[lint.lint_specific]` in `foundry.toml` to replace the default
+list of allowed uppercase patterns (`ERC`, `URI`, `ID`, `URL`, `API`, `JSON`, `XML`, `HTML`, `HTTP`,
+and `HTTPS`):
+
+```toml
+[lint.lint_specific]
+mixed_case_exceptions = ["ERC", "URI", "NFT"]
 ```

--- a/src/pages/forge/linting/mixed-case-variable.mdx
+++ b/src/pages/forge/linting/mixed-case-variable.mdx
@@ -11,8 +11,9 @@ Flags mutable variable names (locals, parameters, mutable state) that do not fol
 
 ### What it does
 
-Reports mutable variable identifiers that contain underscores, start with an uppercase letter,
-or otherwise deviate from `mixedCase`.
+Reports mutable variable identifiers that contain embedded underscores, start with an uppercase
+letter, or otherwise deviate from `mixedCase`. Leading and trailing underscores are preserved, and
+single-character names are not checked.
 
 `constant` and `immutable` state variables are not flagged by this lint — see
 [`screaming-snake-case-const`](https://getfoundry.sh/forge/linting/screaming-snake-case-const) and
@@ -37,4 +38,15 @@ address Owner;
 ```solidity
 uint256 public totalSupply;
 address owner;
+```
+
+### Configuration
+
+Set `mixed_case_exceptions` under `[lint.lint_specific]` in `foundry.toml` to replace the default
+list of allowed uppercase patterns (`ERC`, `URI`, `ID`, `URL`, `API`, `JSON`, `XML`, `HTML`, `HTTP`,
+and `HTTPS`):
+
+```toml
+[lint.lint_specific]
+mixed_case_exceptions = ["ERC", "URI", "NFT"]
 ```

--- a/src/pages/forge/linting/modifier-used-only-once.mdx
+++ b/src/pages/forge/linting/modifier-used-only-once.mdx
@@ -21,7 +21,7 @@ A modifier with a single user adds indirection without factoring anything: the r
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 modifier onlyOwner() {
@@ -34,7 +34,7 @@ function withdraw() external onlyOwner {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
 function withdraw() external {

--- a/src/pages/forge/linting/msg-value-loop.mdx
+++ b/src/pages/forge/linting/msg-value-loop.mdx
@@ -2,7 +2,7 @@
 description: msg.value inside loops
 ---
 
-## msg.value inside loops
+## Msg value inside loop
 
 **Severity**: `Low`
 **ID**: `msg-value-loop`
@@ -11,17 +11,17 @@ Flags `msg.value` reads inside loops reachable from externally callable payable 
 
 ### What it does
 
-Reports `msg.value` expressions that execute inside a `for`, `while`, or `do-while` loop reachable
-from a `public payable` or `external payable` entry point. This includes loops introduced by
-modifiers and reads inside helpers transitively called from the entry point.
+Reports `msg.value` expressions that execute inside a `for`, `while`, or `do while` loop
+reachable from a `public payable` or `external payable` entry point. This includes loops
+introduced by modifiers and reads inside helpers transitively called from the entry point.
 
 Payable constructors are ignored. `receive()` and `fallback()` functions are checked when they are
 payable.
 
 ### Why is this bad?
 
-`msg.value` is fixed for the whole transaction. Reading it inside a loop can accidentally treat the
-same Ether payment as if it were supplied once per iteration.
+`msg.value` is fixed for the whole transaction. Reading it inside a loop can accidentally treat
+the same Ether payment as if it were supplied once per iteration.
 
 This can lead to incorrect accounting, repeated credits, or fund loss when loop iterations send,
 record, or otherwise consume value based on `msg.value`.
@@ -49,7 +49,7 @@ function batch(address[] calldata receivers) external payable {
 }
 ```
 
-### Recommendation
+### Notes
 
 Review each occurrence manually. Prefer computing the intended per-iteration amount before the
 loop, then use that derived value inside the loop.

--- a/src/pages/forge/linting/multi-contract-file.mdx
+++ b/src/pages/forge/linting/multi-contract-file.mdx
@@ -39,3 +39,14 @@ contract TokenA { /* ... */ }
 // File: TokenB.sol
 contract TokenB { /* ... */ }
 ```
+
+### Configuration
+
+Set `multi_contract_file_exceptions` under `[lint.lint_specific]` in `foundry.toml` to allow
+multiple interfaces, libraries, or abstract contracts in one file. Regular contracts cannot be
+exempted.
+
+```toml
+[lint.lint_specific]
+multi_contract_file_exceptions = ["interface", "library", "abstract_contract"]
+```

--- a/src/pages/forge/linting/non-reentrant-not-first.mdx
+++ b/src/pages/forge/linting/non-reentrant-not-first.mdx
@@ -2,28 +2,28 @@
 description: nonReentrant modifier is not first
 ---
 
-## nonReentrant modifier is not first
+## Non-reentrant modifier not first
 
 **Severity**: `Med`
 **ID**: `non-reentrant-not-first`
 
-Flags functions where an OpenZeppelin-style `nonReentrant` modifier is present but is not the
-first modifier in the modifier list.
+Flags functions where an OpenZeppelin-style `nonReentrant` modifier is present but is not the first
+modifier in the modifier list.
 
 ### What it does
 
-Reports a function, fallback, or receive function when a modifier named `nonReentrant` appears
-after another modifier.
+Reports a function, fallback, or receive function when `nonReentrant` appears after another
+modifier, for example `onlyOwner nonReentrant`.
 
-The lint is intentionally narrow: it checks modifier ordering only and only matches a modifier
-named `nonReentrant`.
+The lint is intentionally narrow: it only checks modifier ordering and only matches a modifier named
+`nonReentrant`.
 
 ### Why is this bad?
 
 Solidity applies modifiers in the order they are written. If another modifier runs before
-`nonReentrant`, that modifier's pre-body logic executes before the reentrancy guard is entered.
-For guarded external entry points, placing `nonReentrant` first keeps the reentrancy lock as the
-first modifier logic.
+`nonReentrant`, that modifier's pre-body logic executes before the reentrancy guard is entered. For
+guarded external entry points, placing `nonReentrant` first keeps the reentrancy lock as the first
+piece of modifier logic.
 
 ### Example
 

--- a/src/pages/forge/linting/pascal-case-struct.mdx
+++ b/src/pages/forge/linting/pascal-case-struct.mdx
@@ -11,7 +11,8 @@ Flags struct definitions whose names do not follow `PascalCase`.
 
 ### What it does
 
-Reports any `struct` whose identifier does not match the `PascalCase` convention.
+Reports `struct` identifiers longer than one character that do not match the `PascalCase`
+convention. Single-character names are not checked.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/pragma-inconsistent.mdx
+++ b/src/pages/forge/linting/pragma-inconsistent.mdx
@@ -12,9 +12,9 @@ pragmas.
 
 ### What it does
 
-Inspects every `pragma solidity ...;` directive across all input source files and reports when
+Inspects every `pragma solidity ...;` directive across all input source files and reports once when
 their version requirements are inconsistent (different exact versions, mixed caret/tilde/range
-shapes, etc.).
+shapes, etc.). The diagnostic lists the distinct requirements seen in the project.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/redundant-base-constructor-call.mdx
+++ b/src/pages/forge/linting/redundant-base-constructor-call.mdx
@@ -30,8 +30,8 @@ constructor, the parentheses are redundant noise that obscure the real inheritan
 contract A {}
 contract B { constructor() {} }
 
-contract C is A() {}                        // A has no constructor
-contract D is B { constructor() B() {} }    // B's constructor takes no arguments
+contract C is A() {}                 // A has no constructor
+contract D is B { constructor() B() {} } // B's constructor takes no arguments
 ```
 
 #### Good
@@ -41,5 +41,5 @@ contract A {}
 contract B { constructor() {} }
 
 contract C is A {}
-contract D is B {}
+contract D is B { constructor() {} }
 ```

--- a/src/pages/forge/linting/reentrancy-events.mdx
+++ b/src/pages/forge/linting/reentrancy-events.mdx
@@ -2,42 +2,35 @@
 description: Events emitted after external calls
 ---
 
-## Events emitted after external calls
+## Reentrancy Events
 
 **Severity**: `Low`
 **ID**: `reentrancy-events`
 
-Flags `emit` statements that are reachable after an external call within the same function (or any
-internal helper or modifier it transitively calls).
+Flags `emit` statements that appear after an external call within the same function (or any internal helper it transitively calls). Emitting state-change events only after the external call returns can mislead off-chain consumers — including indexers, subgraphs, monitoring tools, and bridges — that rely on log ordering to reconstruct contract state.
 
 ### What it does
 
-For every function body, this lint runs a control-flow analysis that tracks whether an external
-call has occurred on the path leading to each statement. External calls include:
+For every function body, the lint performs a control-flow analysis that tracks whether an external call has occurred on the path leading to each statement. Only calls that can plausibly affect log ordering or observable state are considered — `staticcall` and high-level `view` / `pure` external calls are excluded. Tracked calls include:
 
-- Low-level calls: `address.call(...)`, `delegatecall(...)`, `staticcall(...)` (with or without
-  `{value: ...}` / `{gas: ...}` options).
+- Low-level calls: `address.call(...)` and `address.delegatecall(...)` (with or without `{value: ...}` / `{gas: ...}` options).
 - ETH sends: `address.transfer(...)`, `address.send(...)`.
 - `this.method(...)` self-external calls.
-- High-level external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`).
-- `new Foo(...)` deployments, which execute the deployed contract's constructor.
+- High-level state-mutating external calls on interface or contract types (e.g. `IERC20(token).transfer(...)`). `view` and `pure` callees are not tracked.
+- Contract deployments via `new Foo(...)` (the constructor runs as an external interaction).
 
-External calls reached through internal/private/public helper functions and modifiers are also
-followed transitively. When the analyzer reaches an `emit` statement on a path that already
-executed an external call, the statement is flagged.
+External calls reached through internal/private/public helper functions, modifiers, and `super.f(...)` base-chain dispatch are tracked transitively when the helper is invoked by a bare identifier (e.g. `_helper()`) or via `super.`. Member-form internal dispatch such as `Lib.f(...)` and `using for` syntax is **not** yet followed; external calls hidden behind those forms may go undetected.
+
+When the analysis encounters an `emit` statement reachable from a path that already executed a tracked external call, the statement is flagged.
 
 ### Why is this bad?
 
 Reentrancy and off-chain ordering both depend on event sequence:
 
-- A reentrant callee can observe — or trigger another contract to observe — events in an order
-  that no longer reflects the final state of the calling contract.
-- Indexers, subgraphs, bridges, and monitoring tools that consume logs in emission order may
-  apply state transitions incorrectly when events are not emitted alongside the writes they
-  describe.
+- A reentrant callee can observe (or trigger another contract to observe) events in an order that no longer reflects the final state of the calling contract.
+- Indexers, bridges, and monitoring tools that consume logs in emission order may apply state transitions incorrectly when events are not emitted alongside the writes they describe.
 
-Emitting the event **before** the external call anchors the log to the local state change,
-regardless of what the callee does.
+Emitting the event **before** the external call ensures the log is anchored to the local state change, regardless of what the callee does.
 
 ### Example
 
@@ -70,9 +63,3 @@ contract GoodCounter {
     }
 }
 ```
-
-### Recommendation
-
-Apply the [Checks-Effects-Interactions](https://docs.soliditylang.org/en/latest/security-considerations.html#use-the-checks-effects-interactions-pattern)
-pattern: perform validation, update state and emit events first, and only then call into external
-contracts.

--- a/src/pages/forge/linting/reentrancy-no-eth.mdx
+++ b/src/pages/forge/linting/reentrancy-no-eth.mdx
@@ -4,7 +4,7 @@ description: No-ETH read-before-write reentrancy
 
 ## No-ETH read-before-write reentrancy
 
-**Severity**: `Medium`
+**Severity**: `Med`
 **ID**: `reentrancy-no-eth`
 
 Flags external calls that do not transfer ETH when state read before the call is written after the

--- a/src/pages/forge/linting/require-revert-in-loop.mdx
+++ b/src/pages/forge/linting/require-revert-in-loop.mdx
@@ -2,50 +2,34 @@
 description: require or revert inside loops
 ---
 
-## Require or revert inside loops
+## Require or revert inside a loop
 
 **Severity**: `Low`
 **ID**: `require-revert-in-loop`
 
-Flags `require` calls and `revert` statements that execute inside loops.
+Flags `require` calls and `revert` statements inside loops because one invalid item can abort the
+entire batch.
 
 ### What it does
 
-Reports `require` and `revert` operations reachable from a `for`, `while`, or `do-while` loop. This
-includes checks in loop bodies, loop conditions, loop update expressions, modifier placeholders,
-internal helpers, internal library extension calls, and inline assembly `revert` instructions.
-
-Calls through an external interface are not followed; this lint reports the `require` or `revert`
-operation itself when Foundry can see that it executes as part of the loop.
+Reports Solidity `require`/`revert`, revert statements, and Yul `revert` inside loops. The analysis
+also follows modifiers and internal helper calls reached from a loop.
 
 ### Why is this bad?
 
-A single invalid item can revert the entire loop. In batched operations, that can make one bad
-entry deny service to every later entry and force users to retry the whole batch.
-
-This is especially risky when invalid items are expected or caller-controlled, because a caller can
-make the batch unusable by including one value that fails validation.
+A single invalid item can revert the entire loop, which can make batched operations unusable when
+one element fails validation.
 
 ### Example
 
 #### Bad
 
 ```solidity
-error BadItem(uint256 index);
-
 contract Batch {
     function process(uint256[] calldata values) external {
         for (uint256 i; i < values.length; ++i) {
-            if (values[i] == 0) {
-                revert BadItem(i);
-            }
-
-            _process(values[i]);
+            require(values[i] != 0, "zero");
         }
-    }
-
-    function _process(uint256 value) internal {
-        // ...
     }
 }
 ```
@@ -53,29 +37,12 @@ contract Batch {
 #### Good
 
 ```solidity
-event SkippedZero(uint256 index);
-
 contract Batch {
     function process(uint256[] calldata values) external {
         for (uint256 i; i < values.length; ++i) {
-            if (values[i] == 0) {
-                emit SkippedZero(i);
-                continue;
-            }
-
-            _process(values[i]);
+            if (values[i] == 0) continue;
+            // Process valid entries.
         }
-    }
-
-    function _process(uint256 value) internal {
-        // ...
     }
 }
 ```
-
-### Recommendation
-
-Prefer batch designs where one invalid item does not revert the whole loop: skip invalid entries
-explicitly, record per-item failures, or split the work into separate transactions. When every item
-must be valid, validate batch-level invariants before the loop and consider exposing a per-item
-entry point so callers can isolate failures.

--- a/src/pages/forge/linting/return-bomb.mdx
+++ b/src/pages/forge/linting/return-bomb.mdx
@@ -13,7 +13,6 @@ Flags external calls that set an explicit gas limit while copying unbounded dyna
 
 Detects low-level `call`, `delegatecall`, and `staticcall` expressions that specify `{gas: ...}`.
 Solidity copies the full returndata for these calls even when the second tuple element is ignored.
-
 It also detects high-level external calls with `{gas: ...}` that consume dynamically encoded return
 values such as `bytes`, `string`, dynamic arrays, or structs containing dynamic fields.
 
@@ -46,7 +45,5 @@ function callTarget(address target, bytes memory payload, uint256 gasLimit) exte
 }
 ```
 
-### Notes
-
-Ignoring the second tuple element does not avoid the returndata copy. If the returndata is needed,
-copy only a bounded number of bytes with a helper that caps returndata size.
+Ignoring the second tuple element does not avoid the copy. If the returndata is needed, copy only a
+bounded number of bytes with a helper that caps returndata size.

--- a/src/pages/forge/linting/screaming-snake-case-const.mdx
+++ b/src/pages/forge/linting/screaming-snake-case-const.mdx
@@ -11,7 +11,8 @@ Flags `constant` state variables whose names do not follow `SCREAMING_SNAKE_CASE
 
 ### What it does
 
-Reports state variables declared `constant` whose identifier deviates from `SCREAMING_SNAKE_CASE`.
+Reports state variables declared `constant` whose identifier is longer than one character and
+deviates from `SCREAMING_SNAKE_CASE`. Leading and trailing underscores are preserved.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/screaming-snake-case-immutable.mdx
+++ b/src/pages/forge/linting/screaming-snake-case-immutable.mdx
@@ -12,7 +12,8 @@ Flags `immutable` state variables whose names do not follow `SCREAMING_SNAKE_CAS
 ### What it does
 
 Reports state variables declared `immutable` whose identifier deviates from
-`SCREAMING_SNAKE_CASE`.
+`SCREAMING_SNAKE_CASE`. Single-character names are not checked, and leading and trailing
+underscores are preserved.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/solmate-safe-transfer-lib.mdx
+++ b/src/pages/forge/linting/solmate-safe-transfer-lib.mdx
@@ -11,9 +11,9 @@ Flags token operations of solmate's `SafeTransferLib`, which does not check that
 
 ### What it does
 
-Reports a reference, called or used as a value, that resolves to `safeTransfer`, `safeTransferFrom` or `safeApprove` declared in a library named exactly `SafeTransferLib`. Resolution goes through the type checker, so the `using for` method form, the library-qualified form and import aliases are all recognized, while same-name functions declared in other libraries (Uniswap's `TransferHelper` style) stay out of scope. `safeTransferETH` involves no token code and stays clean.
+Reports a reference, called or used as a value, that resolves to `safeTransfer`, `safeTransferFrom` or `safeApprove` declared in a library named exactly `SafeTransferLib` whose source comes from a solmate package path (`lib/solmate`, `solmate/...`). Resolution goes through the type checker, so the `using for` method form, the library-qualified form and import aliases are all recognized, while same-name functions declared in other libraries (Uniswap's `TransferHelper` style) and same-name libraries from other packages (Solady's `SafeTransferLib` checks token code on the empty-return path) stay out of scope. `safeTransferETH` involves no token code and stays clean. A vendored solmate copy under a path that does not name solmate is not recognized.
 
-Aderyn's detector of the same name flags the import directive whose path contains `solmate` and `SafeTransferLib`; resolving the calls instead anchors the warning where the risk sits, skips files that import the library without using it, and keeps vendored or re-exported copies covered.
+Aderyn's detector of the same name flags the import directive whose path contains `solmate` and `SafeTransferLib`; resolving the calls instead anchors the warning where the risk sits and skips files that import the library without using it.
 
 ### Why is this bad?
 
@@ -21,7 +21,7 @@ In the released solmate v6, a token call that returns no data is treated as a su
 
 ### Example
 
-### Bad
+#### Bad
 
 ```solidity
 using SafeTransferLib for ERC20;
@@ -31,13 +31,22 @@ function pay(ERC20 token, address to, uint256 amount) internal {
 }
 ```
 
-### Good
+#### Good
 
 ```solidity
-using SafeTransferLib for ERC20;
+using SafeERC20 for IERC20;
 
-function pay(ERC20 token, address to, uint256 amount) internal {
-    require(address(token).code.length > 0, "token has no code");
+function pay(IERC20 token, address to, uint256 amount) internal {
     token.safeTransfer(to, amount);
 }
+```
+
+The lint flags every resolved solmate reference and does not recognize a manual code check
+before the call. A call guarded by `require(address(token).code.length > 0, ...)` mitigates
+the pitfall but still reports; suppress it explicitly:
+
+```solidity
+require(address(token).code.length > 0, "token has no code");
+// forge-lint: disable-next-line(solmate-safe-transfer-lib)
+token.safeTransfer(to, amount);
 ```

--- a/src/pages/forge/linting/tautological-compare.mdx
+++ b/src/pages/forge/linting/tautological-compare.mdx
@@ -11,18 +11,11 @@ Flags a relational or equality comparison whose two sides are the same expressio
 
 ### What it does
 
-Reports `a <op> a` where `a` is a side-effect-free expression and `<op>` is `<`,
-`<=`, `>`, `>=`, `==`, or `!=`. Supported expressions include identifiers, member
-access, and indexing by the same index.
-
-Comparisons whose sides could legitimately differ, such as repeated function calls,
-are left untouched.
+Reports `a <op> a` where `a` is a side-effect-free expression (an identifier, member access, or indexing) and `<op>` is `<`, `<=`, `>`, `>=`, `==`, or `!=`. Such a comparison has a constant result. Comparisons whose sides could legitimately differ (for example involving a function call) are left untouched, as are comparisons on user-defined value types, whose operators are user-defined (`using {f as ==} for T`) and need not be constant.
 
 ### Why is this bad?
 
-`x >= x` is always true and `x < x` is always false, regardless of `x`. It is almost
-always a typo for a comparison against a different operand, or leftover dead code that
-hides a real condition.
+`x >= x` is always true and `x < x` is always false, regardless of `x`. It is almost always a typo for a comparison against a different operand, or leftover dead code that hides a real condition.
 
 ### Example
 
@@ -43,8 +36,3 @@ if (a[i] < a[j]) {
     // ...
 }
 ```
-
-### Recommendation
-
-Compare against the intended distinct operand, or remove the condition if the constant
-result is deliberate and the branch is no longer needed.

--- a/src/pages/forge/linting/too-many-digits.mdx
+++ b/src/pages/forge/linting/too-many-digits.mdx
@@ -11,7 +11,10 @@ Flags numeric literals containing five or more consecutive zeros, which are easy
 
 ### What it does
 
-Reports decimal numeric literals that contain a run of 5 or more `0` characters.
+Reports Solidity and Yul numeric literals that contain a run of 5 or more `0` characters. Decimal
+literals with scientific notation, literals with a sub-denomination, and 40-digit hexadecimal
+address literals are skipped. Other hexadecimal literals remain in scope because long padded masks
+and bit patterns are also difficult to review.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/uninitialized-local.mdx
+++ b/src/pages/forge/linting/uninitialized-local.mdx
@@ -7,43 +7,34 @@ description: Uninitialized local variable
 **Severity**: `Med`
 **ID**: `uninitialized-local`
 
-Flags local variables that are declared without an initializer and then read before any explicit
-assignment. In Solidity, uninitialized value-type locals silently default to zero (`address` →
-`address(0)`, `uint` → `0`, `bool` → `false`), so this is almost always a logic bug rather than
-intentional behavior.
+Flags local variables that are declared without an initializer and then read before any assignment. In Solidity, uninitialized value-type locals silently default to zero (`address` -> `address(0)`, `uint` -> `0`, `bool` -> `false`), so this is almost always a logic bug rather than intentional behavior.
 
 ### What it does
 
-Reports local variables declared with a bare `Type name;` statement (no initializer) when they are
-read — directly or inside a sub-expression — before the first explicit write on at least one
-execution path. Writes in only one branch of an `if`/`else` do not count as a guaranteed
-initialization.
-
-State variables and function parameters are never reported.
+Reports any local variable of `VarKind::Statement` (i.e., a variable declared inside a function body, not a parameter or state variable) whose first use is a read and which has never been explicitly assigned prior to that read on at least one execution path.
 
 ### Why is this bad?
 
-Reading an uninitialized variable means the code silently depends on a language-level zero-default
-rather than a value chosen by the developer. Common consequences include:
+Reading an uninitialized variable means the code silently depends on a language-level zero-default rather than an explicit value chosen by the developer. Common consequences include:
 
-- Sending ETH to `address(0)` and burning it permanently.
+- Sending ETH to `address(0)` and burning it permanently (`address payable to; to.transfer(...)`).
 - Arithmetic operating on an implicit `0` that bypasses guards or produces unexpected results.
 - Returning a meaningless zero from a function whose caller assumes a real value.
 
-The Solidity compiler does not warn about this; only static analysis can catch it.
+The Solidity compiler does not warn about this; only static analysis catches it.
 
 ### Example
 
 #### Bad
 
 ```solidity
-// `to` is never assigned — defaults to address(0), burning all ETH.
+// `to` is never assigned, defaults to address(0), burning all ETH.
 function withdraw() public {
     address payable to;
     to.transfer(address(this).balance);
 }
 
-// `amount` is never assigned — silently returns 0.
+// `amount` is never assigned, silently returns 0.
 function getAmount() public pure returns (uint256) {
     uint256 amount;
     return amount;

--- a/src/pages/forge/linting/uninitialized-state.mdx
+++ b/src/pages/forge/linting/uninitialized-state.mdx
@@ -2,7 +2,7 @@
 description: Uninitialized state variable
 ---
 
-## Uninitialized state variable
+## Uninitialized State Variables
 
 **Severity**: `Med`
 **ID**: `uninitialized-state`

--- a/src/pages/forge/linting/unprotected-initializer.mdx
+++ b/src/pages/forge/linting/unprotected-initializer.mdx
@@ -2,35 +2,30 @@
 description: Unprotected upgradeable initializer
 ---
 
-## Unprotected upgradeable initializer
+## Unprotected initializer
 
 **Severity**: `High`
 **ID**: `unprotected-initializer`
 
-Flags upgradeable contracts whose public or external initializer can still be called directly on
-an implementation contract that exposes a destructive entry point.
+Flags upgradeable contracts whose public or external initializer can still be called directly on an
+implementation contract that exposes a destructive entry point.
 
 ### What it does
 
-Warns on public or external functions that:
+Reports initializer-like functions that:
 
-1. are marked with an `initializer` or `reinitializer` modifier;
-2. write state directly or through an internal helper;
-3. belong to an implementation whose constructor does not call an inherited `_disableInitializers()`; and
-4. are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
-   that is not restricted to proxy calls with `onlyProxy`.
-
-The `onlyProxy` exemption is a name-based heuristic for common UUPS implementations.
+- are public or external;
+- are marked with `initializer` or `reinitializer`;
+- write state directly or through an internal helper; and
+- are in an implementation whose constructor does not call an inherited `_disableInitializers()`; and
+- are in a contract with a public or external `delegatecall`, `callcode`, or `selfdestruct` path
+  that is not restricted to proxy calls with `onlyProxy`.
 
 ### Why is this bad?
 
-Upgradeable implementation contracts are deployed as ordinary contracts. If their initializer is
-left callable on the implementation itself, anyone can initialize implementation storage. When the
-same implementation also exposes a destructive path such as `delegatecall` or `selfdestruct`, an
-attacker may be able to take ownership of the implementation context and destroy or replace it.
-
-Lock the implementation during deployment, for example by calling OpenZeppelin's
-`_disableInitializers()` in the constructor.
+An attacker can initialize the implementation directly, take ownership, and invoke its destructive
+entry point. Destroying or corrupting an implementation can disable every proxy that delegates to
+it.
 
 ### Example
 
@@ -64,10 +59,13 @@ contract Vault is Initializable {
     function initialize(address owner_) public initializer {
         owner = owner_;
     }
-
-    function execute(address target, bytes calldata data) external {
-        (bool ok,) = target.delegatecall(data);
-        require(ok);
-    }
 }
 ```
+
+### Notes
+
+The lint is intentionally local: it does not inspect deployment scripts to prove whether a proxy is
+initialized atomically. It focuses on implementation contracts that remain directly initializable
+and can reach code paths that may destroy or replace implementation state.
+
+The `onlyProxy` exemption is a name-based heuristic for common UUPS implementations.

--- a/src/pages/forge/linting/unsafe-typecast.mdx
+++ b/src/pages/forge/linting/unsafe-typecast.mdx
@@ -11,9 +11,10 @@ Flags explicit numeric typecasts that can silently truncate or alter the value.
 
 ### What it does
 
-Reports casts where the source value's type is wider than the target type
-(e.g. `uint256 → uint128`, `int256 → uint128`), unless the cast is preceded by a check that
-guarantees the value fits in the target.
+Reports casts where the source value's type can exceed the target type (for example,
+`uint256 → uint128` or `int256 → uint128`). An unsigned value masked to the target width, such
+as `uint8(value & 0xff)`, is recognized as bounded and is not flagged. The lint does not perform
+control-flow analysis of preceding range checks.
 
 ### Why is this bad?
 
@@ -35,10 +36,9 @@ function setAmount(uint256 amount) external {
 
 ```solidity
 function setAmount(uint256 amount) external {
-    require(amount <= type(uint128).max, "overflow");
-    smallAmount = uint128(amount);
+    smallAmount = SafeCast.toUint128(amount);
 }
 
-// or
-smallAmount = SafeCast.toUint128(amount);
+// A mask that bounds the value to the target width is also recognized.
+smallByte = uint8(amount & 0xff);
 ```

--- a/src/pages/forge/linting/unused-error.mdx
+++ b/src/pages/forge/linting/unused-error.mdx
@@ -11,9 +11,14 @@ Flags a custom error declaration that is never referenced anywhere in the compil
 
 ### What it does
 
-Reports each `error` declaration whose symbol is never referenced. Any resolved reference counts as a use: a `revert Err(...)` statement (including the qualified `revert Lib.Err(...)`), `require(cond, Err(...))` (Solidity 0.8.26+), and `Err.selector` (including through `abi.encodeWithSelector`). Uses are collected across the whole compilation unit, so an error declared in a shared file and reverted elsewhere in the project is not reported.
+Reports each `error` declaration whose symbol is never referenced. Any resolved reference counts
+as a use: a `revert Err(...)` statement (including the qualified `revert Lib.Err(...)`),
+`require(cond, Err(...))` (Solidity 0.8.26+), and `Err.selector` (including through
+`abi.encodeWithSelector`). Uses are collected across the whole compilation unit,
+so an error declared in a shared file and reverted elsewhere in the project is not reported.
 
-Errors declared in interfaces and abstract contracts are not reported: they are ABI surface meant for implementers and off-chain consumers, which may live outside the compiled sources.
+Errors declared in interfaces and abstract contracts are not reported: they are ABI surface
+meant for implementers and off-chain consumers, which may live outside the compiled sources.
 
 ### Why is this bad?
 
@@ -39,4 +44,5 @@ function withdraw() external {
 
 ### Limitations
 
-A selector hardcoded in inline assembly or built with `abi.encodeWithSignature("Err(...)")` does not reference the declaration and is not seen as a use.
+A selector hardcoded in inline assembly or built with `abi.encodeWithSignature("Err(...)")` does
+not reference the declaration and is not seen as a use.

--- a/src/pages/forge/linting/unused-return.mdx
+++ b/src/pages/forge/linting/unused-return.mdx
@@ -7,29 +7,21 @@ description: Unused return value from an external call
 **Severity**: `Med`
 **ID**: `unused-return`
 
-Flags external calls whose return value is silently discarded.
+Flags external calls whose return value is discarded, which often indicates a logic bug where the
+result of a computation or state query is silently ignored.
 
 ### What it does
 
-Reports member calls on contract-typed variables or explicit interface casts (e.g.
-`IOracle(addr).f()`) that are invoked as standalone expression statements when the callee function
-declares one or more return values. ERC20 `transfer` and `transferFrom` are excluded — they are
-covered by the separate [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) lint.
-
-To avoid false positives from overloading, the lint only fires when **all** same-name / same-arity
-candidates in the target contract return a value. If any overload with the same arity returns
-nothing, the call is skipped conservatively.
+Detects high-level external calls (member calls on contract-typed variables or interface-cast
+addresses) that return one or more values when the entire result is discarded or any slot of a
+tuple return is omitted. ERC20 `transfer` and `transferFrom` are excluded as they are handled by
+the separate `erc20-unchecked-transfer` lint.
 
 ### Why is this bad?
 
-Dropping a return value usually means one of:
-
-- **Ignored error signal** — the callee returns a success flag or error code that the caller
-  never checks, silently continuing through failure.
-- **Discarded computation** — the result of a query (e.g. a price oracle, a balance check) is
-  thrown away, making the call a no-op from the caller's perspective.
-
-Both cases are common sources of logic bugs and security vulnerabilities.
+Discarding a return value can mask failures and incorrect assumptions. For example, ignoring the
+result of an oracle query or a state-mutating helper means the caller proceeds as if the call
+succeeded or that the value is irrelevant, both of which may be bugs.
 
 ### Example
 
@@ -65,9 +57,3 @@ contract Example {
     }
 }
 ```
-
-### Notes
-
-This lint operates on candidate matching rather than exact call resolution: it inspects the
-declared functions on the statically-known contract type. Calls through plain `address` variables,
-`this.f()`, or complex receiver expressions (e.g. `mapping[key].f()`) are not covered.

--- a/src/pages/forge/linting/unwrapped-modifier-logic.mdx
+++ b/src/pages/forge/linting/unwrapped-modifier-logic.mdx
@@ -13,8 +13,12 @@ to reduce contract code size.
 ### What it does
 
 Reports modifiers whose body contains statements other than a single placeholder, simple builtin
-calls (`require`/`assert`), or a single library function call. Modifiers that use inline assembly
-are exempted.
+calls (`require`/`assert`), or a single library function call. Logic on either side of the
+placeholder is considered independently; a side containing inline assembly is not extracted, but
+complex logic on the other side can still be flagged.
+
+The lint only emits a machine-applicable rewrite when the modifier has exactly one top-level
+placeholder and extracting the logic preserves local-variable and parameter behavior.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/var-read-using-this.mdx
+++ b/src/pages/forge/linting/var-read-using-this.mdx
@@ -13,15 +13,15 @@ address, paying the call overhead for data that could be read directly.
 
 ### What it does
 
-Reports `this.<name>(<args>)` calls where `<name>` resolves (via overload resolution by arity)
-to a function reachable on the contract's external interface (`public` or `external`) whose
-state mutability is `view` or `pure`. This includes:
+Reports `this.<name>(<args>)` calls where `<name>` resolves (via overload resolution by arity) to
+a function reachable on the contract's external interface (`public` or `external`) whose state
+mutability is `view` or `pure`. This includes:
 
 - The auto-generated getter for any `public` state variable (simple variables, mappings, arrays).
 - Any inherited `public`/`external` `view`/`pure` function declared in a base contract.
 
-When the offending call is the auto-generated getter for a state variable, the lint emits a
-code fix:
+When the offending call is the auto-generated getter for a state variable, the lint emits a code
+fix:
 
 - Simple state variable: `this.foo()` → `foo` (machine-applicable).
 - Mapping/array getter: `this.m(k)` → `m[k]` (`maybe-incorrect`; double-check the rewrite).
@@ -32,8 +32,8 @@ suggested — the developer is intentionally reaching for the external-call mach
 ### Why is this bad?
 
 Each `this.X(...)` call compiles to a `STATICCALL` to the contract's own address. That costs a
-fixed amount of gas, plus the encoding/decoding of arguments and return data, in addition to
-the storage read itself. Reading the variable directly skips the call entirely.
+fixed amount of gas, plus the encoding/decoding of arguments and return data, in addition to the
+storage read itself. Reading the variable directly skips the call entirely.
 
 ### Example
 

--- a/src/pages/forge/linting/write-after-write.mdx
+++ b/src/pages/forge/linting/write-after-write.mdx
@@ -2,22 +2,30 @@
 description: Redundant storage write; value overwritten before being read
 ---
 
-## Write After Write
+## Write after write
 
 **Severity**: `Gas`
 **ID**: `write-after-write`
 
-Flags storage variables that are written consecutively without the first value ever being read.
+Flags storage variables that are written to consecutively without the first value ever being read.
 The first write is dead code; it pays the SSTORE cost but its value is immediately discarded when
 the second write overwrites it.
 
 ### What it does
 
-Within a flat sequence of statements (no intervening branches or loops), reports the first
-assignment to a simple state variable when that same variable is written a second time before being
-read. Only plain `=` assignments and `delete` expressions on bare state variable identifiers are
-checked; compound assignments (`+=`, `|=`, etc.) and index/member writes (`mapping[k]`,
-`struct.field`) are conservatively excluded to avoid false positives.
+Reports the first assignment to a state variable when that same variable is written a second time
+before being read. Detection covers:
+
+- Plain `=` assignments and `delete` on bare state variable identifiers
+- Tuple/destructuring assignments: `(x, y) = (1, 2)` tracks each component individually
+- Pre/post increment and decrement (`++x`, `x--`, etc.) — these read then write, so the write
+  they produce can itself become dead if immediately overwritten
+
+The analysis recurses into branch bodies (`if`/`else`, loops, `try` clauses) and modifier bodies
+with fresh state so intra-body pairs are still caught. Conditional boundaries (`&&`, `||`,
+ternary) are handled conservatively to avoid false positives across short-circuit paths. Compound
+assignments (`+=`, `|=`, etc.) and index/member writes (`mapping[k]`, `struct.field`) are
+excluded to avoid false positives.
 
 ### Why is this bad?
 


### PR DESCRIPTION
## Summary

- resync 58 lint reference pages with `foundry/crates/lint/docs`
- update affected summaries on the lint overview page
- preserve the three book-only lint pages ahead of their corresponding Foundry changes landing
