### PR TITLE
docs(reference): add generation provenance

### DIFF
--- a/scripts/gen_output/help.rs
+++ b/scripts/gen_output/help.rs
@@ -208,13 +208,52 @@ fn parse_sub_commands(s: &str) -> Vec<String> {
 
 /// Writes the markdown for a command to out_dir.
 fn cmd_markdown(out_dir: &Path, cmd: &Cmd, stdout: &str) -> io::Result<()> {
-    let out = format!("## {}\n\n{}", cmd, help_markdown(cmd, stdout));
+    let (description, _) = parse_description(stdout);
+    let description = normalize_description(cmd, description);
+    let provenance = format!(
+        "_Generated from `{cmd} --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._"
+    );
+    let generation_note = if cmd.subcommands.is_empty() {
+        "\n\n:::note[Generated CLI reference]\nThis reference is generated from the installed command's `--help` output. See [CLI reference versions](/reference/versions) for the exact binaries used.\n:::"
+    } else {
+        ""
+    };
+    let out = format!(
+        "---\ndescription: {}\n---\n\n{}\n\n## {}{}\n\n{}",
+        yaml_double_quote(&description),
+        provenance,
+        cmd,
+        generation_note,
+        help_markdown(cmd, stdout)
+    );
 
     let out_path = out_dir.join(cmd.md_path());
     fs::create_dir_all(out_path.parent().unwrap())?;
     write_file(&out_path.with_extension("mdx"), &out)?;
 
     Ok(())
+}
+
+/// Returns a single-line description suitable for page metadata.
+fn normalize_description(cmd: &Cmd<'_>, description: &str) -> String {
+    let description = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    if description.is_empty() {
+        format!("Command reference for `{cmd}`.")
+    } else {
+        description
+    }
+}
+
+/// Quotes a string as a YAML double-quoted scalar.
+fn yaml_double_quote(value: &str) -> String {
+    format!(
+        "\"{}\"",
+        value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+    )
 }
 
 /// Returns the markdown for a command's help output.

--- a/scripts/gen_output/help.sh
+++ b/scripts/gen_output/help.sh
@@ -32,4 +32,26 @@ gen_help() {
     echo "Running: ${cmd[*]}"
     "${cmd[@]}"
   done
+
+  versions_file="$ROOT/src/pages/reference/versions.mdx"
+  {
+    cat <<'EOF'
+---
+description: Exact Foundry binary versions used to generate the CLI command reference.
+---
+
+## CLI reference versions
+
+The CLI pages under `/reference` are generated from the following installed binaries. Use this page to distinguish documentation drift from behavior in a different stable or nightly release.
+
+EOF
+    for bin in "${bins[@]}"; do
+      if [[ "$bin" != "${bins[0]}" ]]; then
+        printf '\n'
+      fi
+      printf '### `%s`\n\n```text\n' "$bin"
+      "$bin" --version
+      printf '```\n'
+    done
+  } > "$versions_file"
 }

--- a/src/pages/reference/anvil/anvil.mdx
+++ b/src/pages/reference/anvil/anvil.mdx
@@ -1,4 +1,14 @@
+---
+description: "A fast local Ethereum development node"
+---
+
+_Generated from `anvil --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## anvil
+
+:::note[Generated CLI reference]
+This reference is generated from the installed command's `--help` output. See [CLI reference versions](/reference/versions) for the exact binaries used.
+:::
 
 A fast local Ethereum development node
 

--- a/src/pages/reference/anvil/completions.mdx
+++ b/src/pages/reference/anvil/completions.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate shell completions script"
+---
+
+_Generated from `anvil completions --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## anvil completions
 
 Generate shell completions script

--- a/src/pages/reference/cast/4byte-calldata.mdx
+++ b/src/pages/reference/cast/4byte-calldata.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode ABI-encoded calldata using <https://openchain.xyz>"
+---
+
+_Generated from `cast 4byte-calldata --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast 4byte-calldata
 
 Decode ABI-encoded calldata using [https://openchain.xyz](https://openchain.xyz)

--- a/src/pages/reference/cast/4byte-event.mdx
+++ b/src/pages/reference/cast/4byte-event.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the event signature for a given topic 0 from <https://openchain.xyz>"
+---
+
+_Generated from `cast 4byte-event --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast 4byte-event
 
 Get the event signature for a given topic 0 from [https://openchain.xyz](https://openchain.xyz)

--- a/src/pages/reference/cast/4byte.mdx
+++ b/src/pages/reference/cast/4byte.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the function signatures for the given selector from <https://openchain.xyz>"
+---
+
+_Generated from `cast 4byte --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast 4byte
 
 Get the function signatures for the given selector from [https://openchain.xyz](https://openchain.xyz)

--- a/src/pages/reference/cast/abi-encode-event.mdx
+++ b/src/pages/reference/cast/abi-encode-event.mdx
@@ -1,3 +1,9 @@
+---
+description: "ABI encode an event and its arguments to generate topics and data"
+---
+
+_Generated from `cast abi-encode-event --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast abi-encode-event
 
 ABI encode an event and its arguments to generate topics and data

--- a/src/pages/reference/cast/abi-encode.mdx
+++ b/src/pages/reference/cast/abi-encode.mdx
@@ -1,3 +1,9 @@
+---
+description: "ABI encode the given function argument, excluding the selector"
+---
+
+_Generated from `cast abi-encode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast abi-encode
 
 ABI encode the given function argument, excluding the selector

--- a/src/pages/reference/cast/access-list.mdx
+++ b/src/pages/reference/cast/access-list.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create an access list for a transaction"
+---
+
+_Generated from `cast access-list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast access-list
 
 Create an access list for a transaction

--- a/src/pages/reference/cast/address-zero.mdx
+++ b/src/pages/reference/cast/address-zero.mdx
@@ -1,3 +1,9 @@
+---
+description: "Prints the zero address"
+---
+
+_Generated from `cast address-zero --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast address-zero
 
 Prints the zero address

--- a/src/pages/reference/cast/admin.mdx
+++ b/src/pages/reference/cast/admin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetch the EIP-1967 admin account"
+---
+
+_Generated from `cast admin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast admin
 
 Fetch the EIP-1967 admin account

--- a/src/pages/reference/cast/age.mdx
+++ b/src/pages/reference/cast/age.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the timestamp of a block"
+---
+
+_Generated from `cast age --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast age
 
 Get the timestamp of a block

--- a/src/pages/reference/cast/artifact.mdx
+++ b/src/pages/reference/cast/artifact.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate an artifact file, that can be used to deploy a contract locally"
+---
+
+_Generated from `cast artifact --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast artifact
 
 Generate an artifact file, that can be used to deploy a contract locally

--- a/src/pages/reference/cast/b2e-payload.mdx
+++ b/src/pages/reference/cast/b2e-payload.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert Beacon payload to execution payload"
+---
+
+_Generated from `cast b2e-payload --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast b2e-payload
 
 Convert Beacon payload to execution payload

--- a/src/pages/reference/cast/balance.mdx
+++ b/src/pages/reference/cast/balance.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the balance of an account in wei"
+---
+
+_Generated from `cast balance --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast balance
 
 Get the balance of an account in wei

--- a/src/pages/reference/cast/base-fee.mdx
+++ b/src/pages/reference/cast/base-fee.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the basefee of a block"
+---
+
+_Generated from `cast base-fee --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast base-fee
 
 Get the basefee of a block

--- a/src/pages/reference/cast/batch-mktx.mdx
+++ b/src/pages/reference/cast/batch-mktx.mdx
@@ -1,3 +1,9 @@
+---
+description: "Build and sign a batch transaction (Tempo)"
+---
+
+_Generated from `cast batch-mktx --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast batch-mktx
 
 Build and sign a batch transaction (Tempo)

--- a/src/pages/reference/cast/batch-send.mdx
+++ b/src/pages/reference/cast/batch-send.mdx
@@ -1,3 +1,9 @@
+---
+description: "Sign and publish a batch transaction (Tempo)"
+---
+
+_Generated from `cast batch-send --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast batch-send
 
 Sign and publish a batch transaction (Tempo)

--- a/src/pages/reference/cast/bind.mdx
+++ b/src/pages/reference/cast/bind.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate a rust binding from a given ABI"
+---
+
+_Generated from `cast bind --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast bind
 
 Generate a rust binding from a given ABI

--- a/src/pages/reference/cast/block-number.mdx
+++ b/src/pages/reference/cast/block-number.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the latest block number"
+---
+
+_Generated from `cast block-number --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast block-number
 
 Get the latest block number

--- a/src/pages/reference/cast/block.mdx
+++ b/src/pages/reference/cast/block.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get information about a block"
+---
+
+_Generated from `cast block --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast block
 
 Get information about a block

--- a/src/pages/reference/cast/call.mdx
+++ b/src/pages/reference/cast/call.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform a call on an account without publishing a transaction"
+---
+
+_Generated from `cast call --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast call
 
 Perform a call on an account without publishing a transaction

--- a/src/pages/reference/cast/call/--create.mdx
+++ b/src/pages/reference/cast/call/--create.mdx
@@ -1,3 +1,9 @@
+---
+description: "ignores the address field and simulates creating a contract"
+---
+
+_Generated from `cast call --create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast call --create
 
 ignores the address field and simulates creating a contract

--- a/src/pages/reference/cast/calldata.mdx
+++ b/src/pages/reference/cast/calldata.mdx
@@ -1,3 +1,9 @@
+---
+description: "ABI-encode a function with arguments"
+---
+
+_Generated from `cast calldata --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast calldata
 
 ABI-encode a function with arguments

--- a/src/pages/reference/cast/cast.mdx
+++ b/src/pages/reference/cast/cast.mdx
@@ -1,4 +1,14 @@
+---
+description: "A Swiss Army knife for interacting with Ethereum applications from the command line"
+---
+
+_Generated from `cast --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast
+
+:::note[Generated CLI reference]
+This reference is generated from the installed command's `--help` output. See [CLI reference versions](/reference/versions) for the exact binaries used.
+:::
 
 A Swiss Army knife for interacting with Ethereum applications from the command
 line

--- a/src/pages/reference/cast/chain-id.mdx
+++ b/src/pages/reference/cast/chain-id.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the Ethereum chain ID"
+---
+
+_Generated from `cast chain-id --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast chain-id
 
 Get the Ethereum chain ID

--- a/src/pages/reference/cast/chain.mdx
+++ b/src/pages/reference/cast/chain.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the symbolic name of the current chain"
+---
+
+_Generated from `cast chain --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast chain
 
 Get the symbolic name of the current chain

--- a/src/pages/reference/cast/channel-id.mdx
+++ b/src/pages/reference/cast/channel-id.mdx
@@ -1,3 +1,9 @@
+---
+description: "Compute a Tempo TIP-20 channel reserve channel ID"
+---
+
+_Generated from `cast channel-id --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast channel-id
 
 Compute a Tempo TIP-20 channel reserve channel ID

--- a/src/pages/reference/cast/classify.mdx
+++ b/src/pages/reference/cast/classify.mdx
@@ -1,3 +1,9 @@
+---
+description: "Classify a raw transaction as Tempo T5 payment/general lane"
+---
+
+_Generated from `cast classify --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast classify
 
 Classify a raw transaction as Tempo T5 payment/general lane

--- a/src/pages/reference/cast/client.mdx
+++ b/src/pages/reference/cast/client.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the current client version"
+---
+
+_Generated from `cast client --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast client
 
 Get the current client version

--- a/src/pages/reference/cast/code.mdx
+++ b/src/pages/reference/cast/code.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the runtime bytecode of a contract"
+---
+
+_Generated from `cast code --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast code
 
 Get the runtime bytecode of a contract

--- a/src/pages/reference/cast/codehash.mdx
+++ b/src/pages/reference/cast/codehash.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the codehash for an account"
+---
+
+_Generated from `cast codehash --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast codehash
 
 Get the codehash for an account

--- a/src/pages/reference/cast/codesize.mdx
+++ b/src/pages/reference/cast/codesize.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the runtime bytecode size of a contract"
+---
+
+_Generated from `cast codesize --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast codesize
 
 Get the runtime bytecode size of a contract

--- a/src/pages/reference/cast/completions.mdx
+++ b/src/pages/reference/cast/completions.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate shell completions script"
+---
+
+_Generated from `cast completions --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast completions
 
 Generate shell completions script

--- a/src/pages/reference/cast/compute-address.mdx
+++ b/src/pages/reference/cast/compute-address.mdx
@@ -1,3 +1,9 @@
+---
+description: "Compute the contract address from a given nonce and deployer address"
+---
+
+_Generated from `cast compute-address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast compute-address
 
 Compute the contract address from a given nonce and deployer address

--- a/src/pages/reference/cast/concat-hex.mdx
+++ b/src/pages/reference/cast/concat-hex.mdx
@@ -1,3 +1,9 @@
+---
+description: "Concatenate hex strings"
+---
+
+_Generated from `cast concat-hex --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast concat-hex
 
 Concatenate hex strings

--- a/src/pages/reference/cast/constructor-args.mdx
+++ b/src/pages/reference/cast/constructor-args.mdx
@@ -1,3 +1,9 @@
+---
+description: "Display constructor arguments used for the contract initialization"
+---
+
+_Generated from `cast constructor-args --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast constructor-args
 
 Display constructor arguments used for the contract initialization

--- a/src/pages/reference/cast/create2.mdx
+++ b/src/pages/reference/cast/create2.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate a deterministic contract address using CREATE2"
+---
+
+_Generated from `cast create2 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast create2
 
 Generate a deterministic contract address using CREATE2

--- a/src/pages/reference/cast/creation-code.mdx
+++ b/src/pages/reference/cast/creation-code.mdx
@@ -1,3 +1,9 @@
+---
+description: "Download a contract creation code from Etherscan and RPC"
+---
+
+_Generated from `cast creation-code --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast creation-code
 
 Download a contract creation code from Etherscan and RPC

--- a/src/pages/reference/cast/decode-abi.mdx
+++ b/src/pages/reference/cast/decode-abi.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode ABI-encoded input or output data. Defaults to decoding output data. To decode input data pass --input. When passing `--input`, function selector must NOT be prefixed in `calldata` string"
+---
+
+_Generated from `cast decode-abi --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-abi
 
 Decode ABI-encoded input or output data.

--- a/src/pages/reference/cast/decode-calldata.mdx
+++ b/src/pages/reference/cast/decode-calldata.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode ABI-encoded input data. Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata` string"
+---
+
+_Generated from `cast decode-calldata --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-calldata
 
 Decode ABI-encoded input data.

--- a/src/pages/reference/cast/decode-error.mdx
+++ b/src/pages/reference/cast/decode-error.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode custom error data"
+---
+
+_Generated from `cast decode-error --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-error
 
 Decode custom error data

--- a/src/pages/reference/cast/decode-event.mdx
+++ b/src/pages/reference/cast/decode-event.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode event data"
+---
+
+_Generated from `cast decode-event --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-event
 
 Decode event data

--- a/src/pages/reference/cast/decode-string.mdx
+++ b/src/pages/reference/cast/decode-string.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode ABI-encoded string. Similar to `calldata-decode --input`, but the function argument is a `string`"
+---
+
+_Generated from `cast decode-string --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-string
 
 Decode ABI-encoded string.

--- a/src/pages/reference/cast/decode-transaction.mdx
+++ b/src/pages/reference/cast/decode-transaction.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decodes a raw signed EIP 2718 typed transaction"
+---
+
+_Generated from `cast decode-transaction --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast decode-transaction
 
 Decodes a raw signed EIP 2718 typed transaction

--- a/src/pages/reference/cast/disassemble.mdx
+++ b/src/pages/reference/cast/disassemble.mdx
@@ -1,3 +1,9 @@
+---
+description: "Disassembles a hex-encoded bytecode into a human-readable representation"
+---
+
+_Generated from `cast disassemble --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast disassemble
 
 Disassembles a hex-encoded bytecode into a human-readable representation

--- a/src/pages/reference/cast/erc20-token.mdx
+++ b/src/pages/reference/cast/erc20-token.mdx
@@ -1,3 +1,9 @@
+---
+description: "ERC20 token operations"
+---
+
+_Generated from `cast erc20-token --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token
 
 ERC20 token operations

--- a/src/pages/reference/cast/erc20-token/allowance.mdx
+++ b/src/pages/reference/cast/erc20-token/allowance.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token allowance"
+---
+
+_Generated from `cast erc20-token allowance --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token allowance
 
 Query ERC20 token allowance

--- a/src/pages/reference/cast/erc20-token/approve.mdx
+++ b/src/pages/reference/cast/erc20-token/approve.mdx
@@ -1,3 +1,9 @@
+---
+description: "Approve ERC20 token spending"
+---
+
+_Generated from `cast erc20-token approve --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token approve
 
 Approve ERC20 token spending

--- a/src/pages/reference/cast/erc20-token/balance.mdx
+++ b/src/pages/reference/cast/erc20-token/balance.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token balance"
+---
+
+_Generated from `cast erc20-token balance --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token balance
 
 Query ERC20 token balance

--- a/src/pages/reference/cast/erc20-token/burn.mdx
+++ b/src/pages/reference/cast/erc20-token/burn.mdx
@@ -1,3 +1,9 @@
+---
+description: "Burn ERC20 tokens"
+---
+
+_Generated from `cast erc20-token burn --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token burn
 
 Burn ERC20 tokens

--- a/src/pages/reference/cast/erc20-token/decimals.mdx
+++ b/src/pages/reference/cast/erc20-token/decimals.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token decimals"
+---
+
+_Generated from `cast erc20-token decimals --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token decimals
 
 Query ERC20 token decimals

--- a/src/pages/reference/cast/erc20-token/mint.mdx
+++ b/src/pages/reference/cast/erc20-token/mint.mdx
@@ -1,3 +1,9 @@
+---
+description: "Mint ERC20 tokens (if the token supports minting)"
+---
+
+_Generated from `cast erc20-token mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token mint
 
 Mint ERC20 tokens (if the token supports minting)

--- a/src/pages/reference/cast/erc20-token/name.mdx
+++ b/src/pages/reference/cast/erc20-token/name.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token name"
+---
+
+_Generated from `cast erc20-token name --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token name
 
 Query ERC20 token name

--- a/src/pages/reference/cast/erc20-token/symbol.mdx
+++ b/src/pages/reference/cast/erc20-token/symbol.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token symbol"
+---
+
+_Generated from `cast erc20-token symbol --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token symbol
 
 Query ERC20 token symbol

--- a/src/pages/reference/cast/erc20-token/total-supply.mdx
+++ b/src/pages/reference/cast/erc20-token/total-supply.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query ERC20 token total supply"
+---
+
+_Generated from `cast erc20-token total-supply --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token total-supply
 
 Query ERC20 token total supply

--- a/src/pages/reference/cast/erc20-token/transfer.mdx
+++ b/src/pages/reference/cast/erc20-token/transfer.mdx
@@ -1,3 +1,9 @@
+---
+description: "Transfer ERC20 tokens"
+---
+
+_Generated from `cast erc20-token transfer --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast erc20-token transfer
 
 Transfer ERC20 tokens

--- a/src/pages/reference/cast/estimate.mdx
+++ b/src/pages/reference/cast/estimate.mdx
@@ -1,3 +1,9 @@
+---
+description: "Estimate the gas cost of a transaction"
+---
+
+_Generated from `cast estimate --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast estimate
 
 Estimate the gas cost of a transaction

--- a/src/pages/reference/cast/estimate/--create.mdx
+++ b/src/pages/reference/cast/estimate/--create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Estimate gas cost to deploy a smart contract"
+---
+
+_Generated from `cast estimate --create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast estimate --create
 
 Estimate gas cost to deploy a smart contract

--- a/src/pages/reference/cast/find-block.mdx
+++ b/src/pages/reference/cast/find-block.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the block number closest to the provided timestamp"
+---
+
+_Generated from `cast find-block --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast find-block
 
 Get the block number closest to the provided timestamp

--- a/src/pages/reference/cast/format-bytes32-string.mdx
+++ b/src/pages/reference/cast/format-bytes32-string.mdx
@@ -1,3 +1,9 @@
+---
+description: "Formats a string into bytes32 encoding"
+---
+
+_Generated from `cast format-bytes32-string --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast format-bytes32-string
 
 Formats a string into bytes32 encoding

--- a/src/pages/reference/cast/format-units.mdx
+++ b/src/pages/reference/cast/format-units.mdx
@@ -1,3 +1,9 @@
+---
+description: "Format a number from smallest unit to decimal with arbitrary decimals. Examples: - 1000000 6 (for USDC, result: 1.0) - 2500000000000 12 (for 12 decimals, result: 2.5) - 1230 3 (for 3 decimals, result: 1.23)"
+---
+
+_Generated from `cast format-units --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast format-units
 
 Format a number from smallest unit to decimal with arbitrary decimals.

--- a/src/pages/reference/cast/from-bin.mdx
+++ b/src/pages/reference/cast/from-bin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert binary data into hex data"
+---
+
+_Generated from `cast from-bin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast from-bin
 
 Convert binary data into hex data

--- a/src/pages/reference/cast/from-fixed-point.mdx
+++ b/src/pages/reference/cast/from-fixed-point.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a fixed point number into an integer"
+---
+
+_Generated from `cast from-fixed-point --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast from-fixed-point
 
 Convert a fixed point number into an integer

--- a/src/pages/reference/cast/from-rlp.mdx
+++ b/src/pages/reference/cast/from-rlp.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decodes RLP hex-encoded data"
+---
+
+_Generated from `cast from-rlp --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast from-rlp
 
 Decodes RLP hex-encoded data

--- a/src/pages/reference/cast/from-utf8.mdx
+++ b/src/pages/reference/cast/from-utf8.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert UTF8 text to hex"
+---
+
+_Generated from `cast from-utf8 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast from-utf8
 
 Convert UTF8 text to hex

--- a/src/pages/reference/cast/from-wei.mdx
+++ b/src/pages/reference/cast/from-wei.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert wei into an ETH amount. Consider using --to-unit."
+---
+
+_Generated from `cast from-wei --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast from-wei
 
 Convert wei into an ETH amount.

--- a/src/pages/reference/cast/gas-price.mdx
+++ b/src/pages/reference/cast/gas-price.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the current gas price"
+---
+
+_Generated from `cast gas-price --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast gas-price
 
 Get the current gas price

--- a/src/pages/reference/cast/hash-message.mdx
+++ b/src/pages/reference/cast/hash-message.mdx
@@ -1,3 +1,9 @@
+---
+description: "Hash a message according to EIP-191"
+---
+
+_Generated from `cast hash-message --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast hash-message
 
 Hash a message according to EIP-191

--- a/src/pages/reference/cast/hash-zero.mdx
+++ b/src/pages/reference/cast/hash-zero.mdx
@@ -1,3 +1,9 @@
+---
+description: "Prints the zero hash"
+---
+
+_Generated from `cast hash-zero --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast hash-zero
 
 Prints the zero hash

--- a/src/pages/reference/cast/implementation.mdx
+++ b/src/pages/reference/cast/implementation.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetch the EIP-1967 implementation for a contract Can read from the implementation slot or the beacon slot"
+---
+
+_Generated from `cast implementation --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast implementation
 
 Fetch the EIP-1967 implementation for a contract Can read from the

--- a/src/pages/reference/cast/index-erc7201.mdx
+++ b/src/pages/reference/cast/index-erc7201.mdx
@@ -1,3 +1,9 @@
+---
+description: "Compute storage slots as specified by `ERC-7201: Namespaced Storage Layout`"
+---
+
+_Generated from `cast index-erc7201 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast index-erc7201
 
 Compute storage slots as specified by `ERC-7201: Namespaced Storage Layout`

--- a/src/pages/reference/cast/index.mdx
+++ b/src/pages/reference/cast/index.mdx
@@ -1,3 +1,9 @@
+---
+description: "Compute the storage slot for an entry in a mapping"
+---
+
+_Generated from `cast index --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast index
 
 Compute the storage slot for an entry in a mapping

--- a/src/pages/reference/cast/interface.mdx
+++ b/src/pages/reference/cast/interface.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate a Solidity interface from a given ABI. Currently does not support ABI encoder v2."
+---
+
+_Generated from `cast interface --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast interface
 
 Generate a Solidity interface from a given ABI.

--- a/src/pages/reference/cast/keccak.mdx
+++ b/src/pages/reference/cast/keccak.mdx
@@ -1,3 +1,9 @@
+---
+description: "Hash arbitrary data using Keccak-256"
+---
+
+_Generated from `cast keccak --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keccak
 
 Hash arbitrary data using Keccak-256

--- a/src/pages/reference/cast/key-authorization.mdx
+++ b/src/pages/reference/cast/key-authorization.mdx
@@ -1,3 +1,9 @@
+---
+description: "Tempo key authorization RLP helpers"
+---
+
+_Generated from `cast key-authorization --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast key-authorization
 
 Tempo key authorization RLP helpers

--- a/src/pages/reference/cast/key-authorization/encode.mdx
+++ b/src/pages/reference/cast/key-authorization/encode.mdx
@@ -1,3 +1,9 @@
+---
+description: "RLP-encode an unsigned Tempo key authorization"
+---
+
+_Generated from `cast key-authorization encode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast key-authorization encode
 
 RLP-encode an unsigned Tempo key authorization

--- a/src/pages/reference/cast/key-authorization/inspect.mdx
+++ b/src/pages/reference/cast/key-authorization/inspect.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode and inspect a Tempo key authorization (signed or unsigned). Accepts the hex RLP from `encode` (unsigned) or `sign` (signed) and prints its fields, including the T6 `is_admin`/`account` fields and the recovered signer for signed input."
+---
+
+_Generated from `cast key-authorization inspect --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast key-authorization inspect
 
 Decode and inspect a Tempo key authorization (signed or unsigned).

--- a/src/pages/reference/cast/key-authorization/sign.mdx
+++ b/src/pages/reference/cast/key-authorization/sign.mdx
@@ -1,3 +1,9 @@
+---
+description: "Sign and RLP-encode a Tempo key authorization. With an admin access-key signer the bound account is the key's root and is derived automatically; with a direct signer, `--bind-account` binds to another root. A root-signed `--admin` authorization defaults the account to the signer."
+---
+
+_Generated from `cast key-authorization sign --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast key-authorization sign
 
 Sign and RLP-encode a Tempo key authorization.

--- a/src/pages/reference/cast/keychain.mdx
+++ b/src/pages/reference/cast/keychain.mdx
@@ -1,3 +1,9 @@
+---
+description: "Tempo keychain (access key) management"
+---
+
+_Generated from `cast keychain --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain
 
 Tempo keychain (access key) management

--- a/src/pages/reference/cast/keychain/authorize.mdx
+++ b/src/pages/reference/cast/keychain/authorize.mdx
@@ -1,3 +1,9 @@
+---
+description: "Authorize a new key on-chain via the AccountKeychain precompile"
+---
+
+_Generated from `cast keychain authorize --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain authorize
 
 Authorize a new key on-chain via the AccountKeychain precompile

--- a/src/pages/reference/cast/keychain/burn-witness.mdx
+++ b/src/pages/reference/cast/keychain/burn-witness.mdx
@@ -1,3 +1,9 @@
+---
+description: "Burn a TIP-1053 key-authorization witness for the signing account"
+---
+
+_Generated from `cast keychain burn-witness --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain burn-witness
 
 Burn a TIP-1053 key-authorization witness for the signing account

--- a/src/pages/reference/cast/keychain/check.mdx
+++ b/src/pages/reference/cast/keychain/check.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check on-chain provisioning status of a key via the AccountKeychain precompile"
+---
+
+_Generated from `cast keychain check --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain check
 
 Check on-chain provisioning status of a key via the AccountKeychain precompile

--- a/src/pages/reference/cast/keychain/doctor.mdx
+++ b/src/pages/reference/cast/keychain/doctor.mdx
@@ -1,3 +1,9 @@
+---
+description: "Diagnose access-key signing issues end-to-end. Walks the local registry, RPC, and on-chain key state and prints a green checklist. The first failing step turns red and includes a one-line hint."
+---
+
+_Generated from `cast keychain doctor --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain doctor
 
 Diagnose access-key signing issues end-to-end.

--- a/src/pages/reference/cast/keychain/inspect.mdx
+++ b/src/pages/reference/cast/keychain/inspect.mdx
@@ -1,3 +1,9 @@
+---
+description: "Inspect an access key policy using the local key registry and on-chain state"
+---
+
+_Generated from `cast keychain inspect --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain inspect
 
 Inspect an access key policy using the local key registry and on-chain state

--- a/src/pages/reference/cast/keychain/is-admin.mdx
+++ b/src/pages/reference/cast/keychain/is-admin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check whether a key is the root key or an active admin key for an account (T6)"
+---
+
+_Generated from `cast keychain is-admin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain is-admin
 
 Check whether a key is the root key or an active admin key for an account (T6)

--- a/src/pages/reference/cast/keychain/is-witness-burned.mdx
+++ b/src/pages/reference/cast/keychain/is-witness-burned.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check whether a TIP-1053 key-authorization witness has been burned"
+---
+
+_Generated from `cast keychain is-witness-burned --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain is-witness-burned
 
 Check whether a TIP-1053 key-authorization witness has been burned

--- a/src/pages/reference/cast/keychain/list.mdx
+++ b/src/pages/reference/cast/keychain/list.mdx
@@ -1,3 +1,9 @@
+---
+description: "List all keys from the local keys.toml file"
+---
+
+_Generated from `cast keychain list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain list
 
 List all keys from the local keys.toml file

--- a/src/pages/reference/cast/keychain/policy.mdx
+++ b/src/pages/reference/cast/keychain/policy.mdx
@@ -1,3 +1,9 @@
+---
+description: "Read or edit TIP-1011 access-key permissions"
+---
+
+_Generated from `cast keychain policy --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain policy
 
 Read or edit TIP-1011 access-key permissions

--- a/src/pages/reference/cast/keychain/policy/add-call.mdx
+++ b/src/pages/reference/cast/keychain/policy/add-call.mdx
@@ -1,3 +1,9 @@
+---
+description: "Add or widen an allowed call rule for a target contract"
+---
+
+_Generated from `cast keychain policy add-call --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain policy add-call
 
 Add or widen an allowed call rule for a target contract

--- a/src/pages/reference/cast/keychain/policy/remove-target.mdx
+++ b/src/pages/reference/cast/keychain/policy/remove-target.mdx
@@ -1,3 +1,9 @@
+---
+description: "Remove all allowed-call rules for a target contract"
+---
+
+_Generated from `cast keychain policy remove-target --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain policy remove-target
 
 Remove all allowed-call rules for a target contract

--- a/src/pages/reference/cast/keychain/policy/set-limit.mdx
+++ b/src/pages/reference/cast/keychain/policy/set-limit.mdx
@@ -1,3 +1,9 @@
+---
+description: "Update a token spending limit amount for a key"
+---
+
+_Generated from `cast keychain policy set-limit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain policy set-limit
 
 Update a token spending limit amount for a key

--- a/src/pages/reference/cast/keychain/revoke.mdx
+++ b/src/pages/reference/cast/keychain/revoke.mdx
@@ -1,3 +1,9 @@
+---
+description: "Revoke an authorized key on-chain via the AccountKeychain precompile"
+---
+
+_Generated from `cast keychain revoke --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain revoke
 
 Revoke an authorized key on-chain via the AccountKeychain precompile

--- a/src/pages/reference/cast/keychain/rl.mdx
+++ b/src/pages/reference/cast/keychain/rl.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query the remaining spending limit for a key on a specific token"
+---
+
+_Generated from `cast keychain rl --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain rl
 
 Query the remaining spending limit for a key on a specific token

--- a/src/pages/reference/cast/keychain/rs.mdx
+++ b/src/pages/reference/cast/keychain/rs.mdx
@@ -1,3 +1,9 @@
+---
+description: "Remove call scope for a key on a target"
+---
+
+_Generated from `cast keychain rs --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain rs
 
 Remove call scope for a key on a target

--- a/src/pages/reference/cast/keychain/show.mdx
+++ b/src/pages/reference/cast/keychain/show.mdx
@@ -1,3 +1,9 @@
+---
+description: "Show all keys for a specific wallet address from the local keys.toml file"
+---
+
+_Generated from `cast keychain show --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain show
 
 Show all keys for a specific wallet address from the local keys.toml file

--- a/src/pages/reference/cast/keychain/ss.mdx
+++ b/src/pages/reference/cast/keychain/ss.mdx
@@ -1,3 +1,9 @@
+---
+description: "Set allowed call scopes for a key"
+---
+
+_Generated from `cast keychain ss --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain ss
 
 Set allowed call scopes for a key

--- a/src/pages/reference/cast/keychain/ul.mdx
+++ b/src/pages/reference/cast/keychain/ul.mdx
@@ -1,3 +1,9 @@
+---
+description: "Update the spending limit for a key on a specific token"
+---
+
+_Generated from `cast keychain ul --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain ul
 
 Update the spending limit for a key on a specific token

--- a/src/pages/reference/cast/keychain/verify-admin.mdx
+++ b/src/pages/reference/cast/keychain/verify-admin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Verify a Tempo keychain signature against an account's root or admin key (T6). `signature` must be an encoded Tempo keychain signature (not a raw 65-byte secp256k1 signature). Returns true for the root key or an active admin key. `hash` should already be domain-separated by the caller."
+---
+
+_Generated from `cast keychain verify-admin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain verify-admin
 
 Verify a Tempo keychain signature against an account's root or admin key (T6).

--- a/src/pages/reference/cast/keychain/verify.mdx
+++ b/src/pages/reference/cast/keychain/verify.mdx
@@ -1,3 +1,9 @@
+---
+description: "Verify a Tempo keychain signature against an account's active access key (T6). `signature` must be an encoded Tempo keychain signature (not a raw 65-byte secp256k1 signature). Returns true only for an active access key, never the root key. The supplied `hash` should already be domain-separated by the caller."
+---
+
+_Generated from `cast keychain verify --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast keychain verify
 
 Verify a Tempo keychain signature against an account's active access key (T6).

--- a/src/pages/reference/cast/logs.mdx
+++ b/src/pages/reference/cast/logs.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get logs by signature or topic"
+---
+
+_Generated from `cast logs --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast logs
 
 Get logs by signature or topic

--- a/src/pages/reference/cast/lookup-address.mdx
+++ b/src/pages/reference/cast/lookup-address.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform an ENS reverse lookup"
+---
+
+_Generated from `cast lookup-address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast lookup-address
 
 Perform an ENS reverse lookup

--- a/src/pages/reference/cast/max-int.mdx
+++ b/src/pages/reference/cast/max-int.mdx
@@ -1,3 +1,9 @@
+---
+description: "Prints the maximum value of the given integer type"
+---
+
+_Generated from `cast max-int --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast max-int
 
 Prints the maximum value of the given integer type

--- a/src/pages/reference/cast/max-uint.mdx
+++ b/src/pages/reference/cast/max-uint.mdx
@@ -1,3 +1,9 @@
+---
+description: "Prints the maximum value of the given integer type"
+---
+
+_Generated from `cast max-uint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast max-uint
 
 Prints the maximum value of the given integer type

--- a/src/pages/reference/cast/min-int.mdx
+++ b/src/pages/reference/cast/min-int.mdx
@@ -1,3 +1,9 @@
+---
+description: "Prints the minimum value of the given integer type"
+---
+
+_Generated from `cast min-int --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast min-int
 
 Prints the minimum value of the given integer type

--- a/src/pages/reference/cast/mktx.mdx
+++ b/src/pages/reference/cast/mktx.mdx
@@ -1,3 +1,9 @@
+---
+description: "Build and sign a transaction"
+---
+
+_Generated from `cast mktx --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast mktx
 
 Build and sign a transaction

--- a/src/pages/reference/cast/mktx/--create.mdx
+++ b/src/pages/reference/cast/mktx/--create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Use to deploy raw contract bytecode"
+---
+
+_Generated from `cast mktx --create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast mktx --create
 
 Use to deploy raw contract bytecode

--- a/src/pages/reference/cast/namehash.mdx
+++ b/src/pages/reference/cast/namehash.mdx
@@ -1,3 +1,9 @@
+---
+description: "Calculate the ENS namehash of a name"
+---
+
+_Generated from `cast namehash --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast namehash
 
 Calculate the ENS namehash of a name

--- a/src/pages/reference/cast/nonce.mdx
+++ b/src/pages/reference/cast/nonce.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the nonce for an account"
+---
+
+_Generated from `cast nonce --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast nonce
 
 Get the nonce for an account

--- a/src/pages/reference/cast/pad.mdx
+++ b/src/pages/reference/cast/pad.mdx
@@ -1,3 +1,9 @@
+---
+description: "Pads hex data to a specified length"
+---
+
+_Generated from `cast pad --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast pad
 
 Pads hex data to a specified length

--- a/src/pages/reference/cast/parse-bytes32-address.mdx
+++ b/src/pages/reference/cast/parse-bytes32-address.mdx
@@ -1,3 +1,9 @@
+---
+description: "Parses a checksummed address from bytes32 encoding."
+---
+
+_Generated from `cast parse-bytes32-address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast parse-bytes32-address
 
 Parses a checksummed address from bytes32 encoding.

--- a/src/pages/reference/cast/parse-bytes32-string.mdx
+++ b/src/pages/reference/cast/parse-bytes32-string.mdx
@@ -1,3 +1,9 @@
+---
+description: "Parses a string from bytes32 encoding"
+---
+
+_Generated from `cast parse-bytes32-string --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast parse-bytes32-string
 
 Parses a string from bytes32 encoding

--- a/src/pages/reference/cast/parse-units.mdx
+++ b/src/pages/reference/cast/parse-units.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a number from decimal to smallest unit with arbitrary decimals. Examples: - 1.0 6 (for USDC, result: 1000000) - 2.5 12 (for 12 decimals token, result: 2500000000000) - 1.23 3 (for 3 decimals token, result: 1230)"
+---
+
+_Generated from `cast parse-units --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast parse-units
 
 Convert a number from decimal to smallest unit with arbitrary decimals.

--- a/src/pages/reference/cast/pretty-calldata.mdx
+++ b/src/pages/reference/cast/pretty-calldata.mdx
@@ -1,3 +1,9 @@
+---
+description: "Pretty print calldata. Tries to decode the calldata using <https://openchain.xyz> unless --offline is passed."
+---
+
+_Generated from `cast pretty-calldata --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast pretty-calldata
 
 Pretty print calldata.

--- a/src/pages/reference/cast/proof.mdx
+++ b/src/pages/reference/cast/proof.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate a storage proof for a given storage slot"
+---
+
+_Generated from `cast proof --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast proof
 
 Generate a storage proof for a given storage slot

--- a/src/pages/reference/cast/publish.mdx
+++ b/src/pages/reference/cast/publish.mdx
@@ -1,3 +1,9 @@
+---
+description: "Publish a raw transaction to the network"
+---
+
+_Generated from `cast publish --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast publish
 
 Publish a raw transaction to the network

--- a/src/pages/reference/cast/receipt.mdx
+++ b/src/pages/reference/cast/receipt.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the transaction receipt for a transaction"
+---
+
+_Generated from `cast receipt --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receipt
 
 Get the transaction receipt for a transaction

--- a/src/pages/reference/cast/receive-policy.mdx
+++ b/src/pages/reference/cast/receive-policy.mdx
@@ -1,3 +1,9 @@
+---
+description: "Account-level receive policy operations (Tempo)"
+---
+
+_Generated from `cast receive-policy --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy
 
 Account-level receive policy operations (Tempo)

--- a/src/pages/reference/cast/receive-policy/claim.mdx
+++ b/src/pages/reference/cast/receive-policy/claim.mdx
@@ -1,3 +1,9 @@
+---
+description: "Claim held TIP-20 funds using a blocked receive-policy receipt"
+---
+
+_Generated from `cast receive-policy claim --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy claim
 
 Claim held TIP-20 funds using a blocked receive-policy receipt

--- a/src/pages/reference/cast/receive-policy/get.mdx
+++ b/src/pages/reference/cast/receive-policy/get.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get an account's configured receive policy"
+---
+
+_Generated from `cast receive-policy get --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy get
 
 Get an account's configured receive policy

--- a/src/pages/reference/cast/receive-policy/receipt.mdx
+++ b/src/pages/reference/cast/receive-policy/receipt.mdx
@@ -1,3 +1,9 @@
+---
+description: "Blocked receive-policy receipt utilities"
+---
+
+_Generated from `cast receive-policy receipt --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy receipt
 
 Blocked receive-policy receipt utilities

--- a/src/pages/reference/cast/receive-policy/receipt/balance.mdx
+++ b/src/pages/reference/cast/receive-policy/receipt/balance.mdx
@@ -1,3 +1,9 @@
+---
+description: "Query the held TIP-20 balance for a claim receipt"
+---
+
+_Generated from `cast receive-policy receipt balance --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy receipt balance
 
 Query the held TIP-20 balance for a claim receipt

--- a/src/pages/reference/cast/receive-policy/receipt/burn.mdx
+++ b/src/pages/reference/cast/receive-policy/receipt/burn.mdx
@@ -1,3 +1,9 @@
+---
+description: "Burn held funds for a blocked receipt when authorized by the token"
+---
+
+_Generated from `cast receive-policy receipt burn --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy receipt burn
 
 Burn held funds for a blocked receipt when authorized by the token

--- a/src/pages/reference/cast/receive-policy/receipt/decode.mdx
+++ b/src/pages/reference/cast/receive-policy/receipt/decode.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decode an ABI-encoded ReceivePolicyGuard claim receipt"
+---
+
+_Generated from `cast receive-policy receipt decode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy receipt decode
 
 Decode an ABI-encoded ReceivePolicyGuard claim receipt

--- a/src/pages/reference/cast/receive-policy/set.mdx
+++ b/src/pages/reference/cast/receive-policy/set.mdx
@@ -1,3 +1,9 @@
+---
+description: "Set the caller's TIP-403 receive policy. Create the sender and token-filter policies referenced here with `cast tip403 create`."
+---
+
+_Generated from `cast receive-policy set --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy set
 
 Set the caller's TIP-403 receive policy.

--- a/src/pages/reference/cast/receive-policy/validate.mdx
+++ b/src/pages/reference/cast/receive-policy/validate.mdx
@@ -1,3 +1,9 @@
+---
+description: "Validate whether an inbound TIP-20 transfer or mint would be credited or held"
+---
+
+_Generated from `cast receive-policy validate --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast receive-policy validate
 
 Validate whether an inbound TIP-20 transfer or mint would be credited or held

--- a/src/pages/reference/cast/recover-authority.mdx
+++ b/src/pages/reference/cast/recover-authority.mdx
@@ -1,3 +1,9 @@
+---
+description: "Recovery an EIP-7702 authority from a Authorization JSON string"
+---
+
+_Generated from `cast recover-authority --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast recover-authority
 
 Recovery an EIP-7702 authority from a Authorization JSON string

--- a/src/pages/reference/cast/resolve-name.mdx
+++ b/src/pages/reference/cast/resolve-name.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform an ENS lookup"
+---
+
+_Generated from `cast resolve-name --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast resolve-name
 
 Perform an ENS lookup

--- a/src/pages/reference/cast/rpc.mdx
+++ b/src/pages/reference/cast/rpc.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform a raw JSON-RPC request"
+---
+
+_Generated from `cast rpc --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast rpc
 
 Perform a raw JSON-RPC request

--- a/src/pages/reference/cast/run.mdx
+++ b/src/pages/reference/cast/run.mdx
@@ -1,3 +1,9 @@
+---
+description: "Runs a published transaction in a local environment and prints the trace"
+---
+
+_Generated from `cast run --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast run
 
 Runs a published transaction in a local environment and prints the trace

--- a/src/pages/reference/cast/selectors.mdx
+++ b/src/pages/reference/cast/selectors.mdx
@@ -1,3 +1,9 @@
+---
+description: "Extracts function selectors and arguments from bytecode"
+---
+
+_Generated from `cast selectors --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast selectors
 
 Extracts function selectors and arguments from bytecode

--- a/src/pages/reference/cast/send.mdx
+++ b/src/pages/reference/cast/send.mdx
@@ -1,3 +1,9 @@
+---
+description: "Sign and publish a transaction"
+---
+
+_Generated from `cast send --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast send
 
 Sign and publish a transaction

--- a/src/pages/reference/cast/send/--create.mdx
+++ b/src/pages/reference/cast/send/--create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Use to deploy raw contract bytecode"
+---
+
+_Generated from `cast send --create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast send --create
 
 Use to deploy raw contract bytecode

--- a/src/pages/reference/cast/shl.mdx
+++ b/src/pages/reference/cast/shl.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform a left shifting operation"
+---
+
+_Generated from `cast shl --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast shl
 
 Perform a left shifting operation

--- a/src/pages/reference/cast/shr.mdx
+++ b/src/pages/reference/cast/shr.mdx
@@ -1,3 +1,9 @@
+---
+description: "Perform a right shifting operation"
+---
+
+_Generated from `cast shr --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast shr
 
 Perform a right shifting operation

--- a/src/pages/reference/cast/sig-event.mdx
+++ b/src/pages/reference/cast/sig-event.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate event signatures from event string"
+---
+
+_Generated from `cast sig-event --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast sig-event
 
 Generate event signatures from event string

--- a/src/pages/reference/cast/sig.mdx
+++ b/src/pages/reference/cast/sig.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the selector for a function"
+---
+
+_Generated from `cast sig --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast sig
 
 Get the selector for a function

--- a/src/pages/reference/cast/source.mdx
+++ b/src/pages/reference/cast/source.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the source code of a contract from a block explorer"
+---
+
+_Generated from `cast source --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast source
 
 Get the source code of a contract from a block explorer

--- a/src/pages/reference/cast/storage-credits.mdx
+++ b/src/pages/reference/cast/storage-credits.mdx
@@ -1,3 +1,9 @@
+---
+description: "T7 storage credits operations (Tempo)"
+---
+
+_Generated from `cast storage-credits --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits
 
 T7 storage credits operations (Tempo)

--- a/src/pages/reference/cast/storage-credits/balance.mdx
+++ b/src/pages/reference/cast/storage-credits/balance.mdx
@@ -1,3 +1,9 @@
+---
+description: "Show an account's storage credit balance"
+---
+
+_Generated from `cast storage-credits balance --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits balance
 
 Show an account's storage credit balance

--- a/src/pages/reference/cast/storage-credits/budget.mdx
+++ b/src/pages/reference/cast/storage-credits/budget.mdx
@@ -1,3 +1,9 @@
+---
+description: "Show an account's storage credit spend budget. Budget is transaction-local transient state, so a standalone read reflects the default rather than a value set by an earlier `set-budget` transaction."
+---
+
+_Generated from `cast storage-credits budget --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits budget
 
 Show an account's storage credit spend budget.

--- a/src/pages/reference/cast/storage-credits/mode.mdx
+++ b/src/pages/reference/cast/storage-credits/mode.mdx
@@ -1,3 +1,9 @@
+---
+description: "Show an account's storage credit consumption mode. Mode is transaction-local transient state, so a standalone read reflects the default rather than a value set by an earlier `set-mode` transaction."
+---
+
+_Generated from `cast storage-credits mode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits mode
 
 Show an account's storage credit consumption mode.

--- a/src/pages/reference/cast/storage-credits/set-budget.mdx
+++ b/src/pages/reference/cast/storage-credits/set-budget.mdx
@@ -1,3 +1,9 @@
+---
+description: "Set the caller's storage credit spend budget, which also selects `direct` mode. The budget only applies within the transaction that sets it; batch it with the storage operations it should govern."
+---
+
+_Generated from `cast storage-credits set-budget --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits set-budget
 
 Set the caller's storage credit spend budget, which also selects `direct` mode.

--- a/src/pages/reference/cast/storage-credits/set-mode.mdx
+++ b/src/pages/reference/cast/storage-credits/set-mode.mdx
@@ -1,3 +1,9 @@
+---
+description: "Set the caller's storage credit consumption mode. The mode only applies within the transaction that sets it; batch it with the storage operations it should govern."
+---
+
+_Generated from `cast storage-credits set-mode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-credits set-mode
 
 Set the caller's storage credit consumption mode.

--- a/src/pages/reference/cast/storage-root.mdx
+++ b/src/pages/reference/cast/storage-root.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the storage root for an account"
+---
+
+_Generated from `cast storage-root --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage-root
 
 Get the storage root for an account

--- a/src/pages/reference/cast/storage.mdx
+++ b/src/pages/reference/cast/storage.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the raw value of a contract's storage slot"
+---
+
+_Generated from `cast storage --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast storage
 
 Get the raw value of a contract's storage slot

--- a/src/pages/reference/cast/tempo.mdx
+++ b/src/pages/reference/cast/tempo.mdx
@@ -1,3 +1,9 @@
+---
+description: "Tempo wallet integration (login, etc.)"
+---
+
+_Generated from `cast tempo --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tempo
 
 Tempo wallet integration (login, etc.)

--- a/src/pages/reference/cast/tempo/login.mdx
+++ b/src/pages/reference/cast/tempo/login.mdx
@@ -1,3 +1,9 @@
+---
+description: "Authorize a new access key against your Tempo wallet via wallet.tempo. Persists the key to `$TEMPO_HOME/wallet/keys.toml` (default `~/.tempo/wallet/keys.toml`). Also runs automatically on a 402 from a Tempo RPC when no local key is configured. Env: `TEMPO_HOME`, `TEMPO_CLI_AUTH_URL` (override auth service)."
+---
+
+_Generated from `cast tempo login --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tempo login
 
 Authorize a new access key against your Tempo wallet via wallet.tempo.

--- a/src/pages/reference/cast/tip20-token.mdx
+++ b/src/pages/reference/cast/tip20-token.mdx
@@ -1,3 +1,9 @@
+---
+description: "TIP-20 token operations (Tempo)"
+---
+
+_Generated from `cast tip20-token --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip20-token
 
 TIP-20 token operations (Tempo)

--- a/src/pages/reference/cast/tip20-token/create.mdx
+++ b/src/pages/reference/cast/tip20-token/create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a new TIP-20 token via the TIP20Factory"
+---
+
+_Generated from `cast tip20-token create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip20-token create
 
 Create a new TIP-20 token via the TIP20Factory

--- a/src/pages/reference/cast/tip20-token/logo-check.mdx
+++ b/src/pages/reference/cast/tip20-token/logo-check.mdx
@@ -1,3 +1,9 @@
+---
+description: "Validate a TIP-20 logo URI offline against Tempo T5 constraints"
+---
+
+_Generated from `cast tip20-token logo-check --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip20-token logo-check
 
 Validate a TIP-20 logo URI offline against Tempo T5 constraints

--- a/src/pages/reference/cast/tip20-token/logo-set.mdx
+++ b/src/pages/reference/cast/tip20-token/logo-set.mdx
@@ -1,3 +1,9 @@
+---
+description: "Update a TIP-20 token logo URI"
+---
+
+_Generated from `cast tip20-token logo-set --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip20-token logo-set
 
 Update a TIP-20 token logo URI

--- a/src/pages/reference/cast/tip20-token/mine.mdx
+++ b/src/pages/reference/cast/tip20-token/mine.mdx
@@ -1,3 +1,9 @@
+---
+description: "Mine a TIP-1022 salt for virtual address' master registration on Tempo"
+---
+
+_Generated from `cast tip20-token mine --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip20-token mine
 
 Mine a TIP-1022 salt for virtual address' master registration on Tempo

--- a/src/pages/reference/cast/tip403.mdx
+++ b/src/pages/reference/cast/tip403.mdx
@@ -1,3 +1,9 @@
+---
+description: "TIP-403 policy registry operations (Tempo)"
+---
+
+_Generated from `cast tip403 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403
 
 TIP-403 policy registry operations (Tempo)

--- a/src/pages/reference/cast/tip403/blacklist.mdx
+++ b/src/pages/reference/cast/tip403/blacklist.mdx
@@ -1,3 +1,9 @@
+---
+description: "Add or remove an account from a blacklist policy"
+---
+
+_Generated from `cast tip403 blacklist --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403 blacklist
 
 Add or remove an account from a blacklist policy

--- a/src/pages/reference/cast/tip403/check.mdx
+++ b/src/pages/reference/cast/tip403/check.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check whether an address is authorized by a policy"
+---
+
+_Generated from `cast tip403 check --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403 check
 
 Check whether an address is authorized by a policy

--- a/src/pages/reference/cast/tip403/create.mdx
+++ b/src/pages/reference/cast/tip403/create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a new simple (whitelist or blacklist) policy"
+---
+
+_Generated from `cast tip403 create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403 create
 
 Create a new simple (whitelist or blacklist) policy

--- a/src/pages/reference/cast/tip403/info.mdx
+++ b/src/pages/reference/cast/tip403/info.mdx
@@ -1,3 +1,9 @@
+---
+description: "Show a policy's type and admin"
+---
+
+_Generated from `cast tip403 info --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403 info
 
 Show a policy's type and admin

--- a/src/pages/reference/cast/tip403/whitelist.mdx
+++ b/src/pages/reference/cast/tip403/whitelist.mdx
@@ -1,3 +1,9 @@
+---
+description: "Add or remove an account from a whitelist policy"
+---
+
+_Generated from `cast tip403 whitelist --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tip403 whitelist
 
 Add or remove an account from a whitelist policy

--- a/src/pages/reference/cast/to-ascii.mdx
+++ b/src/pages/reference/cast/to-ascii.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert hex data to an ASCII string"
+---
+
+_Generated from `cast to-ascii --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-ascii
 
 Convert hex data to an ASCII string

--- a/src/pages/reference/cast/to-base.mdx
+++ b/src/pages/reference/cast/to-base.mdx
@@ -1,3 +1,9 @@
+---
+description: "Converts a number of one base to another"
+---
+
+_Generated from `cast to-base --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-base
 
 Converts a number of one base to another

--- a/src/pages/reference/cast/to-bytes32.mdx
+++ b/src/pages/reference/cast/to-bytes32.mdx
@@ -1,3 +1,9 @@
+---
+description: "Right-pads hex data to 32 bytes"
+---
+
+_Generated from `cast to-bytes32 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-bytes32
 
 Right-pads hex data to 32 bytes

--- a/src/pages/reference/cast/to-check-sum-address.mdx
+++ b/src/pages/reference/cast/to-check-sum-address.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert an address to a checksummed format (EIP-55)"
+---
+
+_Generated from `cast to-check-sum-address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-check-sum-address
 
 Convert an address to a checksummed format (EIP-55)

--- a/src/pages/reference/cast/to-dec.mdx
+++ b/src/pages/reference/cast/to-dec.mdx
@@ -1,3 +1,9 @@
+---
+description: "Converts a number of one base to decimal"
+---
+
+_Generated from `cast to-dec --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-dec
 
 Converts a number of one base to decimal

--- a/src/pages/reference/cast/to-fixed-point.mdx
+++ b/src/pages/reference/cast/to-fixed-point.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert an integer into a fixed point number"
+---
+
+_Generated from `cast to-fixed-point --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-fixed-point
 
 Convert an integer into a fixed point number

--- a/src/pages/reference/cast/to-hex.mdx
+++ b/src/pages/reference/cast/to-hex.mdx
@@ -1,3 +1,9 @@
+---
+description: "Converts a number of one base to another"
+---
+
+_Generated from `cast to-hex --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-hex
 
 Converts a number of one base to another

--- a/src/pages/reference/cast/to-hexdata.mdx
+++ b/src/pages/reference/cast/to-hexdata.mdx
@@ -1,3 +1,9 @@
+---
+description: "Normalize the input to lowercase, 0x-prefixed hex. The input can be: - mixed case hex with or without 0x prefix - 0x prefixed hex, concatenated with a ':' - an absolute path to file - @tag, where the tag is defined in an environment variable"
+---
+
+_Generated from `cast to-hexdata --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-hexdata
 
 Normalize the input to lowercase, 0x-prefixed hex.

--- a/src/pages/reference/cast/to-int256.mdx
+++ b/src/pages/reference/cast/to-int256.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a number to a hex-encoded int256"
+---
+
+_Generated from `cast to-int256 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-int256
 
 Convert a number to a hex-encoded int256

--- a/src/pages/reference/cast/to-rlp.mdx
+++ b/src/pages/reference/cast/to-rlp.mdx
@@ -1,3 +1,9 @@
+---
+description: "RLP encodes hex data, or an array of hex data. Accepts a hex-encoded string, or an array of hex-encoded strings. Can be arbitrarily recursive. Examples: - `cast to-rlp \"[]\"` -> `0xc0` - `cast to-rlp \"0x22\"` -> `0x22` - `cast to-rlp \"[\\\"0x61\\\"]\"` -> `0xc161` - `cast to-rlp \"[\\\"0xf1\\\", \\\"f2\\\"]\"` -> `0xc481f181f2`"
+---
+
+_Generated from `cast to-rlp --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-rlp
 
 RLP encodes hex data, or an array of hex data.

--- a/src/pages/reference/cast/to-uint256.mdx
+++ b/src/pages/reference/cast/to-uint256.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a number to a hex-encoded uint256"
+---
+
+_Generated from `cast to-uint256 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-uint256
 
 Convert a number to a hex-encoded uint256

--- a/src/pages/reference/cast/to-unit.mdx
+++ b/src/pages/reference/cast/to-unit.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert an ETH amount into another unit (ether, gwei or wei). Examples: - 1ether wei - \"1 ether\" wei - 1ether - 1 gwei - 1gwei ether"
+---
+
+_Generated from `cast to-unit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-unit
 
 Convert an ETH amount into another unit (ether, gwei or wei).

--- a/src/pages/reference/cast/to-utf8.mdx
+++ b/src/pages/reference/cast/to-utf8.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert hex data to a utf-8 string"
+---
+
+_Generated from `cast to-utf8 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-utf8
 
 Convert hex data to a utf-8 string

--- a/src/pages/reference/cast/to-wei.mdx
+++ b/src/pages/reference/cast/to-wei.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert an ETH amount to wei. Consider using --to-unit."
+---
+
+_Generated from `cast to-wei --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast to-wei
 
 Convert an ETH amount to wei.

--- a/src/pages/reference/cast/trace.mdx
+++ b/src/pages/reference/cast/trace.mdx
@@ -1,3 +1,9 @@
+---
+description: "CLI arguments for `cast trace`"
+---
+
+_Generated from `cast trace --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast trace
 
 CLI arguments for `cast trace`

--- a/src/pages/reference/cast/tx-pool.mdx
+++ b/src/pages/reference/cast/tx-pool.mdx
@@ -1,3 +1,9 @@
+---
+description: "Inspect the TxPool of a node"
+---
+
+_Generated from `cast tx-pool --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx-pool
 
 Inspect the TxPool of a node

--- a/src/pages/reference/cast/tx-pool/content-from.mdx
+++ b/src/pages/reference/cast/tx-pool/content-from.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetches the content of the transaction pool filtered by a specific address"
+---
+
+_Generated from `cast tx-pool content-from --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx-pool content-from
 
 Fetches the content of the transaction pool filtered by a specific address

--- a/src/pages/reference/cast/tx-pool/content.mdx
+++ b/src/pages/reference/cast/tx-pool/content.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetches the content of the transaction pool"
+---
+
+_Generated from `cast tx-pool content --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx-pool content
 
 Fetches the content of the transaction pool

--- a/src/pages/reference/cast/tx-pool/inspect.mdx
+++ b/src/pages/reference/cast/tx-pool/inspect.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetches a textual summary of each transaction in the pool"
+---
+
+_Generated from `cast tx-pool inspect --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx-pool inspect
 
 Fetches a textual summary of each transaction in the pool

--- a/src/pages/reference/cast/tx-pool/status.mdx
+++ b/src/pages/reference/cast/tx-pool/status.mdx
@@ -1,3 +1,9 @@
+---
+description: "Fetches the current status of the transaction pool"
+---
+
+_Generated from `cast tx-pool status --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx-pool status
 
 Fetches the current status of the transaction pool

--- a/src/pages/reference/cast/tx.mdx
+++ b/src/pages/reference/cast/tx.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get information about a transaction"
+---
+
+_Generated from `cast tx --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast tx
 
 Get information about a transaction

--- a/src/pages/reference/cast/upload-signature.mdx
+++ b/src/pages/reference/cast/upload-signature.mdx
@@ -1,3 +1,9 @@
+---
+description: "Upload the given signatures to <https://openchain.xyz>. Example inputs: - \"transfer(address,uint256)\" - \"function transfer(address,uint256)\" - \"function transfer(address,uint256)\" \"event Transfer(address,address,uint256)\" - \"./out/Contract.sol/Contract.json\""
+---
+
+_Generated from `cast upload-signature --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast upload-signature
 
 Upload the given signatures to [https://openchain.xyz](https://openchain.xyz).

--- a/src/pages/reference/cast/virtual-address.mdx
+++ b/src/pages/reference/cast/virtual-address.mdx
@@ -1,3 +1,9 @@
+---
+description: "TIP-1022 virtual address registry operations (Tempo)"
+---
+
+_Generated from `cast virtual-address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast virtual-address
 
 TIP-1022 virtual address registry operations (Tempo)

--- a/src/pages/reference/cast/virtual-address/create.mdx
+++ b/src/pages/reference/cast/virtual-address/create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Mine a TIP-1022 proof-of-work salt, register as a virtual address master, and print derived virtual addresses for the given owner"
+---
+
+_Generated from `cast virtual-address create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast virtual-address create
 
 Mine a TIP-1022 proof-of-work salt, register as a virtual address master, and

--- a/src/pages/reference/cast/virtual-address/resolve.mdx
+++ b/src/pages/reference/cast/virtual-address/resolve.mdx
@@ -1,3 +1,9 @@
+---
+description: "Resolve a virtual address to its registered master and decode its components"
+---
+
+_Generated from `cast virtual-address resolve --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast virtual-address resolve
 
 Resolve a virtual address to its registered master and decode its components

--- a/src/pages/reference/cast/virtual-address/watch.mdx
+++ b/src/pages/reference/cast/virtual-address/watch.mdx
@@ -1,3 +1,9 @@
+---
+description: "Watch (tail) incoming TIP-20 transfers to a virtual address"
+---
+
+_Generated from `cast virtual-address watch --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast virtual-address watch
 
 Watch (tail) incoming TIP-20 transfers to a virtual address

--- a/src/pages/reference/cast/wallet.mdx
+++ b/src/pages/reference/cast/wallet.mdx
@@ -1,3 +1,9 @@
+---
+description: "Wallet management utilities"
+---
+
+_Generated from `cast wallet --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet
 
 Wallet management utilities

--- a/src/pages/reference/cast/wallet/address.mdx
+++ b/src/pages/reference/cast/wallet/address.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a private key to an address"
+---
+
+_Generated from `cast wallet address --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet address
 
 Convert a private key to an address

--- a/src/pages/reference/cast/wallet/change-password.mdx
+++ b/src/pages/reference/cast/wallet/change-password.mdx
@@ -1,3 +1,9 @@
+---
+description: "Change the password of a keystore file"
+---
+
+_Generated from `cast wallet change-password --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet change-password
 
 Change the password of a keystore file

--- a/src/pages/reference/cast/wallet/decrypt-keystore.mdx
+++ b/src/pages/reference/cast/wallet/decrypt-keystore.mdx
@@ -1,3 +1,9 @@
+---
+description: "Decrypt a keystore file to get the private key"
+---
+
+_Generated from `cast wallet decrypt-keystore --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet decrypt-keystore
 
 Decrypt a keystore file to get the private key

--- a/src/pages/reference/cast/wallet/derive.mdx
+++ b/src/pages/reference/cast/wallet/derive.mdx
@@ -1,3 +1,9 @@
+---
+description: "Derive accounts from a mnemonic"
+---
+
+_Generated from `cast wallet derive --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet derive
 
 Derive accounts from a mnemonic

--- a/src/pages/reference/cast/wallet/import.mdx
+++ b/src/pages/reference/cast/wallet/import.mdx
@@ -1,3 +1,9 @@
+---
+description: "Import a private key into an encrypted keystore"
+---
+
+_Generated from `cast wallet import --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet import
 
 Import a private key into an encrypted keystore

--- a/src/pages/reference/cast/wallet/list.mdx
+++ b/src/pages/reference/cast/wallet/list.mdx
@@ -1,3 +1,9 @@
+---
+description: "List all the accounts in the keystore default directory"
+---
+
+_Generated from `cast wallet list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet list
 
 List all the accounts in the keystore default directory

--- a/src/pages/reference/cast/wallet/new-mnemonic.mdx
+++ b/src/pages/reference/cast/wallet/new-mnemonic.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generates a random BIP39 mnemonic phrase"
+---
+
+_Generated from `cast wallet new-mnemonic --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet new-mnemonic
 
 Generates a random BIP39 mnemonic phrase

--- a/src/pages/reference/cast/wallet/new.mdx
+++ b/src/pages/reference/cast/wallet/new.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a new random keypair"
+---
+
+_Generated from `cast wallet new --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet new
 
 Create a new random keypair

--- a/src/pages/reference/cast/wallet/private-key.mdx
+++ b/src/pages/reference/cast/wallet/private-key.mdx
@@ -1,3 +1,9 @@
+---
+description: "Derives private key from mnemonic"
+---
+
+_Generated from `cast wallet private-key --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet private-key
 
 Derives private key from mnemonic

--- a/src/pages/reference/cast/wallet/public-key.mdx
+++ b/src/pages/reference/cast/wallet/public-key.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the public key for the given private key"
+---
+
+_Generated from `cast wallet public-key --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet public-key
 
 Get the public key for the given private key

--- a/src/pages/reference/cast/wallet/remove.mdx
+++ b/src/pages/reference/cast/wallet/remove.mdx
@@ -1,3 +1,9 @@
+---
+description: "Remove a wallet from the keystore. This command requires the wallet alias and will prompt for a password to ensure that only an authorized user can remove the wallet."
+---
+
+_Generated from `cast wallet remove --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet remove
 
 Remove a wallet from the keystore.

--- a/src/pages/reference/cast/wallet/session.mdx
+++ b/src/pages/reference/cast/wallet/session.mdx
@@ -1,3 +1,9 @@
+---
+description: "Manage temporary Tempo wallet sessions"
+---
+
+_Generated from `cast wallet session --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet session
 
 Manage temporary Tempo wallet sessions

--- a/src/pages/reference/cast/wallet/session/create.mdx
+++ b/src/pages/reference/cast/wallet/session/create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a temporary Tempo session and persist it locally"
+---
+
+_Generated from `cast wallet session create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet session create
 
 Create a temporary Tempo session and persist it locally

--- a/src/pages/reference/cast/wallet/session/revoke.mdx
+++ b/src/pages/reference/cast/wallet/session/revoke.mdx
@@ -1,3 +1,9 @@
+---
+description: "Revoke a Tempo session key on-chain when provisioned, then clear local key material"
+---
+
+_Generated from `cast wallet session revoke --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet session revoke
 
 Revoke a Tempo session key on-chain when provisioned, then clear local key

--- a/src/pages/reference/cast/wallet/sign-auth.mdx
+++ b/src/pages/reference/cast/wallet/sign-auth.mdx
@@ -1,3 +1,9 @@
+---
+description: "EIP-7702 sign authorization"
+---
+
+_Generated from `cast wallet sign-auth --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet sign-auth
 
 EIP-7702 sign authorization

--- a/src/pages/reference/cast/wallet/sign.mdx
+++ b/src/pages/reference/cast/wallet/sign.mdx
@@ -1,3 +1,9 @@
+---
+description: "Sign a message or typed data"
+---
+
+_Generated from `cast wallet sign --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet sign
 
 Sign a message or typed data

--- a/src/pages/reference/cast/wallet/vanity.mdx
+++ b/src/pages/reference/cast/wallet/vanity.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate a vanity address"
+---
+
+_Generated from `cast wallet vanity --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet vanity
 
 Generate a vanity address

--- a/src/pages/reference/cast/wallet/verify.mdx
+++ b/src/pages/reference/cast/wallet/verify.mdx
@@ -1,3 +1,9 @@
+---
+description: "Verify the signature of a message"
+---
+
+_Generated from `cast wallet verify --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## cast wallet verify
 
 Verify the signature of a message

--- a/src/pages/reference/chisel/chisel.mdx
+++ b/src/pages/reference/chisel/chisel.mdx
@@ -1,4 +1,14 @@
+---
+description: "Fast, utilitarian, and verbose Solidity REPL"
+---
+
+_Generated from `chisel --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel
+
+:::note[Generated CLI reference]
+This reference is generated from the installed command's `--help` output. See [CLI reference versions](/reference/versions) for the exact binaries used.
+:::
 
 Fast, utilitarian, and verbose Solidity REPL
 

--- a/src/pages/reference/chisel/clear-cache.mdx
+++ b/src/pages/reference/chisel/clear-cache.mdx
@@ -1,3 +1,9 @@
+---
+description: "Clear all cached chisel sessions from the cache directory"
+---
+
+_Generated from `chisel clear-cache --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel clear-cache
 
 Clear all cached chisel sessions from the cache directory

--- a/src/pages/reference/chisel/eval.mdx
+++ b/src/pages/reference/chisel/eval.mdx
@@ -1,3 +1,9 @@
+---
+description: "Simple evaluation of a command without entering the REPL"
+---
+
+_Generated from `chisel eval --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel eval
 
 Simple evaluation of a command without entering the REPL

--- a/src/pages/reference/chisel/list.mdx
+++ b/src/pages/reference/chisel/list.mdx
@@ -1,3 +1,9 @@
+---
+description: "List all cached sessions"
+---
+
+_Generated from `chisel list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel list
 
 List all cached sessions

--- a/src/pages/reference/chisel/load.mdx
+++ b/src/pages/reference/chisel/load.mdx
@@ -1,3 +1,9 @@
+---
+description: "Load a cached session"
+---
+
+_Generated from `chisel load --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel load
 
 Load a cached session

--- a/src/pages/reference/chisel/view.mdx
+++ b/src/pages/reference/chisel/view.mdx
@@ -1,3 +1,9 @@
+---
+description: "View the source of a cached session"
+---
+
+_Generated from `chisel view --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## chisel view
 
 View the source of a cached session

--- a/src/pages/reference/forge/bind-json.mdx
+++ b/src/pages/reference/forge/bind-json.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate bindings for serialization/deserialization of project structs via JSON cheatcodes"
+---
+
+_Generated from `forge bind-json --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge bind-json
 
 Generate bindings for serialization/deserialization of project structs via JSON

--- a/src/pages/reference/forge/bind.mdx
+++ b/src/pages/reference/forge/bind.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate Rust bindings for smart contracts"
+---
+
+_Generated from `forge bind --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge bind
 
 Generate Rust bindings for smart contracts

--- a/src/pages/reference/forge/build.mdx
+++ b/src/pages/reference/forge/build.mdx
@@ -1,3 +1,9 @@
+---
+description: "Build the project's smart contracts"
+---
+
+_Generated from `forge build --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge build
 
 Build the project's smart contracts

--- a/src/pages/reference/forge/cache.mdx
+++ b/src/pages/reference/forge/cache.mdx
@@ -1,3 +1,9 @@
+---
+description: "Manage the Foundry cache"
+---
+
+_Generated from `forge cache --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge cache
 
 Manage the Foundry cache

--- a/src/pages/reference/forge/cache/clean.mdx
+++ b/src/pages/reference/forge/cache/clean.mdx
@@ -1,3 +1,9 @@
+---
+description: "Cleans cached data from the global foundry directory"
+---
+
+_Generated from `forge cache clean --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge cache clean
 
 Cleans cached data from the global foundry directory

--- a/src/pages/reference/forge/cache/ls.mdx
+++ b/src/pages/reference/forge/cache/ls.mdx
@@ -1,3 +1,9 @@
+---
+description: "Shows cached data from the global foundry directory"
+---
+
+_Generated from `forge cache ls --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge cache ls
 
 Shows cached data from the global foundry directory

--- a/src/pages/reference/forge/clean.mdx
+++ b/src/pages/reference/forge/clean.mdx
@@ -1,3 +1,9 @@
+---
+description: "Remove the build artifacts and cache directories"
+---
+
+_Generated from `forge clean --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge clean
 
 Remove the build artifacts and cache directories

--- a/src/pages/reference/forge/clone.mdx
+++ b/src/pages/reference/forge/clone.mdx
@@ -1,3 +1,9 @@
+---
+description: "Clone a contract from Etherscan"
+---
+
+_Generated from `forge clone --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge clone
 
 Clone a contract from Etherscan

--- a/src/pages/reference/forge/compiler.mdx
+++ b/src/pages/reference/forge/compiler.mdx
@@ -1,3 +1,9 @@
+---
+description: "Compiler utilities"
+---
+
+_Generated from `forge compiler --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge compiler
 
 Compiler utilities

--- a/src/pages/reference/forge/compiler/resolve.mdx
+++ b/src/pages/reference/forge/compiler/resolve.mdx
@@ -1,3 +1,9 @@
+---
+description: "Retrieves the resolved version(s) of the compiler within the project"
+---
+
+_Generated from `forge compiler resolve --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge compiler resolve
 
 Retrieves the resolved version(s) of the compiler within the project

--- a/src/pages/reference/forge/completions.mdx
+++ b/src/pages/reference/forge/completions.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate shell completions script"
+---
+
+_Generated from `forge completions --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge completions
 
 Generate shell completions script

--- a/src/pages/reference/forge/config.mdx
+++ b/src/pages/reference/forge/config.mdx
@@ -1,3 +1,9 @@
+---
+description: "Display the current config"
+---
+
+_Generated from `forge config --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge config
 
 Display the current config

--- a/src/pages/reference/forge/coverage.mdx
+++ b/src/pages/reference/forge/coverage.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate coverage reports"
+---
+
+_Generated from `forge coverage --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge coverage
 
 Generate coverage reports

--- a/src/pages/reference/forge/create.mdx
+++ b/src/pages/reference/forge/create.mdx
@@ -1,3 +1,9 @@
+---
+description: "Deploy a smart contract"
+---
+
+_Generated from `forge create --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge create
 
 Deploy a smart contract

--- a/src/pages/reference/forge/doc.mdx
+++ b/src/pages/reference/forge/doc.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate documentation for the project"
+---
+
+_Generated from `forge doc --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge doc
 
 Generate documentation for the project

--- a/src/pages/reference/forge/eip712.mdx
+++ b/src/pages/reference/forge/eip712.mdx
@@ -1,3 +1,9 @@
+---
+description: "Generate EIP-712 struct encodings for structs from a given file"
+---
+
+_Generated from `forge eip712 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge eip712
 
 Generate EIP-712 struct encodings for structs from a given file

--- a/src/pages/reference/forge/flatten.mdx
+++ b/src/pages/reference/forge/flatten.mdx
@@ -1,3 +1,9 @@
+---
+description: "Flatten a source file and all of its imports into one file"
+---
+
+_Generated from `forge flatten --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge flatten
 
 Flatten a source file and all of its imports into one file

--- a/src/pages/reference/forge/fmt.mdx
+++ b/src/pages/reference/forge/fmt.mdx
@@ -1,3 +1,9 @@
+---
+description: "Format Solidity source files"
+---
+
+_Generated from `forge fmt --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fmt
 
 Format Solidity source files

--- a/src/pages/reference/forge/forge.mdx
+++ b/src/pages/reference/forge/forge.mdx
@@ -1,4 +1,14 @@
+---
+description: "Build, test, fuzz, debug and deploy Solidity contracts"
+---
+
+_Generated from `forge --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge
+
+:::note[Generated CLI reference]
+This reference is generated from the installed command's `--help` output. See [CLI reference versions](/reference/versions) for the exact binaries used.
+:::
 
 Build, test, fuzz, debug and deploy Solidity contracts
 

--- a/src/pages/reference/forge/fuzz.mdx
+++ b/src/pages/reference/forge/fuzz.mdx
@@ -1,3 +1,9 @@
+---
+description: "Run and manage Forge fuzzing corpora"
+---
+
+_Generated from `forge fuzz --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz
 
 Run and manage Forge fuzzing corpora

--- a/src/pages/reference/forge/fuzz/cmin.mdx
+++ b/src/pages/reference/forge/fuzz/cmin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Minimize a corpus by keeping entries that contribute new coverage"
+---
+
+_Generated from `forge fuzz cmin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz cmin
 
 Minimize a corpus by keeping entries that contribute new coverage

--- a/src/pages/reference/forge/fuzz/replay.mdx
+++ b/src/pages/reference/forge/fuzz/replay.mdx
@@ -1,3 +1,9 @@
+---
+description: "Replay persisted fuzz failures, or corpus entries with `--corpus-dir`"
+---
+
+_Generated from `forge fuzz replay --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz replay
 
 Replay persisted fuzz failures, or corpus entries with `--corpus-dir`

--- a/src/pages/reference/forge/fuzz/run.mdx
+++ b/src/pages/reference/forge/fuzz/run.mdx
@@ -1,3 +1,9 @@
+---
+description: "Run only fuzz and invariant tests"
+---
+
+_Generated from `forge fuzz run --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz run
 
 Run only fuzz and invariant tests

--- a/src/pages/reference/forge/fuzz/show.mdx
+++ b/src/pages/reference/forge/fuzz/show.mdx
@@ -1,3 +1,9 @@
+---
+description: "Print persisted corpus entries"
+---
+
+_Generated from `forge fuzz show --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz show
 
 Print persisted corpus entries

--- a/src/pages/reference/forge/fuzz/tmin.mdx
+++ b/src/pages/reference/forge/fuzz/tmin.mdx
@@ -1,3 +1,9 @@
+---
+description: "Minimize one corpus entry while preserving its failure or coverage"
+---
+
+_Generated from `forge fuzz tmin --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge fuzz tmin
 
 Minimize one corpus entry while preserving its failure or coverage

--- a/src/pages/reference/forge/geiger.mdx
+++ b/src/pages/reference/forge/geiger.mdx
@@ -1,3 +1,9 @@
+---
+description: "DEPRECATED: Detects usage of unsafe cheat codes in a project and its dependencies. This is an alias for `forge lint --only-lint unsafe-cheatcode`."
+---
+
+_Generated from `forge geiger --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge geiger
 
 DEPRECATED: Detects usage of unsafe cheat codes in a project and its

--- a/src/pages/reference/forge/init.mdx
+++ b/src/pages/reference/forge/init.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a new Forge project"
+---
+
+_Generated from `forge init --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge init
 
 Create a new Forge project

--- a/src/pages/reference/forge/inspect.mdx
+++ b/src/pages/reference/forge/inspect.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get specialized information about a smart contract"
+---
+
+_Generated from `forge inspect --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge inspect
 
 Get specialized information about a smart contract

--- a/src/pages/reference/forge/install.mdx
+++ b/src/pages/reference/forge/install.mdx
@@ -1,3 +1,9 @@
+---
+description: "Install one or multiple dependencies. If no arguments are provided, then existing dependencies will be installed."
+---
+
+_Generated from `forge install --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge install
 
 Install one or multiple dependencies.

--- a/src/pages/reference/forge/lint.mdx
+++ b/src/pages/reference/forge/lint.mdx
@@ -1,3 +1,9 @@
+---
+description: "Lint Solidity source files"
+---
+
+_Generated from `forge lint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge lint
 
 Lint Solidity source files

--- a/src/pages/reference/forge/remappings.mdx
+++ b/src/pages/reference/forge/remappings.mdx
@@ -1,3 +1,9 @@
+---
+description: "Get the automatically inferred remappings for the project"
+---
+
+_Generated from `forge remappings --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge remappings
 
 Get the automatically inferred remappings for the project

--- a/src/pages/reference/forge/remove.mdx
+++ b/src/pages/reference/forge/remove.mdx
@@ -1,3 +1,9 @@
+---
+description: "Remove one or multiple dependencies"
+---
+
+_Generated from `forge remove --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge remove
 
 Remove one or multiple dependencies

--- a/src/pages/reference/forge/script.mdx
+++ b/src/pages/reference/forge/script.mdx
@@ -1,3 +1,9 @@
+---
+description: "Run a smart contract as a script, building transactions that can be sent onchain"
+---
+
+_Generated from `forge script --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge script
 
 Run a smart contract as a script, building transactions that can be sent onchain

--- a/src/pages/reference/forge/selectors.mdx
+++ b/src/pages/reference/forge/selectors.mdx
@@ -1,3 +1,9 @@
+---
+description: "Function selector utilities"
+---
+
+_Generated from `forge selectors --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors
 
 Function selector utilities

--- a/src/pages/reference/forge/selectors/cache.mdx
+++ b/src/pages/reference/forge/selectors/cache.mdx
@@ -1,3 +1,9 @@
+---
+description: "Cache project selectors (enables trace with local contracts functions and events)"
+---
+
+_Generated from `forge selectors cache --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors cache
 
 Cache project selectors (enables trace with local contracts functions and

--- a/src/pages/reference/forge/selectors/collision.mdx
+++ b/src/pages/reference/forge/selectors/collision.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check for selector collisions between contracts"
+---
+
+_Generated from `forge selectors collision --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors collision
 
 Check for selector collisions between contracts

--- a/src/pages/reference/forge/selectors/find.mdx
+++ b/src/pages/reference/forge/selectors/find.mdx
@@ -1,3 +1,9 @@
+---
+description: "Find if a selector is present in the project"
+---
+
+_Generated from `forge selectors find --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors find
 
 Find if a selector is present in the project

--- a/src/pages/reference/forge/selectors/list.mdx
+++ b/src/pages/reference/forge/selectors/list.mdx
@@ -1,3 +1,9 @@
+---
+description: "List selectors from current workspace"
+---
+
+_Generated from `forge selectors list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors list
 
 List selectors from current workspace

--- a/src/pages/reference/forge/selectors/upload.mdx
+++ b/src/pages/reference/forge/selectors/upload.mdx
@@ -1,3 +1,9 @@
+---
+description: "Upload selectors to registry"
+---
+
+_Generated from `forge selectors upload --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge selectors upload
 
 Upload selectors to registry

--- a/src/pages/reference/forge/snapshot.mdx
+++ b/src/pages/reference/forge/snapshot.mdx
@@ -1,3 +1,9 @@
+---
+description: "Create a gas snapshot of each test's gas usage"
+---
+
+_Generated from `forge snapshot --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge snapshot
 
 Create a gas snapshot of each test's gas usage

--- a/src/pages/reference/forge/soldeer.mdx
+++ b/src/pages/reference/forge/soldeer.mdx
@@ -1,3 +1,9 @@
+---
+description: "Soldeer dependency manager"
+---
+
+_Generated from `forge soldeer --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer
 
 Soldeer dependency manager

--- a/src/pages/reference/forge/soldeer/clean.mdx
+++ b/src/pages/reference/forge/soldeer/clean.mdx
@@ -1,3 +1,9 @@
+---
+description: "Clean downloaded dependencies and generated artifacts"
+---
+
+_Generated from `forge soldeer clean --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer clean
 
 Clean downloaded dependencies and generated artifacts

--- a/src/pages/reference/forge/soldeer/init.mdx
+++ b/src/pages/reference/forge/soldeer/init.mdx
@@ -1,3 +1,9 @@
+---
+description: "Convert a Foundry project to use Soldeer"
+---
+
+_Generated from `forge soldeer init --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer init
 
 Convert a Foundry project to use Soldeer

--- a/src/pages/reference/forge/soldeer/install.mdx
+++ b/src/pages/reference/forge/soldeer/install.mdx
@@ -1,3 +1,9 @@
+---
+description: "Install a dependency If used with arguments, a dependency will be added to the configuration. When used without argument, installs all dependencies that are missing. Examples: - Install all: soldeer install - Add from registry: soldeer install lib_name~2.3.0 - Add with custom URL: soldeer install lib_name~2.3.0 --url https://foo.bar/lib.zip - Add with git: soldeer install lib_name~2.3.0 --git git@github.com:foo/bar.git - Add with git (commit): soldeer install lib_name~2.3.0 --git git@github.com:foo/bar.git --rev 05f218fb6617932e56bf5388c3b389c3028a7b73 - Add with git (tag): soldeer install lib_name~2.3.0 --git git@github.com:foo/bar.git --tag v2.3.0 - Add with git (branch): soldeer install lib_name~2.3.0 --git git@github.com:foo/bar.git --branch feature/baz"
+---
+
+_Generated from `forge soldeer install --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer install
 
 Install a dependency

--- a/src/pages/reference/forge/soldeer/login.mdx
+++ b/src/pages/reference/forge/soldeer/login.mdx
@@ -1,3 +1,9 @@
+---
+description: "Log into the central repository to push packages The credentials are saved by default into ~/.soldeer. If you want to overwrite that location, use the SOLDEER_LOGIN_FILE env var."
+---
+
+_Generated from `forge soldeer login --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer login
 
 Log into the central repository to push packages

--- a/src/pages/reference/forge/soldeer/push.mdx
+++ b/src/pages/reference/forge/soldeer/push.mdx
@@ -1,3 +1,9 @@
+---
+description: "Push a dependency to the soldeer.xyz repository. You need to be logged in first (soldeer login) or provide the `SOLDEER_API_TOKEN` environment variable with a valid CLI token generated on soldeer.xyz. Examples: - Current directory: soldeer push mypkg~0.1.0 - Custom directory: soldeer push mypkg~0.1.0 /path/to/dep - Dry run: soldeer push mypkg~0.1.0 --dry-run To ignore certain files, create a `.soldeerignore` file in the root of the project and add the files you want to ignore. The `.soldeerignore` uses the same syntax as `.gitignore`."
+---
+
+_Generated from `forge soldeer push --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer push
 
 Push a dependency to the soldeer.xyz repository.

--- a/src/pages/reference/forge/soldeer/uninstall.mdx
+++ b/src/pages/reference/forge/soldeer/uninstall.mdx
@@ -1,3 +1,9 @@
+---
+description: "Uninstall a dependency"
+---
+
+_Generated from `forge soldeer uninstall --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer uninstall
 
 Uninstall a dependency

--- a/src/pages/reference/forge/soldeer/update.mdx
+++ b/src/pages/reference/forge/soldeer/update.mdx
@@ -1,3 +1,9 @@
+---
+description: "Update dependencies by reading the config file"
+---
+
+_Generated from `forge soldeer update --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer update
 
 Update dependencies by reading the config file

--- a/src/pages/reference/forge/soldeer/version.mdx
+++ b/src/pages/reference/forge/soldeer/version.mdx
@@ -1,3 +1,9 @@
+---
+description: "Display the version of Soldeer"
+---
+
+_Generated from `forge soldeer version --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge soldeer version
 
 Display the version of Soldeer

--- a/src/pages/reference/forge/test.mdx
+++ b/src/pages/reference/forge/test.mdx
@@ -1,3 +1,9 @@
+---
+description: "Run the project's tests"
+---
+
+_Generated from `forge test --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge test
 
 Run the project's tests

--- a/src/pages/reference/forge/tree.mdx
+++ b/src/pages/reference/forge/tree.mdx
@@ -1,3 +1,9 @@
+---
+description: "Display a tree visualization of the project's dependency graph"
+---
+
+_Generated from `forge tree --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge tree
 
 Display a tree visualization of the project's dependency graph

--- a/src/pages/reference/forge/update.mdx
+++ b/src/pages/reference/forge/update.mdx
@@ -1,3 +1,9 @@
+---
+description: "Update one or multiple dependencies. If no arguments are provided, then all dependencies are updated."
+---
+
+_Generated from `forge update --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge update
 
 Update one or multiple dependencies.

--- a/src/pages/reference/forge/verify-bytecode.mdx
+++ b/src/pages/reference/forge/verify-bytecode.mdx
@@ -1,3 +1,9 @@
+---
+description: "Verify the deployed bytecode against its source on Etherscan"
+---
+
+_Generated from `forge verify-bytecode --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge verify-bytecode
 
 Verify the deployed bytecode against its source on Etherscan

--- a/src/pages/reference/forge/verify-check.mdx
+++ b/src/pages/reference/forge/verify-check.mdx
@@ -1,3 +1,9 @@
+---
+description: "Check verification status on the selected verifier"
+---
+
+_Generated from `forge verify-check --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge verify-check
 
 Check verification status on the selected verifier

--- a/src/pages/reference/forge/verify-contract.mdx
+++ b/src/pages/reference/forge/verify-contract.mdx
@@ -1,3 +1,9 @@
+---
+description: "Verify smart contracts on Etherscan and Sourcify"
+---
+
+_Generated from `forge verify-contract --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
 ## forge verify-contract
 
 Verify smart contracts on Etherscan and Sourcify

--- a/src/pages/reference/versions.mdx
+++ b/src/pages/reference/versions.mdx
@@ -1,0 +1,43 @@
+---
+description: Exact Foundry binary versions used to generate the CLI command reference.
+---
+
+## CLI reference versions
+
+The CLI pages under `/reference` are generated from the following installed binaries. Use this page to distinguish documentation drift from behavior in a different stable or nightly release.
+
+### `forge`
+
+```text
+forge Version: 1.7.2-nightly
+Commit SHA: 61a1bb421e4aa5c4ce38da57f5e9064b0aff3330
+Build Timestamp: 2026-07-13T07:05:41.632297000Z (1783926341)
+Build Profile: dist
+```
+
+### `cast`
+
+```text
+cast Version: 1.7.2-nightly
+Commit SHA: 61a1bb421e4aa5c4ce38da57f5e9064b0aff3330
+Build Timestamp: 2026-07-13T07:05:41.632297000Z (1783926341)
+Build Profile: dist
+```
+
+### `anvil`
+
+```text
+anvil Version: 1.7.2-nightly
+Commit SHA: 61a1bb421e4aa5c4ce38da57f5e9064b0aff3330
+Build Timestamp: 2026-07-13T07:05:41.632297000Z (1783926341)
+Build Profile: dist
+```
+
+### `chisel`
+
+```text
+chisel Version: 1.7.2-nightly
+Commit SHA: 61a1bb421e4aa5c4ce38da57f5e9064b0aff3330
+Build Timestamp: 2026-07-13T07:05:41.632297000Z (1783926341)
+Build Profile: dist
+```


### PR DESCRIPTION
Makes generated CLI reference pages attributable and searchable. The help generator now emits frontmatter descriptions for every command, a concise source marker on every page, and a visible provenance note on each root tool reference. It also generates one versions page containing the exact Forge, Cast, Anvil, and Chisel binaries, avoiding version churn across hundreds of files while giving people and agents a canonical place to resolve nightly drift. The reference files in this pull request were regenerated without substantive command-help changes.