### PR TITLE
docs(lint): add reentrancy balance

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -57,6 +57,7 @@ const docs = [
               { text: "incorrect-exp", link: "/forge/linting/incorrect-exp" },
               { text: "incorrect-shift", link: "/forge/linting/incorrect-shift" },
               { text: "protected-vars", link: "/forge/linting/protected-vars" },
+              { text: "reentrancy-balance", link: "/forge/linting/reentrancy-balance" },
               { text: "reentrancy-eth", link: "/forge/linting/reentrancy-eth" },
               { text: "rtlo", link: "/forge/linting/rtlo" },
               { text: "unchecked-call", link: "/forge/linting/unchecked-call" },

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -165,6 +165,7 @@ navigation on the right to browse by severity.
 - [`incorrect-exp`](/forge/linting/incorrect-exp) — Flags `^` (bitwise xor) used between integer literals where `**` (exponentiation) was almost certainly intended.
 - [`incorrect-shift`](/forge/linting/incorrect-shift) — Flags shift operations where a literal appears on the left and a non-literal on the right, which is almost always the wrong operand order.
 - [`protected-vars`](/forge/linting/protected-vars) — Flags externally callable functions that can write an annotated state variable without invoking its declared protection.
+- [`reentrancy-balance`](/forge/linting/reentrancy-balance) — Flags reentrant external calls between saving the current contract balance and checking a fresh balance against that stale value.
 - [`reentrancy-eth`](/forge/linting/reentrancy-eth) — Flags uncapped ETH-transferring low-level `call` operations when state read before the call is written after the call.
 - [`rtlo`](/forge/linting/rtlo) — Flags the presence of Unicode bidirectional override characters in source code, which can be used to hide malicious behavior ("Trojan Source", [CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574)).
 - [`unchecked-call`](/forge/linting/unchecked-call) — Flags low-level calls (`call`, `delegatecall`, `staticcall`, `callcode`) whose `success` return value is ignored.

--- a/src/pages/forge/linting/reentrancy-balance.mdx
+++ b/src/pages/forge/linting/reentrancy-balance.mdx
@@ -1,0 +1,55 @@
+---
+description: Reentrancy through stale contract balance checks
+---
+
+## Reentrancy through stale contract balance checks
+
+**Severity**: `High`
+**ID**: `reentrancy-balance`
+
+Flags reentrant external calls between saving `address(this).balance` and checking the current
+contract balance against that saved value.
+
+### What it does
+
+Warns when a public or external entry point saves `address(this).balance` in a local value, performs
+an external call that can forward enough gas to re-enter, and then compares the saved value with a
+fresh contract-balance read in a `require`, `assert`, or exiting branch. Casts, tuple assignments,
+derived locals, fresh post-call balance locals, internal helper parameters and returns, and
+modifiers are tracked when their bodies are available.
+
+This detector intentionally covers native ETH held by the current contract. It is not the later
+token `balanceOf(address)` detector with a similar name. It does not report token balances,
+balances of other addresses, mutable state or storage baselines, view or static calls, calls capped
+at the 2,300-gas stipend or less, checks on directly mutually exclusive branches, baselines
+overwritten after the call, or expressions that do not compare a fresh contract-balance read with
+the stale local value.
+
+### Why is this bad?
+
+A callback can re-enter the function several times before any invocation reaches its balance
+check. Nested invocations can therefore share the same pre-call balance and make one payment appear
+to satisfy several operations. A non-strict inequality does not prevent the attack because the
+saved baseline, rather than the comparison operator, is stale.
+
+### Example
+
+#### Bad
+
+```solidity
+function mint(IPayer payer, uint256 amount) external {
+    uint256 balanceBefore = address(this).balance;
+    payer.pay();
+    require(address(this).balance >= balanceBefore + amount, "insufficient payment");
+    _mint(msg.sender, amount);
+}
+```
+
+#### Good
+
+```solidity
+function mint(uint256 amount) external payable nonReentrant {
+    require(msg.value >= amount, "insufficient payment");
+    _mint(msg.sender, amount);
+}
+```


### PR DESCRIPTION
This documents the `reentrancy-balance` lint added in foundry-rs/foundry#15769, explains its stale native-balance analysis and exclusions, and adds the rule to the high-severity reference index and sidebar.
