### PR TITLE
docs(config): add tracing reference

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -129,6 +129,7 @@ export const sidebar: Sidebar = {
         { text: "Project", link: "/config/reference/project" },
         { text: "Solidity Compiler", link: "/config/reference/solidity-compiler" },
         { text: "Testing", link: "/config/reference/testing" },
+        { text: "Tracing", link: "/config/reference/tracing" },
         { text: "In-line Test Config", link: "/config/reference/inline-test-config" },
         { text: "Formatter", link: "/config/reference/formatter" },
         { text: "Linter", link: "/config/reference/linter" },

--- a/src/pages/config/reference/README.mdx
+++ b/src/pages/config/reference/README.mdx
@@ -4,6 +4,7 @@
 - [Project](/config/reference/project.mdx)
 - [Solidity Compiler](/config/reference/solidity-compiler.mdx)
 - [Testing](/config/reference/testing.mdx)
+- [Tracing](/config/reference/tracing.mdx)
 - [In-line test configuration](/config/reference/inline-test-config.mdx)
 - [Formatter](/config/reference/formatter.mdx)
 - [Linter](/config/reference/linter.mdx)

--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -508,17 +508,27 @@ read = ["out"]
 read-write = ["cache", "broadcast"]
 
 # =============================================================================
-# ADDRESS LABELS
+# TRACE CONFIGURATION
 # =============================================================================
 
-# Address labels for better trace output
-[profile.default.labels]
+# Trace rendering settings
+[profile.default.tracing]
+verbosity = 0
+disable_labels = false
+compact_labels = false
+# trace_depth = 10
+decode_internal = false
+
+# Address labels for trace output
+[profile.default.tracing.labels]
 "0x1234..." = "MyContract"
 "0xabcd..." = "Treasury"
 
 # =============================================================================
 # CHEATCODE CONFIGURATION
 # =============================================================================
+
+[profile.default]
 
 # Verbosity level (0-5)
 # Default: 0

--- a/src/pages/config/reference/tracing.mdx
+++ b/src/pages/config/reference/tracing.mdx
@@ -1,0 +1,69 @@
+## Tracing
+
+Configuration for decoding and rendering execution traces produced by `forge test`,
+`forge script`, `cast call`, and `cast run`.
+
+Define these settings under `[profile.<name>.tracing]`:
+
+```toml
+[profile.default.tracing]
+verbosity = 3
+compact_labels = true
+trace_depth = 10
+decode_internal = true
+
+[profile.default.tracing.labels]
+"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" = "vitalik.eth"
+```
+
+CLI trace options override or extend these values for the current command. The
+legacy `[labels]` and profile-level `labels` settings are deprecated; move them
+to `[profile.<name>.tracing.labels]`.
+
+### Fields
+
+#### `verbosity`
+
+- Type: integer
+- Default: 0
+
+The minimum verbosity used when rendering traces. A command's `-v` flags can
+increase, but not decrease, this value.
+
+#### `labels`
+
+- Type: table mapping addresses to strings
+- Default: empty
+
+Labels addresses in decoded traces. Labels passed with `--label` or `--labels`
+extend this table and take precedence for duplicate addresses.
+
+#### `disable_labels`
+
+- Type: boolean
+- Default: false
+
+Disables address labels in rendered traces.
+
+#### `compact_labels`
+
+- Type: boolean
+- Default: false
+
+Hides an address in trace parameters when a label is available, displaying only
+the label.
+
+#### `trace_depth`
+
+- Type: integer
+- Default: none
+
+Limits the maximum depth of rendered traces.
+
+#### `decode_internal`
+
+- Type: boolean
+- Default: false
+
+Identifies internal functions and decodes their stack parameters. Dynamic values
+stored in memory are decoded only when Foundry can match a single function.


### PR DESCRIPTION
Documents the `[tracing]` configuration introduced by foundry-rs/foundry#15665, including every field, its default, precedence with CLI options, and the migration path for legacy labels. The tracing page is linked from the config reference, and the default configuration example now uses the canonical nested table.

AI assistance was used for this change, per CONTRIBUTING.md.

Prompted by: @DaniPopes
