### PR TITLE
docs(lint): add inconsistent type names

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -96,6 +96,7 @@ const docs = [
               { text: "deprecated-oz-function", link: "/forge/linting/deprecated-oz-function" },
               { text: "empty-block", link: "/forge/linting/empty-block" },
               { text: "incorrect-modifier", link: "/forge/linting/incorrect-modifier" },
+              { text: "inconsistent-type-names", link: "/forge/linting/inconsistent-type-names" },
               { text: "missing-events-access-control", link: "/forge/linting/missing-events-access-control" },
               { text: "missing-events-arithmetic", link: "/forge/linting/missing-events-arithmetic" },
               { text: "missing-zero-check", link: "/forge/linting/missing-zero-check" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -199,6 +199,7 @@ navigation on the right to browse by severity.
 - [`deprecated-oz-function`](/forge/linting/deprecated-oz-function) — Flags references to functions OpenZeppelin deprecated: `SafeERC20.safeApprove` and `AccessControl._setupRole`.
 - [`empty-block`](/forge/linting/empty-block) — Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
 - [`incorrect-modifier`](/forge/linting/incorrect-modifier) — Flags modifiers that can finish without executing the modified function body or reverting.
+- [`inconsistent-type-names`](/forge/linting/inconsistent-type-names) — Flags mixed use of `uint`/`uint256` or `int`/`int256` spellings within one contract.
 - [`missing-events-access-control`](/forge/linting/missing-events-access-control) — Flags protected entry-point functions that update state used for access control without emitting an event.
 - [`missing-events-arithmetic`](/forge/linting/missing-events-arithmetic) — Flags protected entry-point functions that update tainted integer state used in arithmetic by an unprotected function without emitting an event.
 - [`missing-zero-check`](/forge/linting/missing-zero-check) — Flags entry-point functions and constructors where an `address` parameter flows into a state write or value transfer without a zero-address guard.

--- a/src/pages/forge/linting/inconsistent-type-names.mdx
+++ b/src/pages/forge/linting/inconsistent-type-names.mdx
@@ -1,0 +1,42 @@
+---
+description: Inconsistent type names
+---
+
+## Inconsistent type names
+
+**Severity**: `Low`
+**ID**: `inconsistent-type-names`
+
+Flags mixed use of the equivalent `uint`/`uint256` or `int`/`int256` type spellings within one contract.
+
+### What it does
+
+Reports a variable declaration that uses `uint` when another declaration in the same directly declared contract uses `uint256`, and likewise reports `int` when the contract also uses `int256`. Only the shorthand declaration is reported because the explicit 256-bit spelling is preferred.
+
+The lint checks state variables, struct fields, event and error parameters, function parameters and returns, local variables, try/catch variables, and function-type parameters and returns. It also inspects array element and mapping key/value types recursively. A declaration such as `mapping(uint => uint256)` is therefore inconsistent by itself and produces one diagnostic for the declaration.
+
+Consistency is evaluated separately for each directly declared contract. Types declared in a base contract or another contract do not affect a child, and type spellings in casts, `type(...)` expressions, `using ... for` directives, or user-defined value type definitions do not affect the result. A contract that consistently uses only `uint` and `int` is not reported, though explicit sizes remain preferable.
+
+### Why is this bad?
+
+`uint` and `uint256` compile to the same type, as do `int` and `int256`, so mixing their spellings does not change runtime behavior. It does make the code less consistent and can make readers wonder whether an omitted size was intentional. Using the explicit spelling throughout removes that ambiguity.
+
+### Example
+
+#### Bad
+
+```solidity
+contract Vault {
+    uint public shares;
+    uint256 public assets;
+}
+```
+
+#### Good
+
+```solidity
+contract Vault {
+    uint256 public shares;
+    uint256 public assets;
+}
+```


### PR DESCRIPTION
Documents the `inconsistent-type-names` lint introduced by [foundry-rs/foundry#15761](https://github.com/foundry-rs/foundry/pull/15761), including its per-contract scope, shorthand-only diagnostics, nested type behavior, examples, and navigation/index entries.
