### PR TITLE
docs: fix forge test debugger example in FAQ

### DIFF
--- a/src/pages/help/faq.mdx
+++ b/src/pages/help/faq.mdx
@@ -91,7 +91,7 @@ Common causes:
 Use the interactive debugger:
 
 ```bash
-$ forge test --debug test_MyTest
+$ forge test --match-test test_MyTest --debug
 ```
 
 Or increase verbosity to see the trace:


### PR DESCRIPTION
The FAQ's debugger example passed the test name directly after `--debug`. Since `--debug` is a bare flag and `forge test`'s only positional argument is a path glob, `test_MyTest` was treated as a file-path filter that matches no test files, so the command ran nothing. The test has to be selected with `--match-test` instead, matching the invocation shown in the debugging guides.

Same broken pattern in `forge/debugging.mdx` is already fixed by #2012.

AI assisted.
