### PR TITLE
fix: use canonical docs origin

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
   description:
     "Documentation for Foundry's Forge, Cast, Anvil, and Chisel Ethereum development tools.",
   baseUrl: "https://www.getfoundry.sh",
+  head: {
+    base: false,
+  },
   rootDir: ".",
   sidebar,
   changelog: Changelog.github({ repo: "foundry-rs/foundry" }),

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   title: "foundry - Ethereum Development Framework",
   description:
     "Documentation for Foundry's Forge, Cast, Anvil, and Chisel Ethereum development tools.",
-  baseUrl: "https://getfoundry.sh",
+  baseUrl: "https://www.getfoundry.sh",
   rootDir: ".",
   sidebar,
   changelog: Changelog.github({ repo: "foundry-rs/foundry" }),

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
   description:
     "Documentation for Foundry's Forge, Cast, Anvil, and Chisel Ethereum development tools.",
   baseUrl: "https://www.getfoundry.sh",
+  // Keep assets on the current origin so Vercel previews do not load them cross-origin.
+  // `baseUrl` still provides the production origin for canonical and Open Graph metadata.
   head: {
     base: false,
   },


### PR DESCRIPTION
## Summary

- configure Vocs with the canonical `www.getfoundry.sh` origin
- omit the `<base>` tag so JavaScript and other assets stay on the current deployment origin
- restore client hydration and documentation search on production and Vercel previews

## Verification

- reproduced the production failure in Chromium: the search button did not open and the browser blocked an apex-hosted JavaScript module from the `www` page due to CORS
- reproduced the first preview failure: it fetched JavaScript from `www.getfoundry.sh`, which Vercel blocked cross-origin
- verified the updated Vercel preview at the reported URL: Search opens, the input is interactive, and `forge` returns 21 options with no failed asset requests
- `bunx vocs build`

Prompted by: @DaniPopes