### PR TITLE
docs: fix broken command examples across authored pages

### DIFF
--- a/src/pages/anvil/forking.mdx
+++ b/src/pages/anvil/forking.mdx
@@ -72,12 +72,14 @@ $ anvil --fork-url $RPC_URL --fork-header "Authorization: Bearer $TOKEN"
 
 ### L2 support
 
-Anvil supports L2-specific features:
+Anvil can fork L2 networks directly. The network family is inferred from the forked chain ID, so forking a network like Optimism needs no extra flags:
 
-```bash [Enable Optimism features]
-$ anvil --fork-url https://mainnet.optimism.io --optimism
+```bash [Fork Optimism]
+$ anvil --fork-url https://mainnet.optimism.io
 ```
 
 ```bash [Enable Celo features]
 $ anvil --fork-url https://forno.celo.org --celo
 ```
+
+Use `--network` to select a network family explicitly; see the [`anvil` reference](/reference/anvil/anvil) for the supported values.

--- a/src/pages/best-practices.mdx
+++ b/src/pages/best-practices.mdx
@@ -260,20 +260,6 @@ function run() public {
 
 ### Security
 
-#### Run taint analysis
-
-Use `forge taint` to detect dangerous data flows from untrusted sources:
-
-```bash [Check a specific contract]
-$ forge taint src/Vault.sol
-```
-
-```bash [Check all contracts]
-$ forge taint
-```
-
-Taint analysis identifies when user-controlled data flows into sensitive operations without validation.
-
 #### Enable the linter
 
 Catch common issues with `forge lint`:

--- a/src/pages/cast/abi-encoding.mdx
+++ b/src/pages/cast/abi-encoding.mdx
@@ -160,5 +160,5 @@ $ cast interface 0xContractAddress --etherscan-api-key $KEY
 ```
 
 ```bash [Pretty print ABI]
-$ cast abi-print ./out/Counter.sol/Counter.json
+$ forge inspect Counter abi
 ```

--- a/src/pages/cast/reading-chain-data.mdx
+++ b/src/pages/cast/reading-chain-data.mdx
@@ -49,11 +49,11 @@ $ cast receipt $TX_HASH
 ```
 
 ```bash [Status]
-$ cast receipt $TX_HASH --field status
+$ cast receipt $TX_HASH status
 ```
 
 ```bash [Gas used]
-$ cast receipt $TX_HASH --field gasUsed
+$ cast receipt $TX_HASH gasUsed
 ```
 
 :::
@@ -133,22 +133,14 @@ Use `--block` to select the chain state on which to base the call, then use `--b
 | --- | --- |
 | `--block.number <NUMBER>` | Block number. |
 | `--block.time <TIME>` | Timestamp. |
-| `--block.gas-limit <GAS_LIMIT>` | Gas limit. |
-| `--block.fee-recipient <ADDRESS>` | Fee recipient (`COINBASE`). Alias: `--block.coinbase`. |
-| `--block.base-fee <BASE_FEE>` | Base fee per gas. Alias: `--block.base-fee-per-gas`. |
-| `--block.blob-base-fee <BLOB_BASE_FEE>` | Base fee per blob gas. Alias: `--block.blob-base-fee-per-gas`. |
 
-For example, this reads state from block `20000000` while the contract observes the overridden block context:
+For example, this reads state from block `20000000` while the contract observes the overridden block number and timestamp:
 
 ```bash
 $ cast call $CONTRACT "quote()(uint256)" \
     --block 20000000 \
     --block.number 21000000 \
-    --block.time 1750000000 \
-    --block.gas-limit 30000000 \
-    --block.fee-recipient 0x000000000000000000000000000000000000bEEF \
-    --block.base-fee 1000000000 \
-    --block.blob-base-fee 1
+    --block.time 1750000000
 ```
 
 The same state and block overrides apply to regular calls, local `--trace` calls, remote `--debug-trace-call` calls, and requests printed with `--curl`. Remote calls require an RPC node that supports the corresponding `eth_call` or `debug_traceCall` override parameters.

--- a/src/pages/guides/upgrading-contracts.mdx
+++ b/src/pages/guides/upgrading-contracts.mdx
@@ -158,8 +158,8 @@ contract UpgradeToken is Script {
 Since the proxy stores all state, the new implementation's storage layout must be compatible with the old one. Foundry can export and diff storage layouts to catch breaking changes before deployment:
 
 ```bash
-$ forge inspect src/TokenV1.sol:TokenV1 storage-layout --pretty > v1-layout.txt
-$ forge inspect src/TokenV2.sol:TokenV2 storage-layout --pretty > v2-layout.txt
+$ forge inspect src/TokenV1.sol:TokenV1 storage-layout > v1-layout.txt
+$ forge inspect src/TokenV2.sol:TokenV2 storage-layout > v2-layout.txt
 $ diff v1-layout.txt v2-layout.txt
 ```
 
@@ -299,8 +299,8 @@ contract TokenUpgradeTest is Test {
 #### Verify storage compatibility
 
 ```bash
-$ forge inspect src/TokenV1.sol:TokenV1 storage-layout --pretty
-$ forge inspect src/TokenV2.sol:TokenV2 storage-layout --pretty
+$ forge inspect src/TokenV1.sol:TokenV1 storage-layout
+$ forge inspect src/TokenV2.sol:TokenV2 storage-layout
 ```
 
 #### Test the upgrade on a fork

--- a/src/pages/help/faq.mdx
+++ b/src/pages/help/faq.mdx
@@ -82,7 +82,7 @@ $ forge test -vv
 #### Why are my tests slow?
 
 Common causes:
-1. **Forking without caching** — Enable fork caching with `--fork-cache`
+1. **Forking without a pinned block** — Pin the fork with `--fork-block-number` so the RPC cache is reused across runs
 2. **Too many fuzz runs** — Reduce `fuzz.runs` in `foundry.toml` for local development
 3. **Large contracts** — Consider splitting tests into separate files
 

--- a/src/pages/help/troubleshooting.mdx
+++ b/src/pages/help/troubleshooting.mdx
@@ -165,17 +165,17 @@ rpc_retry_backoff = 2
 
 #### Fork tests are slow
 
-Enable caching:
+Forked state is cached to disk by default, but the cache is only reused when the fork block is pinned:
 
 ```bash
-$ forge test --fork-url $RPC_URL --fork-cache
+$ forge test --fork-url $RPC_URL --fork-block-number 18000000
 ```
 
 Or in `foundry.toml`:
 
 ```toml
 [profile.default]
-fork_cache = true
+fork_block_number = 18000000
 ```
 
 The cache is stored in `~/.foundry/cache/rpc/`.


### PR DESCRIPTION
Several authored pages show commands that current Foundry releases reject. This fixes the remaining broken examples surfaced by the narrative command checker in #2014, with each replacement verified against the generated CLI reference pages.

On the cast side, the receipt examples passed the field as `--field`, but `cast receipt` takes it as a positional argument. The block-context section in reading-chain-data.mdx documented `--block.gas-limit`, `--block.fee-recipient`, `--block.base-fee`, and `--block.blob-base-fee`, while `cast call` only supports `--block.number` and `--block.time`; the table and example now match. abi-encoding.mdx advertised a nonexistent `cast abi-print`, for which `forge inspect Counter abi` is the working equivalent.

On the forge side, the upgrade guide still passed `--pretty` to `forge inspect`, which was removed in v1 now that table output is the default. The troubleshooting page and FAQ recommended a made-up `--fork-cache` flag and `fork_cache` config key; forked state is cached by default, so the advice now pins `--fork-block-number` (or `fork_block_number` in foundry.toml), which is what actually makes the cache reusable across runs. best-practices.mdx documented a nonexistent `forge taint` command; that section is removed since the linter section directly below it covers static analysis.

The anvil forking page used the removed `--optimism` flag. Released binaries fork OP networks without extra flags — the network family is inferred from the forked chain ID — so the example drops the flag and points at `--network` for explicit selection.

Once this lands, the matching ten entries in #2014's `scripts/narrative-command-baseline.json` become stale and should be dropped there; running that PR's checker against this branch reports exactly these entries as fixed and no new violations.
