### PR TITLE
docs(cheatcodes): document frame gas helpers

### DIFF
--- a/sidebar/cmd-reference.ts
+++ b/sidebar/cmd-reference.ts
@@ -41,6 +41,7 @@ export const cmdReference: SidebarItem[] = [
           { text: 'pauseGasMetering', link: '/reference/cheatcodes/pause-gas-metering' },
           { text: 'resetGasMetering', link: '/reference/cheatcodes/reset-gas-metering' },
           { text: 'resumeGasMetering', link: '/reference/cheatcodes/resume-gas-metering' },
+          { text: 'lastFrameGas', link: '/reference/cheatcodes/last-frame-gas' },
           { text: 'txGasPrice', link: '/reference/cheatcodes/tx-gas-price' },
           { text: 'startStateDiffRecording', link: '/reference/cheatcodes/start-state-diff-recording' },
           { text: 'stopAndReturnStateDiff', link: '/reference/cheatcodes/stop-and-return-state-diff' },

--- a/src/pages/reference/cheatcodes/gas-snapshots.mdx
+++ b/src/pages/reference/cheatcodes/gas-snapshots.mdx
@@ -16,6 +16,8 @@ function snapshotValue(string calldata name, uint256 value) external;
 function snapshotValue(string calldata group, string calldata name, uint256 value) external;
 function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
 function snapshotGasLastCall(string calldata group, string calldata name) external returns (uint256 gasUsed);
+function snapshotGasLastFrame(string calldata name) external returns (uint256 gasUsed);
+function snapshotGasLastFrame(string calldata group, string calldata name) external returns (uint256 gasUsed);
 ```
 
 ### Description
@@ -27,7 +29,8 @@ These cheatcodes allow you to capture gas usage in your tests. Snapshots are wri
 | `startSnapshotGas`   | Start capturing gas usage                            |
 | `stopSnapshotGas`    | Stop capturing and record the gas used               |
 | `snapshotValue`      | Record an arbitrary numerical value                  |
-| `snapshotGasLastCall`| Record gas usage of the last external call           |
+| `snapshotGasLastFrame` | Record gas usage of the last external call or contract creation |
+| `snapshotGasLastCall` | Deprecated call-only variant; use `snapshotGasLastFrame` |
 
 ### Configuration
 
@@ -54,12 +57,12 @@ function testSnapshotGas() public {
 }
 ```
 
-#### Capturing gas for the last call
+#### Capturing gas for the last frame
 
 ```solidity [test/GasSnapshotLastCall.t.sol]
-function testSnapshotGasLastCall() public {
+function testSnapshotGasLastFrame() public {
     myContract.run(256);
-    vm.snapshotGasLastCall("run256");
+    vm.snapshotGasLastFrame("run256");
     // Captures gas used by myContract.run(256)
 }
 ```
@@ -99,4 +102,5 @@ The `snapshots/` directory should be committed to version control to track gas c
 
 ### Related Cheatcodes
 
+- [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) - Inspect all gas fields for the last call or creation without writing a snapshot
 - [`snapshotState`](/reference/cheatcodes/state-snapshots) - Snapshot EVM state

--- a/src/pages/reference/cheatcodes/last-frame-gas.mdx
+++ b/src/pages/reference/cheatcodes/last-frame-gas.mdx
@@ -1,0 +1,66 @@
+---
+description: Returns gas measurements for the last external call or contract creation
+---
+
+## `lastFrameGas`
+
+### Signatures
+
+```solidity
+struct Gas {
+    uint64 gasLimit;
+    uint64 gasTotalUsed;
+    uint64 gasMemoryUsed;
+    int64 gasRefunded;
+    uint64 gasRemaining;
+}
+
+function lastFrameGas() external view returns (Gas memory gas);
+function lastCallGas() external view returns (Gas memory gas);
+```
+
+### Description
+
+`lastFrameGas` returns gas measurements for the most recently completed external call or contract creation. The values are recorded from the callee's perspective, so they describe the child execution frame rather than all overhead paid by its caller.
+
+`lastCallGas` provides the same measurements but only records calls, not `CREATE` or `CREATE2`. It is deprecated; use `lastFrameGas` for new tests.
+
+Reading either value does not replace the recorded frame because cheatcode calls are excluded from this measurement.
+
+### Returns
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gasLimit` | `uint64` | Gas limit available to the frame |
+| `gasTotalUsed` | `uint64` | Total gas spent by the frame |
+| `gasMemoryUsed` | `uint64` | Deprecated field that currently returns `0` |
+| `gasRefunded` | `int64` | Gas refund accumulated by the frame |
+| `gasRemaining` | `uint64` | Gas remaining when the frame completed |
+
+### Examples
+
+#### Inspect an external call
+
+```solidity [test/LastFrameGas.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/LastFrameGas.t.sol:call]
+```
+
+#### Inspect contract creation
+
+```solidity [test/LastFrameGas.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/LastFrameGas.t.sol:create]
+```
+
+### Gotchas
+
+- `lastFrameGas` reverts when no external call or contract creation has completed yet.
+- `lastCallGas` reverts when no external call has completed, even if a contract was created.
+- The measurement is for the callee frame. It does not equal the caller's complete gas delta around the call.
+- Expected-revert handling can clear the cached frame. Do not rely on `lastFrameGas` after a call or creation consumed by `vm.expectRevert`.
+- Gas depends on EVM version, optimizer settings, isolation, and warm or cold state. Keep those inputs stable when comparing values.
+
+### Related Cheatcodes
+
+- [`snapshotGas`](/reference/cheatcodes/gas-snapshots) - Persist the last frame's gas usage or measure a code section
+- [`pauseGasMetering`](/reference/cheatcodes/pause-gas-metering) - Exclude code from gas metering
+- [Forge testing](/forge/testing) - Understand isolation and transaction-like call boundaries

--- a/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
+++ b/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract GasTarget {
+    uint256 public value;
+
+    function setValue(uint256 newValue) external {
+        value = newValue;
+    }
+}
+
+contract LastFrameGasTest is Test {
+    // [!region call]
+    function testMeasureLastCallFrame() public {
+        GasTarget target = new GasTarget();
+        target.setValue(42);
+
+        Vm.Gas memory gas = vm.lastFrameGas();
+
+        assertGt(gas.gasLimit, 0);
+        assertGt(gas.gasTotalUsed, 0);
+        assertEq(gas.gasMemoryUsed, 0);
+        assertGt(gas.gasRemaining, 0);
+    }
+    // [!endregion call]
+
+    // [!region create]
+    function testMeasureContractCreationFrame() public {
+        new GasTarget();
+
+        Vm.Gas memory gas = vm.lastFrameGas();
+
+        assertGt(gas.gasTotalUsed, 0);
+    }
+    // [!endregion create]
+}


### PR DESCRIPTION
Documents `lastFrameGas`, its return fields, callee-frame scope, call and creation behavior, cache failure cases, and the deprecated `lastCallGas` predecessor with tested examples. It also updates gas snapshots to expose and recommend `snapshotGasLastFrame` while clearly marking the call-only variants as deprecated.
