### PR TITLE
docs(cheatcodes): document JSON log output

### DIFF
--- a/src/pages/reference/cheatcodes/get-recorded-logs.mdx
+++ b/src/pages/reference/cheatcodes/get-recorded-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Gets all emitted events recorded by recordLogs
+description: Gets emitted events recorded by recordLogs as Solidity structs or JSON
 ---
 
 ## `getRecordedLogs`
@@ -13,12 +13,27 @@ struct Log {
     address emitter;
 }
 
-function getRecordedLogs() external returns (Log[] memory);
+function getRecordedLogs() external view returns (Log[] memory logs);
+function getRecordedLogsJson() external view returns (string memory logsJson);
 ```
 
 ### Description
 
 Gets all emitted events recorded by [`recordLogs`](/reference/cheatcodes/record-logs).
+
+`getRecordedLogs` returns Solidity `Log` structs. `getRecordedLogsJson` returns the same fields as a JSON array, with topics, data, and emitter addresses encoded as `0x`-prefixed strings:
+
+```json
+[
+  {
+    "topics": ["0xddf252ad...", "0x00000000..."],
+    "data": "0x00000000...",
+    "emitter": "0x1234..."
+  }
+]
+```
+
+An empty recording is returned as `[]`.
 
 ### Returns
 
@@ -27,6 +42,8 @@ Gets all emitted events recorded by [`recordLogs`](/reference/cheatcodes/record-
 | `topics`  | `bytes32[]` | The indexed topics (topics[0] is the event signature) |
 | `data`    | `bytes`     | The non-indexed event data               |
 | `emitter` | `address`   | The address that emitted the event       |
+
+The JSON representation uses the same field names. Each topic and the data field are hex encoded, while `emitter` is formatted as an address string.
 
 ### Examples
 
@@ -61,10 +78,16 @@ function testGetRecordedLogs() public {
 }
 ```
 
+#### Get logs as JSON
+
+```solidity [test/GetRecordedLogsJson.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/GetRecordedLogsJson.t.sol:json]
+```
+
 ### Gotchas
 
 :::warning
-Calling `getRecordedLogs` **consumes** the recorded logs. Subsequent calls will only return logs emitted after the previous call.
+Calling either `getRecordedLogs` or `getRecordedLogsJson` **consumes** the recorded logs. Subsequent calls to either function only return logs emitted after the previous call.
 :::
 
 ```solidity [test/LogsConsumed.t.sol]
@@ -84,3 +107,4 @@ function testLogsConsumed() public {
 ### Related Cheatcodes
 
 - [`recordLogs`](/reference/cheatcodes/record-logs) - Starts recording emitted events
+- [`parseJson`](/reference/cheatcodes/parse-json) - Parses values from a JSON string

--- a/src/snippets/projects/cheatcodes/test/GetRecordedLogsJson.t.sol
+++ b/src/snippets/projects/cheatcodes/test/GetRecordedLogsJson.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+contract GetRecordedLogsJsonTest is Test {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    // [!region json]
+    function testGetRecordedLogsJson() public {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        vm.recordLogs();
+        emit Transfer(alice, bob, 10 ether);
+
+        string memory logsJson = vm.getRecordedLogsJson();
+        string[] memory topics = vm.parseJsonStringArray(logsJson, "[0].topics");
+        string memory emitter = vm.parseJsonString(logsJson, "[0].emitter");
+
+        assertEq(vm.parseBytes32(topics[0]), keccak256("Transfer(address,address,uint256)"));
+        assertEq(vm.parseAddress(emitter), address(this));
+        assertEq(vm.getRecordedLogsJson(), "[]");
+    }
+    // [!endregion json]
+}


### PR DESCRIPTION
Extends the existing recorded-logs reference with `getRecordedLogsJson`, its exact JSON shape and encodings, empty result, and shared consuming behavior with `getRecordedLogs`. It also corrects the signatures to match the generated interface and adds an executable example that parses the serialized topics and emitter.
