### PR TITLE
docs(cheatcodes): document transaction execution

### DIFF
--- a/sidebar/cmd-reference.ts
+++ b/sidebar/cmd-reference.ts
@@ -42,6 +42,7 @@ export const cmdReference: SidebarItem[] = [
           { text: 'resetGasMetering', link: '/reference/cheatcodes/reset-gas-metering' },
           { text: 'resumeGasMetering', link: '/reference/cheatcodes/resume-gas-metering' },
           { text: 'txGasPrice', link: '/reference/cheatcodes/tx-gas-price' },
+          { text: 'executeTransaction', link: '/reference/cheatcodes/execute-transaction' },
           { text: 'startStateDiffRecording', link: '/reference/cheatcodes/start-state-diff-recording' },
           { text: 'stopAndReturnStateDiff', link: '/reference/cheatcodes/stop-and-return-state-diff' },
           { text: 'snapshotState', link: '/reference/cheatcodes/state-snapshots' },

--- a/src/pages/reference/cheatcodes/execute-transaction.mdx
+++ b/src/pages/reference/cheatcodes/execute-transaction.mdx
@@ -1,0 +1,59 @@
+---
+description: Executes a signed raw transaction with isolated transaction semantics
+---
+
+## `executeTransaction`
+
+### Signature
+
+```solidity
+function executeTransaction(bytes calldata rawTx) external returns (bytes memory output);
+```
+
+### Description
+
+Decodes and executes a signed raw transaction with full transaction semantics, similar to running a test with `forge test --isolate`. The input can be a legacy RLP transaction or an [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) typed transaction containing its type byte and encoded payload.
+
+Foundry recovers the sender from the signature, checks the account nonce, executes the transaction in a fresh EVM context, and merges the resulting state back into the test. Calls after `executeTransaction` can immediately use those state changes.
+
+During the nested execution, Foundry sets the base fee and effective gas price to zero. Gas limits and EVM rules are still enforced, but the sender is not charged a gas fee.
+
+The returned bytes are the transaction output. Contract calls return their returndata, contract creation returns the created contract's bytecode output, and a plain value transfer returns empty bytes.
+
+This cheatcode is available in tests, but it is not allowed in `forge script`.
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `rawTx` | `bytes` | Signed legacy RLP or EIP-2718 transaction envelope |
+
+### Returns
+
+| Type | Description |
+|------|-------------|
+| `bytes` | Output produced by a successful transaction |
+
+### Example
+
+```solidity [test/ExecuteTransaction.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/ExecuteTransaction.t.sol:execute]
+```
+
+The encoded transaction sends 17 wei from `sender` to `recipient`. Because its nonce is zero and its chain ID is one, the test configures matching state before execution.
+
+### Gotchas
+
+- The transaction must be signed. Foundry recovers and uses its signer instead of `msg.sender` from the surrounding test.
+- The signer's current nonce and the configured chain ID must match the transaction.
+- Fund the signer for the transaction value. You do not need to fund the gas fee because execution uses a zero gas price.
+- Invalid encoding or signatures, transaction reverts, and EVM halts cause the cheatcode call to revert.
+- This cheatcode commits transaction state to the test, unlike an RPC simulation such as `eth_call`.
+- `executeTransaction` cannot be used from `forge script`.
+
+### Related Cheatcodes
+
+- [`transact`](/reference/cheatcodes/transact) - Replay a transaction from the active fork by hash
+- [`prank`](/reference/cheatcodes/prank) - Set the caller for the next test call
+- [`chainId`](/reference/cheatcodes/chain-id) - Set the chain ID used by the test
+- [`deal`](/reference/cheatcodes/deal) - Set an account's balance

--- a/src/snippets/projects/cheatcodes/test/ExecuteTransaction.t.sol
+++ b/src/snippets/projects/cheatcodes/test/ExecuteTransaction.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+contract ExecuteTransactionTest is Test {
+    // [!region execute]
+    function testExecuteSignedTransaction() public {
+        address sender = 0x5316812db67073C4d4af8BB3000C5B86c2877e94;
+        address recipient = 0x6Fd0A0CFF9A87aDF51695b40b4fA267855a8F4c6;
+
+        vm.chainId(1);
+        vm.deal(sender, 1 ether);
+
+        bytes memory rawTx =
+            hex"f860806483030d40946fd0a0cff9a87adf51695b40b4fa267855a8f4c6118025a03ebeabbcfe43c2c982e99b376b5fb6e765059d7f215533c8751218cac99bbd80a00a56cf5c382442466770a756e81272d06005c9e90fb8dbc5b53af499d5aca856";
+        bytes memory output = vm.executeTransaction(rawTx);
+
+        assertEq(output.length, 0);
+        assertEq(sender.balance, 1 ether - 17);
+        assertEq(recipient.balance, 17);
+        assertEq(vm.getNonce(sender), 1);
+    }
+    // [!endregion execute]
+}


### PR DESCRIPTION
Documents `executeTransaction` as a standalone reference, covering supported raw transaction envelopes, signer recovery, isolated execution and state merging, zero-fee behavior, error cases, and the restriction in Forge scripts. The page includes an executable signed-transaction example and exposes the cheatcode in the environment sidebar.
