### PR TITLE
docs(forge): drop no-op --no-commit flag from examples

### DIFF
--- a/src/pages/projects/dependencies.mdx
+++ b/src/pages/projects/dependencies.mdx
@@ -18,8 +18,8 @@ $ forge install OpenZeppelin/openzeppelin-contracts
 $ forge install OpenZeppelin/openzeppelin-contracts@v5.0.0
 ```
 
-```bash [No commit]
-$ forge install OpenZeppelin/openzeppelin-contracts --no-commit
+```bash [With commit]
+$ forge install OpenZeppelin/openzeppelin-contracts --commit
 ```
 
 :::
@@ -167,11 +167,8 @@ $ git commit -m "Pin conflicting-library to v2.0.0"
 If dependencies need different versions, install both under different names:
 
 ```bash
-$ forge install org/library@v1.0.0 --no-commit
-$ mv lib/library lib/library-v1
-
-$ forge install org/library@v2.0.0 --no-commit
-$ mv lib/library lib/library-v2
+$ forge install library-v1=org/library@v1.0.0
+$ forge install library-v2=org/library@v2.0.0
 ```
 
 Add remappings:

--- a/src/pages/projects/index.mdx
+++ b/src/pages/projects/index.mdx
@@ -36,10 +36,10 @@ $ forge init --force
 
 | Flag | Description |
 |------|-------------|
-| `--template <url>` | Use a custom template repository |
+| `--template <repo>` | Use a custom template repository (URL or `owner/repo`) |
 | `--no-git` | Skip git repository initialization |
-| `--no-commit` | Skip initial commit |
-| `--shallow` | Perform shallow clone for template |
+| `--commit` | Create an initial commit |
+| `--shallow` | Perform shallow dependency clones |
 | `--offline` | Skip dependency installation |
 | `--vscode` | Generate VS Code settings |
 


### PR DESCRIPTION
forge install and forge init no longer create commits by default; --no-commit is a hidden noop kept for backwards compatibility and --commit is the opt-in. The dependency and project pages still taught --no-commit in four places, which teaches a dead flag and hides the real one.

While touching those lines, the two-version install example now uses the alias syntax (forge install library-v1=org/library@v1.0.0) instead of installing and moving submodule paths, and the --template and --shallow rows in the forge init flags table were corrected to match current behavior (owner/repo shorthand; the flag controls dependency clone depth, template fetches are always shallow).