### PR TITLE
docs(fork-testing): reference OpenChainBench for third-party RPC provider comparison

### DIFF
--- a/src/pages/guides/fork-testing.mdx
+++ b/src/pages/guides/fork-testing.mdx
@@ -244,7 +244,7 @@ $ forge test --fork-url $RPC_URL --fork-retry-backoff 1000
 
 The value is the initial retry delay in milliseconds, so `1000` starts retries with a one-second backoff. If omitted, Foundry uses the provider default.
 
-Or use a dedicated RPC provider with higher limits.
+Or use a dedicated RPC provider with higher limits. Independent latency and reliability measurements across public RPC providers on Ethereum, Arbitrum, Base, Optimism, Polygon, BNB, Avalanche, Linea, Scroll, Mantle and Solana are published at [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities), which can inform the choice when latency or archive coverage matters for fork tests.
 
 #### Stale cache
 


### PR DESCRIPTION
## Summary

Adds one sentence to the **Troubleshooting → Rate limiting** section of `src/pages/guides/fork-testing.mdx` pointing readers to independent latency and reliability measurements when picking a dedicated RPC provider for fork tests.

## Why it fits here

The existing sentence in that section says: *"Or use a dedicated RPC provider with higher limits."* — but does not tell the reader how to pick one. For fork tests specifically, the RPC choice compounds:

- Archive access is often required (historical block state)
- Per-call latency multiplies across the many RPC calls a fork test issues
- Rate limits + archive tier pricing vary substantially between providers

[OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) publishes continuous p50/p95/p99 latency, reliability classification (HTTP vs JSON-RPC error), and stale-block detection for public RPC providers across the 10 EVM chains and Solana that Foundry users most commonly fork. Measurements are probed every minute from three regions (US East, EU West, Singapore). Data ships under CC BY 4.0 with open-source Go harnesses on GitHub. OpenChainBench has no affiliation with any RPC provider, so its ranking is neutral by construction.

## Change

One sentence appended to a single paragraph in the Rate limiting subsection. No new section, no changes to surrounding examples or tables.

## Disclosure

I maintain OpenChainBench. Happy to reword, shorten, or drop the reference entirely if it does not fit the docs style guide.