### PR TITLE
docs(lint): accept code-less ERC721 guards

### DIFF
--- a/src/pages/forge/linting/unsafe-oz-erc721-mint.mdx
+++ b/src/pages/forge/linting/unsafe-oz-erc721-mint.mdx
@@ -13,9 +13,9 @@ Flags calls that resolve to `ERC721._mint`, which credits a token without checki
 
 Reports calls that resolve to the unchecked `_mint` implementation in OpenZeppelin's `ERC721`, `ERC721Upgradeable`, `ERC721Consecutive`, or `ERC721ConsecutiveUpgradeable`, including calls that transitively reach one through a user override. Plain `_mint(to, id)`, qualified `ERC721._mint(to, id)`, and `super._mint(to, id)` forms are covered. Exact contract names and OpenZeppelin source provenance keep unrelated local functions and `ERC20._mint` out of scope.
 
-The lint recognizes wrappers that provide the receiver check themselves. A wrapper must call `onERC721Received` on the same recipient and token, require the ERC721 receiver selector on the accepting path, and revert on refusal without a path that can return successfully. Common `require`, `assert`, `if`/`else`, and contract-account short-circuit forms are supported.
+The lint recognizes wrappers that prove the recipient has no code or provide the receiver check themselves. A receiver-checking wrapper must call `onERC721Received` on the same recipient and token, require the ERC721 receiver selector on the accepting path, and revert on refusal without a path that can return successfully. Common `require`, `assert`, `if`/`else`, and contract-account short-circuit forms are supported.
 
-Guards may be factored into non-virtual, same-frame internal helpers or modifiers when both the recipient and token are forwarded unchanged and the guard cannot be bypassed. Cross-contract helpers do not count because the receiver would see the helper contract as its caller. The analysis follows recursive unsafe `_mint` overrides as well, so every intermediate delegation must preserve those identities. Reassigning either value after a guard invalidates its coverage, including reassignment inside a condition or inside the helper or modifier itself.
+Guards may be factored into non-virtual, same-frame internal helpers or modifiers when the guard cannot be bypassed. A code-less proof needs only the recipient; a receiver callback must receive both the recipient and token unchanged. Cross-contract helpers do not count because the receiver would see the helper contract as its caller. The analysis follows recursive unsafe `_mint` overrides as well, requiring every intermediate delegation to preserve the recipient and, for callback guards, the token. Reassigning the recipient invalidates either proof, while a computed or remapped token remains covered by a code-less proof.
 
 Assembly is handled conservatively because it can remap values or leave the current call frame. Assembly reached while evaluating a guard prevents that guard from establishing coverage, and assembly between a guard and mint retires the coverage; a fresh guard afterward can establish it again. An unresolved internal function-pointer call is likewise treated as able to leave the frame before a later revert.
 
@@ -26,7 +26,7 @@ The principal exemptions are:
 - calls to `_safeMint`, the recommended fix;
 - calls inside OpenZeppelin's canonical `_safeMint` wrapper;
 - delegation inside a user `_mint` override, whose call sites are checked instead;
-- call sites whose full delegated path is protected by a recognized receiver guard.
+- call sites whose full delegated path proves the recipient is code-less or is protected by a recognized receiver guard.
 
 Calls dispatched through assembly or an internal function pointer are not analyzed because the type checker does not resolve them to an `_mint` declaration. A user override that reimplements ownership changes without delegating to OpenZeppelin is likewise outside this lint's scope.
 


### PR DESCRIPTION
This follows up on #1988 to match the final review-driven behavior in foundry-rs/foundry#15551. The `unsafe-oz-erc721-mint` page now explains that proving a recipient has no code is sufficient without a receiver callback, that this proof depends only on recipient identity, and that computed or remapped token IDs remain covered while callback guards still correlate both recipient and token.

This documentation update was prepared with OpenAI Codex assistance and independently reviewed in a fresh context.
