### PR TITLE
docs(config): document nested remappings

### DIFF
--- a/src/pages/config/reference/solidity-compiler.mdx
+++ b/src/pages/config/reference/solidity-compiler.mdx
@@ -19,7 +19,8 @@ Configuration related to the behavior of the Solidity compiler.
 - Default: none
 - Environment: `FOUNDRY_REMAPPINGS` or `DAPP_REMAPPINGS`
 
-An array of remappings in the following format: `<name>=<target>`.
+An array of remappings in the following format: `[<context>:]<name>=<target>`. The optional
+`<context>` restricts the remapping to imports made by source units whose names begin with it.
 
 A remapping _remaps_ Solidity imports to different directories. For example, the following remapping
 
@@ -38,6 +39,10 @@ becomes
 ```solidity
 import {Context} from "node_modules/@openzeppelin/openzeppelin-contracts/contracts/utils/Context.sol";
 ```
+
+Foundry can generate contextual remappings for dependencies while retaining a broader package
+fallback. See [Nested dependency remappings](/projects/dependencies#nested-dependency-remappings)
+for details.
 
 ##### `auto_detect_remappings`
 

--- a/src/pages/projects/dependencies.mdx
+++ b/src/pages/projects/dependencies.mdx
@@ -97,6 +97,27 @@ Save to a file for IDE support:
 $ forge remappings > remappings.txt
 ```
 
+#### Nested dependency remappings
+
+When a dependency remapping points below an auto-detected package root, Foundry preserves both by
+scoping the dependency remapping to the directory that declares it. For example, `forge remappings`
+can output:
+
+```txt
+lib/outer/:inner/=lib/outer/lib/inner/contracts/
+inner/=lib/outer/lib/inner/
+```
+
+The contextual form `<context>:<name>=<target>` applies to imports made by source units whose names
+begin with `<context>`. Here, the trailing slash in `lib/outer/` creates a directory boundary, so
+sources inside `lib/outer/` use the dependency's `contracts/` directory while root sources and
+sibling dependencies use the auto-detected package-root mapping.
+
+Foundry preserves explicit root-project and CLI remappings when constructing generated dependency
+contexts. An equal or broader global alias suppresses the generated context. A narrower global
+alias is overlaid into that context, so it overrides only its matching import subtree while the
+dependency mapping handles the remaining imports. Explicit contextual remappings are unchanged.
+
 ### Updating dependencies
 
 Use `forge install` to add a dependency or initialize the dependencies already recorded in a checkout. Running it without arguments reconciles existing git submodules and `foundry.lock`; it does not intentionally fetch newer dependency revisions.


### PR DESCRIPTION
Documents contextual remapping syntax and explains how Foundry scopes nested dependency refinements while retaining package-root fallbacks and explicit remapping precedence. Companion to foundry-rs/foundry#15929. AI assistance was used to draft and review these changes.