### PR TITLE
docs(forge): document proxy cloning

### DIFF
--- a/sidebar/forge.ts
+++ b/sidebar/forge.ts
@@ -3,6 +3,7 @@ import type { SidebarItem } from "./types";
 export const forgeDocs: SidebarItem[] = [
   { text: "Overview", link: "/forge" },
   { text: "Building", link: "/forge/build" },
+  { text: "Cloning Contracts", link: "/forge/cloning" },
   { text: "Documentation", link: "/forge/documentation" },
   { text: "Contract Bindings", link: "/forge/contract-bindings" },
   { text: "Testing", link: "/forge/testing" },

--- a/src/pages/forge/cloning.mdx
+++ b/src/pages/forge/cloning.mdx
@@ -1,0 +1,64 @@
+---
+description: Clone explorer-verified Solidity source into a Forge project, including a proxy's implementation.
+---
+
+## Cloning verified contracts
+
+`forge clone` downloads verified Solidity source and compiler settings from a block explorer, initializes a Forge project, compiles it, and writes deployment metadata to `.clone.meta`.
+
+By default, Forge clones the exact address you provide. Add `--implementation` when the address is a proxy and you want the implementation reported by Etherscan.
+
+### Prerequisites
+
+- An explorer-verified contract.
+- An Etherscan API key, supplied through `ETHERSCAN_API_KEY` or `--etherscan-api-key`.
+- The contract's chain name or chain ID when it is not on Ethereum mainnet.
+
+### Clone the contract at an address
+
+Pass the contract address and the directory that Forge should create:
+
+```bash
+$ forge clone \
+  --chain mainnet \
+  0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359 \
+  sparklend-usds
+```
+
+This clones the verified contract at the supplied address. If the address is a proxy, the generated project contains the proxy source unless you request its implementation explicitly.
+
+### Clone a proxy implementation
+
+Add `--implementation` to clone the implementation address reported in the proxy's Etherscan metadata:
+
+```bash
+$ forge clone \
+  --implementation \
+  --chain mainnet \
+  0xC02aB1A5eaA8d1B114EF786D9bde108cD4364359 \
+  sparklend-usds
+```
+
+Forge uses the resolved implementation for:
+
+- Downloaded source code and compiler settings.
+- Contract creation data and constructor arguments.
+- The compiled storage layout.
+- The address, contract name, and source path recorded in `.clone.meta`.
+
+If Etherscan does not mark the supplied address as a proxy, `--implementation` clones the supplied address normally.
+
+### Understand implementation resolution
+
+Implementation resolution follows one Etherscan metadata link. Forge fetches the implementation reported for the supplied proxy and stops there, even if that implementation is also marked as a proxy. This avoids following an unrelated delegate-call target reported by the explorer.
+
+The resolved target must be a Solidity contract. A Vyper proxy can still resolve to a Solidity implementation because Forge only compiles the selected target.
+
+When verified sources remain under `lib`, Forge creates an import-only entry point such as `src/Clone.sol` so the compiler discovers the cloned target. The downloaded library sources remain under `lib`.
+
+`--implementation` is supported only with Etherscan. It cannot be combined with `--source sourcify` or `--sourcify-url`, and resolution depends on the proxy metadata returned by the explorer.
+
+### Next steps
+
+- See the [`forge clone` reference](/reference/forge/clone) for all command options.
+- Compare storage layouts when [upgrading contracts](/guides/upgrading-contracts).

--- a/src/pages/forge/index.mdx
+++ b/src/pages/forge/index.mdx
@@ -17,6 +17,11 @@ Forge compiles, tests, and deploys Solidity smart contracts. It's the core devel
     to="/forge/testing"
   />
   <Card
+    title="Clone verified contracts"
+    description="Create a Forge project from explorer-verified source."
+    to="/forge/cloning"
+  />
+  <Card
     title="Document contracts"
     description="Generate and publish an API site from Solidity NatSpec."
     to="/forge/documentation"
@@ -98,6 +103,7 @@ $ forge verify-contract $ADDRESS src/Counter.sol:Counter --etherscan-api-key $KE
 ### Learn more
 
 - [Building contracts](/forge/build) — Compilation, artifacts, and optimization
+- [Cloning verified contracts](/forge/cloning) — Recreate a project from an address or proxy implementation
 - [Contract documentation](/forge/documentation) — NatSpec, generated API pages, and publishing
 - [Contract bindings](/forge/contract-bindings) — Alloy bindings and Solidity JSON helpers
 - [Testing](/forge/testing) — Writing and running tests


### PR DESCRIPTION
Documents `forge clone --implementation` in a new authored Forge guide, including direct Etherscan metadata resolution, behavior for non-proxies, source and deployment metadata selection, the Solidity and Vyper boundary, and library-only source entrypoints. The page is linked from the Forge overview and sidebar.

Depends on foundry-rs/foundry#15833. The generated `forge clone` reference remains unchanged because its pinned nightly predates the flag; the normal CLI regeneration will pick up the option after the implementation lands. The pinned Vocs build resolves the new route and internal links.

This PR was written primarily with Codex.
