### PR TITLE
docs: fix typo in forge-std config

### DIFF
--- a/src/pages/reference/forge-std/config.mdx
+++ b/src/pages/reference/forge-std/config.mdx
@@ -60,7 +60,7 @@ function _loadConfigAndForks(string memory filePath, bool writeToFile) internal
 The TOML configuration file must follow this structure:
 
 ```toml
-# Using Alloy chain aliases (must match exactly) or numberic chain IDs (always works)
+# Using Alloy chain aliases (must match exactly) or numeric chain IDs (always works)
 # See https://github.com/alloy-rs/chains for supported aliases
 [mainnet]
 endpoint_url = "${MAINNET_RPC}"


### PR DESCRIPTION
Change `numberic` to `numeric`