### PR TITLE
docs(forge): document debugger features and networks config

### DIFF
--- a/src/pages/config/reference/tooling.mdx
+++ b/src/pages/config/reference/tooling.mdx
@@ -44,9 +44,29 @@ the [Soldeer guide](/projects/soldeer) for its fields and workflows.
 
 ### Networks
 
-The `network` field selects a network family (`ethereum`, `optimism`, or
-`tempo`). Foundry also accepts the legacy `celo` and `tempo` boolean fields.
-`bypass_prevrandao` controls the Celo-specific prevrandao compatibility path.
+Network keys enable chain-specific execution behavior. They live at the top
+level of `[profile.<name>]`.
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `network` | none | Selects the network family: `ethereum`, `optimism`, or `tempo`. |
+| `celo` | `false` | Enables Celo network features such as the Celo transfer precompile. |
+| `bypass_prevrandao` | `false` | Uses a random `prevrandao` when the forked block does not provide one. |
+
+Selecting a network family enables its execution rules and precompiles — for
+example the Tempo system precompiles, which are also labeled in traces. When
+forking, Foundry infers the network from the chain ID, so `network` mainly
+matters for local execution; see the
+[`network`](/config/reference/testing#network) entry for details. The legacy
+boolean forms `optimism = true` and `tempo = true` are still accepted.
+
+```toml
+[profile.default]
+network = "tempo"
+```
+
+`bypass_prevrandao` is enabled automatically on chains that do not supply a
+`prevrandao` value, such as Moonbeam, RSK, and Gnosis.
 
 ### Linter-specific fields
 

--- a/src/pages/forge/debugging.mdx
+++ b/src/pages/forge/debugging.mdx
@@ -40,35 +40,78 @@ Debug a transaction that failed on-chain:
 $ cast run 0x<txhash> --rpc-url $RPC_URL
 ```
 
-This replays the transaction and shows the execution trace.
+This replays the transaction and shows the execution trace. Add `--debug` to open the transaction in the interactive debugger instead; `cast call --trace --debug` does the same for a call without sending it.
 
 ### Interactive debugger
 
-Launch the debugger for a specific test:
+Launch the debugger for a single test:
 
 ```bash
-$ forge test --debug test_Increment
+$ forge test --debug --match-test test_Increment
 ```
 
-The debugger shows:
-- Source code with current line highlighted
-- Stack contents
-- Memory contents
-- Storage changes
-- Call stack
+In an interactive terminal, a filter that matches more than one test opens a prompt asking which test to debug, so you can also run `forge test --debug` without a filter and pick from the list. In a non-interactive terminal the filter must match exactly one test.
 
-#### Debugger commands
+The debugger is a terminal UI with five panes:
+
+- **Source** – Source code with the currently executing line highlighted.
+- **Opcodes** – The opcode list for the current call, with the program counter, address, and gas information in the title.
+- **Variables** – Parameters, return values, and locals in the current scope, with decoded values where available. When you step through a constructor during contract creation, the constructor arguments are decoded and shown here. Storage reads and writes performed by the current step also appear in this pane.
+- **Stack** – The current EVM stack.
+- **Data** – A shared pane showing either a buffer (memory, calldata, or returndata) or the [storage explorer](#storage-explorer).
+
+The debugger picks a two-column or single-column layout based on the terminal size. Press `l` to switch layouts, or force one with `--debug-layout <horizontal|vertical>`.
+
+#### Key bindings
 
 | Key | Action |
 |-----|--------|
-| `n` | Step to next opcode |
-| `s` | Step into call |
-| `o` | Step out of call |
-| `g` | Go to start |
-| `G` | Go to end |
-| `c` | Continue to next breakpoint |
+| `j` / `k` (or arrow keys, mouse scroll) | Step forward / backward one instruction |
+| `s` / `a` | Move to the next / previous jump |
+| `C` / `c` | Move to the next / previous call |
+| `g` / `G` | Go to the beginning / end |
+| `'<char>` | Jump to the breakpoint set with [`vm.breakpoint`](/reference/cheatcodes/breakpoint) |
+| `0-9` | Repeat prefix for movement keys, e.g. `10k` steps back 10 instructions |
+| `b` | Cycle the data pane between memory, calldata, and returndata |
+| `J` / `K` | Scroll the stack pane |
+| `Ctrl+j` / `Ctrl+k` | Scroll the data pane |
+| `t` | Toggle stack labels |
+| `m` | Toggle UTF-8 decoding of the active buffer |
+| `p` | Go to a program counter |
+| `o` | Go to a byte offset in the active buffer, or to a slot when the storage explorer is active |
+| `/`, then `n` / `N` | Search opcodes in the current call, then repeat the search forward / backward |
+| `:` | Open the command prompt |
+| `h` | Toggle the shortcut footer |
 | `q` | Quit |
-| `h` | Show help |
+
+#### Command prompt
+
+Press `:` to run a debugger command. `:help` lists all commands and their aliases.
+
+| Command | Action |
+|---------|--------|
+| `:pc <pc>` (alias `:continue <pc>`) | Jump to a program counter in the current contract |
+| `:line <line>` | Jump to the nearest instruction mapped to a source line in the current contract |
+| `:mem [<offset>]`, `:calldata [<offset>]`, `:ret [<offset>]` | Select a buffer in the data pane, optionally jumping to a byte offset |
+| `:storage [<slot>]` | Open the storage explorer, optionally jumping to the nearest access of a slot |
+| `:transient [<slot>]` | Open the transient storage explorer, optionally jumping to a slot |
+| `:source`, `:opcodes`, `:variables`, `:stack`, `:data` | Show or hide a pane; the remaining panes reclaim the space |
+
+#### Storage explorer
+
+`:storage` switches the data pane to a storage view that lists every slot the current call has accessed up to the current step, showing each slot's most recent operation (`SLOAD` or `SSTORE`) and value. The slot touched by the current step is highlighted. `:storage <slot>` jumps to the nearest access of a specific slot: the access at or after the current step, or the most recent earlier one.
+
+`:transient` and `:transient <slot>` provide the same view for transient storage (`TLOAD` and `TSTORE`). Press `b` to switch the data pane back to the buffer view.
+
+#### Breakpoints
+
+Place breakpoints in code with the [`vm.breakpoint`](/reference/cheatcodes/breakpoint) cheatcode:
+
+```solidity
+vm.breakpoint("a");
+```
+
+Pressing `'a` in the debugger jumps to the step where the breakpoint was recorded.
 
 ### Debugging scripts
 

--- a/src/pages/forge/scripting.mdx
+++ b/src/pages/forge/scripting.mdx
@@ -104,6 +104,16 @@ uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
 vm.startBroadcast(deployerPrivateKey);
 ```
 
+### Overriding the sender nonce
+
+By default the sender's starting nonce is fetched from the RPC endpoint, or set to 1 when no endpoint is configured. Pass `--sender-nonce` to pin it instead:
+
+```bash
+$ forge script script/Deploy.s.sol --rpc-url $RPC_URL --sender-nonce 7
+```
+
+The override applies to script execution and transaction generation and is kept even when broadcasting switches to a different sender. Because addresses of contracts deployed with `CREATE` depend on the sender's nonce, this keeps simulated deployment addresses consistent with the nonce you plan to broadcast from. See [`forge script`](/reference/forge/script) for the full option reference.
+
 ### Verifying deployed contracts
 
 Verify on Etherscan during deployment:

--- a/src/pages/guides/debugging-transactions.mdx
+++ b/src/pages/guides/debugging-transactions.mdx
@@ -130,17 +130,17 @@ Forge includes an interactive debugger:
 $ forge test --match-test test_Failing --debug
 ```
 
-Debugger controls:
+Basic controls:
 
 | Key | Action |
 |-----|--------|
-| `n` | Next step |
-| `s` | Step into |
-| `o` | Step out |
-| `g` | Jump to start |
-| `G` | Jump to end |
-| `c` | Continue |
+| `j` / `k` | Step forward / backward |
+| `s` / `a` | Move to the next / previous jump |
+| `C` / `c` | Move to the next / previous call |
+| `g` / `G` | Jump to start / end |
 | `q` | Quit |
+
+See [Debugging](/forge/debugging#interactive-debugger) for the full list of key bindings and debugger commands.
 
 ### Common failure patterns
 


### PR DESCRIPTION
The interactive debugger gained a storage explorer, transient storage inspection, interactive test selection, jump-to-source, pane toggling, and constructor argument display over the last months with no documentation. This rewrites the debugger section of the debugging page around the current TUI: the five panes, the real key bindings (the previous table listed keys like n/s/o/c that do not exist), the command prompt including :storage/:transient/:line/:pc and pane toggles, layout control via l and --debug-layout, and the additional entry points cast run --debug and cast call --trace --debug. The stale key table in the debugging-transactions guide is replaced with a link to the reference so the two pages cannot drift apart again.

The scripting page now covers the --sender-nonce override, and the networks section of the config tooling reference was corrected and expanded: network selects the ethereum/optimism/tempo family, celo is a real (not legacy) toggle for the Celo transfer precompile, and bypass_prevrandao substitutes a random prevrandao when a forked block lacks one rather than being Celo-specific.

All key bindings, commands, and behavior claims were verified against the debugger source rather than the shipped PR descriptions.