### PR TITLE
docs(traces): document external identification timeout

### DIFF
--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -518,6 +518,8 @@ disable_labels = false
 compact_labels = false
 # trace_depth = 10
 decode_internal = false
+# Cumulative Sourcify/Etherscan trace lookup budget in seconds; 0 disables external identification
+external_identification_timeout = 5
 
 # Address labels for trace output
 [profile.default.tracing.labels]

--- a/src/pages/config/reference/tracing.mdx
+++ b/src/pages/config/reference/tracing.mdx
@@ -11,6 +11,7 @@ verbosity = 3
 compact_labels = true
 trace_depth = 10
 decode_internal = true
+external_identification_timeout = 5
 
 [profile.default.tracing.labels]
 "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" = "vitalik.eth"
@@ -67,3 +68,17 @@ Limits the maximum depth of rendered traces.
 
 Identifies internal functions and decodes their stack parameters. Dynamic values
 stored in memory are decoded only when Foundry can match a single function.
+
+#### `external_identification_timeout`
+
+- Type: integer
+- Default: 5
+
+Sets the cumulative time budget, in seconds, for identifying contracts in traces
+through Sourcify and Etherscan. Once the budget is exhausted, Foundry renders
+the trace with any identification results it has already received.
+
+Set this value to `0` to disable all external trace identification, including
+OpenChain signature lookups. You can also pass
+`--disable-external-identification` to disable it for a single command. Neither
+setting prevents Foundry from downloading compiler versions.

--- a/src/pages/reference/cast/call.mdx
+++ b/src/pages/reference/cast/call.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Perform a call on an account without publishing a transaction"
+description: "Perform a call on an account without publishing a transaction Examples: - cast call $TOKEN \"balanceOf(address)(uint256)\" vitalik.eth - cast call $TOKEN \"transfer(address,uint256)\" vitalik.eth 100 --trace"
 ---
 
 _Generated from `cast call --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,10 @@ _Generated from `cast call --help`; see [CLI reference versions](/reference/vers
 ## cast call
 
 Perform a call on an account without publishing a transaction
+
+Examples:
+- cast call $TOKEN "balanceOf(address)(uint256)" vitalik.eth
+- cast call $TOKEN "transfer(address,uint256)" vitalik.eth 100 --trace
 
 :::terminal
 
@@ -33,8 +37,8 @@ Arguments:
 
 Options:
       --data <DATA>
-          Raw hex-encoded data for the transaction. Used instead of \[SIG\] and
-          \[ARGS\]
+          Raw hex-encoded data for the transaction. Used instead of `SIG` and
+          `ARGS`
 
       --trace
           Forks the remote rpc, executes the transaction locally and prints a
@@ -101,6 +105,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
 Transaction options:
       --gas-limit <GAS_LIMIT>
@@ -238,15 +246,19 @@ Tempo:
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
-          Remote sponsor (fee payer) service URL.
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
           
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
           
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+
           Example: `cast send 0x... --sponsor-url
-          https://sponsor.tempo.xyz/tp_abc123`
+          https://sponsor.moderato.tempo.xyz`
           
           [env: TEMPO_SPONSOR_URL=]
 

--- a/src/pages/reference/cast/run.mdx
+++ b/src/pages/reference/cast/run.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Runs a published transaction in a local environment and prints the trace"
+description: "Runs a published transaction in a local environment and prints the trace Examples: - cast run $TX_HASH - cast run $TX_HASH --quick (only use the state from the previous block) - cast run $TX_HASH --debug (open the transaction in the debugger)"
 ---
 
 _Generated from `cast run --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `cast run --help`; see [CLI reference versions](/reference/versi
 ## cast run
 
 Runs a published transaction in a local environment and prints the trace
+
+Examples:
+- cast run $TX_HASH
+- cast run $TX_HASH --quick (only use the state from the previous block)
+- cast run $TX_HASH --debug (open the transaction in the debugger)
 
 :::terminal
 
@@ -106,6 +111,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
 Rpc options:
   -r, --rpc-url <URL>

--- a/src/pages/reference/forge/coverage.mdx
+++ b/src/pages/reference/forge/coverage.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Generate coverage reports"
+description: "Generate coverage reports Examples: - forge coverage - forge coverage --report lcov --report-file lcov.info - forge coverage --match-contract CounterTest"
 ---
 
 _Generated from `forge coverage --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `forge coverage --help`; see [CLI reference versions](/reference
 ## forge coverage
 
 Generate coverage reports
+
+Examples:
+- forge coverage
+- forge coverage --report lcov --report-file lcov.info
+- forge coverage --match-contract CounterTest
 
 :::terminal
 
@@ -605,6 +610,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
   -s, --suppress-successful-traces
           Suppress successful test traces and show only traces for failures

--- a/src/pages/reference/forge/script.mdx
+++ b/src/pages/reference/forge/script.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Run a smart contract as a script, building transactions that can be sent onchain"
+description: "Run a smart contract as a script, building transactions that can be sent onchain Examples: - forge script script/Counter.s.sol (simulate the script locally) - forge script script/Counter.s.sol --rpc-url $RPC_URL --broadcast --account dev - forge script script/Counter.s.sol --rpc-url $RPC_URL --resume"
 ---
 
 _Generated from `forge script --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `forge script --help`; see [CLI reference versions](/reference/v
 ## forge script
 
 Run a smart contract as a script, building transactions that can be sent onchain
+
+Examples:
+- forge script script/Counter.s.sol (simulate the script locally)
+- forge script script/Counter.s.sol --rpc-url $RPC_URL --broadcast --account dev
+- forge script script/Counter.s.sol --rpc-url $RPC_URL --resume
 
 :::terminal
 
@@ -204,15 +209,19 @@ Tempo:
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
-          Remote sponsor (fee payer) service URL.
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
           
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
           
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+
           Example: `cast send 0x... --sponsor-url
-          https://sponsor.tempo.xyz/tp_abc123`
+          https://sponsor.moderato.tempo.xyz`
           
           [env: TEMPO_SPONSOR_URL=]
 
@@ -373,6 +382,10 @@ Tempo:
       --verify
           Verifies all the contracts found in the receipts of a script, if any
 
+      --verify-external
+          Opt-in verification of contracts deployed by external factories using
+          explorer source
+
       --with-gas-price <PRICE>
           Gas price for legacy transactions, or max fee per gas for EIP1559
           transactions, either specified in wei, or as a string with a unit
@@ -412,6 +425,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
 Cache options:
       --force

--- a/src/pages/reference/forge/snapshot.mdx
+++ b/src/pages/reference/forge/snapshot.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Create a gas snapshot of each test's gas usage"
+description: "Create a gas snapshot of each test's gas usage Examples: - forge snapshot - forge snapshot --diff (compare against the existing .gas-snapshot file) - forge snapshot --check (fail if gas usage does not match .gas-snapshot)"
 ---
 
 _Generated from `forge snapshot --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `forge snapshot --help`; see [CLI reference versions](/reference
 ## forge snapshot
 
 Create a gas snapshot of each test's gas usage
+
+Examples:
+- forge snapshot
+- forge snapshot --diff (compare against the existing .gas-snapshot file)
+- forge snapshot --check (fail if gas usage does not match .gas-snapshot)
 
 :::terminal
 
@@ -591,6 +596,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
   -s, --suppress-successful-traces
           Suppress successful test traces and show only traces for failures

--- a/src/pages/reference/forge/test.mdx
+++ b/src/pages/reference/forge/test.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Run the project's tests"
+description: "Run the project's tests Examples: - forge test - forge test --match-test test_Increment -vvvv (show traces for a matching test) - forge test --match-contract CounterTest --fuzz-runs 1000"
 ---
 
 _Generated from `forge test --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `forge test --help`; see [CLI reference versions](/reference/ver
 ## forge test
 
 Run the project's tests
+
+Examples:
+- forge test
+- forge test --match-test test_Increment -vvvv (show traces for a matching test)
+- forge test --match-contract CounterTest --fuzz-runs 1000
 
 :::terminal
 
@@ -560,6 +565,10 @@ Trace options:
           Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
           
           [alias: --label]
+
+      --disable-external-identification
+          Disable external trace identification using Sourcify, Etherscan, or
+          OpenChain
 
   -s, --suppress-successful-traces
           Suppress successful test traces and show only traces for failures

--- a/src/pages/reference/versions.mdx
+++ b/src/pages/reference/versions.mdx
@@ -10,8 +10,8 @@ The CLI pages under `/reference` are generated from the following installed bina
 
 ```text
 forge Version: 1.7.2-nightly
-Commit SHA: 4aec465267fd92b44b54fafc7fbe8ebbe7f96eca
-Build Timestamp: 2026-07-25T06:43:24.493330419Z (1784961804)
+Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
+Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
 Build Profile: dist
 ```
 
@@ -19,8 +19,8 @@ Build Profile: dist
 
 ```text
 cast Version: 1.7.2-nightly
-Commit SHA: 4aec465267fd92b44b54fafc7fbe8ebbe7f96eca
-Build Timestamp: 2026-07-25T06:43:24.493330419Z (1784961804)
+Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
+Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
 Build Profile: dist
 ```
 
@@ -28,8 +28,8 @@ Build Profile: dist
 
 ```text
 anvil Version: 1.7.2-nightly
-Commit SHA: 4aec465267fd92b44b54fafc7fbe8ebbe7f96eca
-Build Timestamp: 2026-07-25T06:43:24.493330419Z (1784961804)
+Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
+Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
 Build Profile: dist
 ```
 
@@ -37,7 +37,7 @@ Build Profile: dist
 
 ```text
 chisel Version: 1.7.2-nightly
-Commit SHA: 4aec465267fd92b44b54fafc7fbe8ebbe7f96eca
-Build Timestamp: 2026-07-25T06:43:24.493330419Z (1784961804)
+Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
+Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
 Build Profile: dist
 ```


### PR DESCRIPTION
## Summary

- document the five-second external trace-identification timeout introduced by foundry-rs/foundry#15883
- explain how zero disables Sourcify, Etherscan, and OpenChain identification while compiler downloads remain enabled
- add `--disable-external-identification` to the affected Forge and Cast command references
- update the default tracing configuration and CLI reference versions

## Generation

The affected command references were generated with the latest published Foundry nightly:

```text
Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
Build Profile: dist
```

## Validation

- `git diff --check`
- `bunx vocs build`
- inspected the rendered Markdown for all six affected commands and the versions page

## AI assistance

OpenAI Codex was used to prepare this change.
