### PR TITLE
docs(cheatcodes): document isolate mode check

### DIFF
--- a/sidebar/cmd-reference.ts
+++ b/sidebar/cmd-reference.ts
@@ -48,6 +48,7 @@ export const cmdReference: SidebarItem[] = [
           { text: 'snapshotGas', link: '/reference/cheatcodes/gas-snapshots' },
           { text: 'isImplicitlyApproved', link: '/reference/cheatcodes/is-implicitly-approved' },
           { text: 'isContext', link: '/reference/cheatcodes/is-context' },
+          { text: 'isIsolateMode', link: '/reference/cheatcodes/is-isolate-mode' },
         ],
       },
       {

--- a/src/pages/reference/cheatcodes/is-isolate-mode.mdx
+++ b/src/pages/reference/cheatcodes/is-isolate-mode.mdx
@@ -1,0 +1,49 @@
+---
+description: Checks whether isolated test execution is enabled
+---
+
+## `isIsolateMode`
+
+### Signature
+
+```solidity
+function isIsolateMode() external view returns (bool result);
+```
+
+### Description
+
+Returns whether isolated test execution is enabled for the current Forge run.
+
+Isolation runs external calls from a test with transaction-like boundaries. This gives each call its own gas accounting and access-list state instead of carrying warmed accounts and storage slots across every call in the test function. Isolation is enabled by default.
+
+Use `isIsolateMode` when a test helper needs to reject an incompatible mode or select assertions whose gas or warm-state assumptions depend on isolation.
+
+### Returns
+
+| Type | Description |
+|------|-------------|
+| `bool` | `true` when isolated execution is enabled; otherwise `false` |
+
+### Example
+
+```solidity [test/IsIsolateMode.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/IsIsolateMode.t.sol:require-isolation]
+```
+
+Run with `forge test --no-isolate` to disable isolation, or set it persistently in `foundry.toml`:
+
+```toml [foundry.toml]
+[profile.default]
+isolate = false
+```
+
+### Gotchas
+
+- The result reports the resolved Forge configuration. It does not toggle isolation; use the CLI flag or `isolate` configuration value to do that.
+- Gas snapshots and tests that model separate transactions generally require isolation. Tests that intentionally depend on warm access carrying between calls may require `--no-isolate`.
+- Avoid silently skipping broad assertions based on this value. Prefer a clear failure when the test requires a specific mode.
+
+### Related Cheatcodes
+
+- [`isContext`](/reference/cheatcodes/is-context) - Check whether Forge is running a test, coverage, snapshot, or script workflow
+- [`snapshotGas`](/reference/cheatcodes/gas-snapshots) - Record and compare gas snapshots

--- a/src/snippets/projects/cheatcodes/test/IsIsolateMode.t.sol
+++ b/src/snippets/projects/cheatcodes/test/IsIsolateMode.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+contract IsIsolateModeTest is Test {
+    // [!region require-isolation]
+    function testRequiresIsolation() public view {
+        assertTrue(vm.isIsolateMode(), "run this test without --no-isolate");
+    }
+    // [!endregion require-isolation]
+}


### PR DESCRIPTION
Adds a standalone `isIsolateMode` reference that explains the resolved configuration, default behavior, transaction-like call boundaries, and when warm-state or gas assertions require a particular mode. The executable example fails clearly when a test that requires isolation is run with `--no-isolate`.
