### PR TITLE
docs(forge): enforce lint warnings in CI

### DIFF
--- a/src/pages/config/ci.mdx
+++ b/src/pages/config/ci.mdx
@@ -122,7 +122,7 @@ jobs:
         run: forge fmt --check
 
       - name: Run linter
-        run: forge lint
+        run: forge lint --deny warnings
 
       - name: Build
         run: forge build

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -138,11 +138,12 @@ lint_on_build = false
 
 ### CI integration
 
-Add linting to your CI pipeline:
+Add linting to your CI pipeline with `--deny warnings`, which exits with a non-zero
+status when warning-level lint diagnostics are emitted:
 
 ```yaml
 - name: Run linter
-  run: forge lint
+  run: forge lint --deny warnings
 ```
 
 See the [linter reference](/config/reference/linter) for all configuration options.


### PR DESCRIPTION
Updates the recommended CI command to exit with a non-zero status when Forge emits warning-level lint diagnostics. This keeps the linting guide and complete CI example consistent.

Closes foundry-rs/foundry#15913.