### PR TITLE
docs(lint): require protected write dominance

### DIFF
--- a/src/pages/forge/linting/protected-vars.mdx
+++ b/src/pages/forge/linting/protected-vars.mdx
@@ -21,9 +21,15 @@ address owner;
 
 The lint follows modifiers, library calls, and resolved internal call paths from public, external,
 fallback, and receive entry points. If an entry point writes the variable directly or through a
-reachable helper, the required function or modifier must also be reachable from that entry point.
-This includes writes through storage references, returned storage locations, collection
-`push`/`pop` operations, and resolvable inline-assembly storage slots.
+reachable helper, the required function or modifier must run on every path reaching that write.
+Guards are tracked through branches, short-circuit and ternary expressions, loops, returns, and
+reachable modifier-placeholder continuations, so a call on only one branch or after the write does
+not satisfy the annotation. This includes writes through storage references, returned storage
+locations, collection `push`/`pop` operations, and resolvable inline-assembly storage slots.
+
+Inline assembly tracks storage-pointer `.slot` retargeting and resolved Yul return locations.
+Persistent `sstore` operations count as writes; transient `tstore` uses a separate namespace and
+does not imply that the annotated state variable changed.
 
 Overloads are matched by their exact signature. Inherited variables, entry points, functions, and
 modifiers are resolved in the most-derived contract, including virtual dispatch. External calls
@@ -31,9 +37,9 @@ such as `this.onlyOwner()` do not satisfy an internal write-protection requireme
 signature or malformed `write-protection` value is treated as unsatisfied so an invalid annotation
 cannot silently disable the lint.
 
-Like Slither's annotation semantics, this rule is reachability-based rather than order- or
-path-sensitive: the annotation identifies a required internal call, not a proof that the call
-dominates every write.
+The rule checks protection at each write occurrence. A protected write on one path does not hide an
+unprotected write on another, and a modifier that exits before its placeholder does not make an
+unreachable function body appear writable.
 
 ### Why is this bad?
 


### PR DESCRIPTION
The original protected-vars page in #1982 described simple reachability. The reviewed implementation in foundry-rs/foundry#15766 instead requires each protected write to be dominated by its guard, including modifier placeholder flow, branches, early exits, and nested modifiers. This also documents Yul return resolution, storage-slot retargeting, and the distinction between persistent `sstore` and transient `tstore`.

Follow-up to #1982 and foundry-rs/foundry#15766.

Prepared with assistance from OpenAI Codex.

