### PR TITLE
docs(lint): add selector collision

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -51,6 +51,7 @@ const docs = [
               { text: "encode-packed-collision", link: "/forge/linting/encode-packed-collision" },
               { text: "enumerable-loop-removal", link: "/forge/linting/enumerable-loop-removal" },
               { text: "erc20-unchecked-transfer", link: "/forge/linting/erc20-unchecked-transfer" },
+              { text: "function-selector-collision", link: "/forge/linting/function-selector-collision" },
               { text: "incorrect-exp", link: "/forge/linting/incorrect-exp" },
               { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },
               { text: "reentrancy-eth", link: "/forge/linting/reentrancy-eth" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -161,6 +161,7 @@ navigation on the right to browse by severity.
 - [`encode-packed-collision`](/forge/linting/encode-packed-collision) — Flags `abi.encodePacked()` calls with two or more dynamic-type arguments (`string`, `bytes`, `T[]`) that can produce hash collisions.
 - [`enumerable-loop-removal`](/forge/linting/enumerable-loop-removal) — Flags `remove` on an EnumerableSet inside a loop that also iterates a set with `at`; swap-and-pop removal corrupts the iteration.
 - [`erc20-unchecked-transfer`](/forge/linting/erc20-unchecked-transfer) — Flags calls to ERC20 `transfer` and `transferFrom` where the boolean return value is ignored.
+- [`function-selector-collision`](/forge/linting/function-selector-collision) — Flags different proxy and implementation function signatures that produce the same four-byte selector.
 - [`incorrect-exp`](/forge/linting/incorrect-exp) — Flags `^` (bitwise xor) used between integer literals where `**` (exponentiation) was almost certainly intended.
 - [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.
 - [`reentrancy-eth`](/forge/linting/reentrancy-eth) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.

--- a/src/pages/forge/linting/function-selector-collision.mdx
+++ b/src/pages/forge/linting/function-selector-collision.mdx
@@ -1,0 +1,59 @@
+---
+description: Function selector collision
+---
+
+## Function selector collision
+
+**Severity**: `High`
+**ID**: `function-selector-collision`
+
+Flags different proxy and implementation function signatures that produce the same four-byte selector and can route implementation calls to the proxy instead.
+
+### What it does
+
+Solidity already rejects selector collisions within one contract and its inheritance tree, so this lint focuses on the separate APIs that coexist at a proxy address. It identifies a proxy and implementation pair when a concrete contract's fallback directly calls the built-in `address.delegatecall` with the full calldata (`msg.data` or the parameterized fallback's unmodified `bytes calldata` input) on an address converted from a statically typed contract or interface value. It compares the proxy's effective external API with the target type's effective external API and reports different signatures with the same four-byte selector. Identical signatures are not reported because they are function shadowing rather than a hash collision.
+
+The explicit source-level target type keeps the check conservative. The lint does not compare unrelated contracts across the project, recover target types erased to `address`, follow calldata aliases or delegatecalls hidden behind helper functions, read EIP-1967 slots, or inspect inline assembly. Receive functions are excluded because they only handle empty calldata. For those common proxy forms, we can use `forge selectors collision <proxy> <implementation>` to designate the pair explicitly.
+
+### Why is this bad?
+
+A proxy dispatches its own external functions before its fallback. If a proxy function and an implementation function have the same selector, calls intended for the implementation execute the proxy function instead. The implementation function becomes unreachable through the proxy and may produce unexpected state changes or access-control behavior.
+
+### Example
+
+#### Bad
+
+```solidity
+interface IImplementation {
+    function gsf() external;
+}
+
+contract Proxy {
+    IImplementation internal implementation;
+
+    // tgeo() and gsf() both have selector 0x67e43e43.
+    function tgeo() external {}
+
+    fallback() external payable {
+        address(implementation).delegatecall(msg.data);
+    }
+}
+```
+
+#### Good
+
+```solidity
+interface IImplementation {
+    function gsf() external;
+}
+
+contract Proxy {
+    IImplementation internal implementation;
+
+    function proxyAdminAction() external {}
+
+    fallback() external payable {
+        address(implementation).delegatecall(msg.data);
+    }
+}
+```


### PR DESCRIPTION
Documents the `function-selector-collision` lint added by [foundry-rs/foundry#15762](https://github.com/foundry-rs/foundry/pull/15762). The new high-severity reference page explains the conservative proxy and implementation inference, the collision risk, unsupported proxy shapes, and bad and good examples, and adds the lint to the reference index and sidebar.
