### PR TITLE
docs(lint): describe post-call ecrecover guards

### DIFF
--- a/src/pages/forge/linting/ecrecover.mdx
+++ b/src/pages/forge/linting/ecrecover.mdx
@@ -19,13 +19,19 @@ comparisons, and the equivalent strict comparison against that value plus one. F
 invalidated by reassignment, loop-carried writes, and calls that may change mutable state. They are
 retained only when they hold on every path reaching the call.
 
+When the recovered address is stored in a local variable, the diagnostic is deferred until its
+first non-copy observable use. Local-to-local copies keep the diagnostic deferred, and a guard is
+needed only on paths that later use the signer. A dominating low-`s` guard after the call can
+therefore validate the exact `s` value before the signer affects behavior. The warning remains if
+any path reaches an observable use or state store before a matching guard, if `s` is reassigned
+before that guard, or if an unguarded named return exposes the result.
+
 Checks on `v`, the recovered address, nonces, domain separators, or the top bit of an EIP-2098
 signature do not prove that `s` is canonical and do not suppress the warning.
 
-The analysis is intentionally local and requires the low-`s` guard to be established before the
-call. It does not summarize internal helpers or modifiers, prove post-call guards, recognize bound
-signature schemes that fix one recovery ID, or inspect Yul and low-level calls to precompile
-address `0x01`.
+The analysis is intentionally local. It does not summarize internal helpers or modifiers,
+recognize bound signature schemes that fix one recovery ID, or inspect Yul and low-level calls to
+precompile address `0x01`.
 
 ### Why is this bad?
 


### PR DESCRIPTION
The original ecrecover page in #1981 said post-call guards were unsupported. The reviewed implementation in foundry-rs/foundry#15765 now defers a locally stored recovery result until its first non-copy observable use, so this documents safe local copies, branch-local guarded use, named-return paths, and the exact zero-address plus low-s validation that clears the warning.

Follow-up to #1981 and foundry-rs/foundry#15765.

Prepared with assistance from OpenAI Codex.

