### PR TITLE
docs: add reference overview

### DIFF
--- a/src/pages/reference/README.md
+++ b/src/pages/reference/README.md
@@ -1,9 +1,0 @@
-## References
-
-- [forge Commands](/reference/forge/forge)
-- [cast Commands](/reference/cast/cast)
-- [anvil Reference](/reference/anvil/anvil)
-- [chisel Reference](/reference/chisel/chisel)
-- [Config Reference](/config/reference/overview)
-- [Cheatcodes Reference](/reference/cheatcodes/overview)
-- [Forge Standard Library Reference](/reference/forge-std/overview)

--- a/src/pages/reference/index.mdx
+++ b/src/pages/reference/index.mdx
@@ -1,0 +1,64 @@
+---
+description: Find exact CLI, cheatcode, Forge Std, and configuration reference documentation for Foundry.
+---
+
+import { Cards, Card } from 'vocs'
+
+## Reference
+
+Use these pages when you know which command, option, cheatcode, helper, or configuration key you need. For task-oriented explanations and complete workflows, start with the [documentation](/introduction/getting-started) or [guides](/guides) instead.
+
+### Command-line tools
+
+<Cards>
+  <Card
+    title="Forge"
+    description="Commands and options for building, testing, scripting, deploying, and verifying contracts."
+    to="/reference/forge/forge"
+    icon="lucide:hammer"
+  />
+  <Card
+    title="Cast"
+    description="Commands and options for querying chains, encoding data, signing, and sending transactions."
+    to="/reference/cast/cast"
+    icon="lucide:terminal"
+  />
+  <Card
+    title="Anvil"
+    description="Options for configuring and running a local Ethereum development node."
+    to="/reference/anvil/anvil"
+    icon="lucide:server"
+  />
+  <Card
+    title="Chisel"
+    description="Commands and options for the interactive Solidity REPL."
+    to="/reference/chisel/chisel"
+    icon="lucide:code"
+  />
+</Cards>
+
+### Solidity APIs
+
+<Cards>
+  <Card
+    title="Cheatcodes"
+    description="VM functions for controlling state, calls, accounts, forks, and test execution."
+    to="/reference/cheatcodes/overview"
+  />
+  <Card
+    title="Forge Std"
+    description="Contracts, interfaces, assertions, logging helpers, and testing utilities."
+    to="/reference/forge-std/overview"
+  />
+</Cards>
+
+### Project configuration
+
+<Cards>
+  <Card
+    title="Configuration"
+    description="Every foundry.toml setting, environment variable, and profile option."
+    to="/config/reference/overview"
+    icon="lucide:settings"
+  />
+</Cards>

--- a/src/pages/reference/index.mdx
+++ b/src/pages/reference/index.mdx
@@ -57,7 +57,7 @@ Use these pages when you know which command, option, cheatcode, helper, or confi
 <Cards>
   <Card
     title="Configuration"
-    description="Every foundry.toml setting, environment variable, and profile option."
+    description="Configuration keys, profiles, and environment-variable overrides."
     to="/config/reference/overview"
     icon="lucide:settings"
   />

--- a/vercel.json
+++ b/vercel.json
@@ -98,7 +98,7 @@
     { "source": "/reference/cli/chisel/:id", "destination": "/reference/chisel/:id" },
     { "source": "/reference/cli/chisel", "destination": "/reference/chisel/chisel" },
     { "source": "/reference/cli", "destination": "/reference/forge/forge" },
-    { "source": "/reference", "destination": "/reference/forge/forge" },
+    { "source": "/reference/README", "destination": "/reference" },
 
     { "source": "/cheatcodes/:id", "destination": "/reference/cheatcodes/:id" },
     { "source": "/cheatcodes", "destination": "/reference/cheatcodes/overview" },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
       text: "Reference",
       items: [
         {
+          text: "Overview",
+          link: "/reference",
+        },
+        {
           text: "forge",
           link: "/reference/forge/forge",
         },
@@ -93,6 +97,10 @@ export default defineConfig({
         {
           text: "Forge Std",
           link: "/reference/forge-std/overview",
+        },
+        {
+          text: "Configuration",
+          link: "/config/reference/overview",
         },
       ],
     },


### PR DESCRIPTION
The `/reference` route currently redirects directly to the Forge CLI output, which makes the other reference families difficult to discover and gives agents no useful reference entry point. This adds a concise landing page that routes readers to every CLI, Solidity API, and configuration reference while distinguishing exact lookup pages from task-oriented documentation and guides.

The Reference menu now includes the overview and configuration, and the former `/reference/README` route redirects to the new canonical page.