### PR TITLE
docs(cast): document browser wallet restoration

### DIFF
--- a/src/pages/cast/wallet-operations.mdx
+++ b/src/pages/cast/wallet-operations.mdx
@@ -66,6 +66,10 @@ $ cast wallet sign "Hello, Ethereum!" --private-key $KEY
 $ cast wallet sign "Hello, Ethereum!" --keystore ~/.foundry/keystores/my-key
 ```
 
+```bash [With browser wallet]
+$ cast wallet sign "Hello, Ethereum!" --browser
+```
+
 ```bash [Sign a 32-byte hash]
 $ cast wallet sign --no-hash $HASH --private-key $KEY
 ```
@@ -103,6 +107,8 @@ $ cast wallet sign --data '{
     }
   }' --private-key $KEY
 ```
+
+Use `--browser` instead of a private-key option to sign the typed data with an injected browser wallet. Browser wallets support personal-message and EIP-712 signing, but not raw-hash signing with `--no-hash`.
 
 ### Verifying signatures
 

--- a/src/pages/guides/browser-wallet.mdx
+++ b/src/pages/guides/browser-wallet.mdx
@@ -1,10 +1,10 @@
 ---
-description: Send Cast and Forge transactions through an injected browser wallet.
+description: Use an injected browser wallet with Cast and Forge.
 ---
 
 ## Browser Wallet Signing
 
-Foundry can hand transaction requests to an injected browser wallet instead of loading a private key in the CLI. The wallet shows its normal approval prompt, signs the request, broadcasts it, and returns the transaction hash to Foundry.
+Foundry can connect to an injected browser wallet instead of loading a private key in the CLI. You can use the connected account to sign messages, resolve the sender for simulations, and approve transactions through the wallet's normal prompts.
 
 :::warning
 Browser wallet support is still in early development. Review every request and use it cautiously. For high-value production operations, prefer a well-tested hardware wallet or organizational signer policy.
@@ -22,7 +22,40 @@ $ cast send $CONTRACT "mint(address,uint256)" $RECIPIENT 1 \
 
 Foundry opens a local page, waits for you to connect an injected wallet, and then submits the transaction request to that wallet. Confirm the account, network, destination, value, calldata, and fees in the wallet prompt. `cast send` waits for the receipt by default; add `--async` to print the hash and exit after the wallet submits it.
 
-The same browser options are available on other Cast commands that submit on-chain transactions, including the ERC-20 transaction commands. They are not part of `cast wallet sign`; check a command's `--help` output for the **Wallet options - browser wallet** section.
+The same browser options are available on other Cast commands that submit on-chain transactions, including the ERC-20 transaction commands. Check a command's `--help` output for the **Wallet options - browser wallet** section.
+
+### Sign a message
+
+Use the connected browser account to sign a personal message:
+
+```bash
+$ cast wallet sign "Hello, Ethereum!" --browser
+```
+
+Pass `--data` to sign dynamic EIP-712 typed data. Browser wallets do not support signing a raw hash with `--no-hash`.
+
+Foundry verifies that the returned personal-message or EIP-712 signature belongs to the connected account. The command fails if the signature recovers to a different address.
+
+### Resolve the account for a simulation
+
+Use `--browser` when a read-only command should use the connected account as its sender:
+
+```bash
+$ cast wallet address --browser
+$ cast call $CONTRACT "balanceOf(address)(uint256)" $ACCOUNT \
+    --rpc-url $RPC_URL \
+    --browser
+$ cast estimate $CONTRACT "transfer(address,uint256)" $TO $AMOUNT \
+    --rpc-url $RPC_URL \
+    --browser
+$ cast access-list $CONTRACT "transfer(address,uint256)" $TO $AMOUNT \
+    --rpc-url $RPC_URL \
+    --browser
+```
+
+These commands connect to the wallet to obtain its address; they do not ask it to sign or submit a transaction. `cast estimate` also prepares the request for browser-wallet transaction behavior where the network requires it.
+
+`cast call --curl` only prints an offline RPC request and cannot connect to a browser wallet. Use `--from <ADDRESS>` instead of `--browser` when generating a curl command.
 
 ### Deploy a contract
 
@@ -90,7 +123,7 @@ Each command creates a new local session and stops its bridge when the signer is
 
 ### Check the account and network
 
-Foundry records the address and chain ID reported at connection time. Before a transaction is sent, it verifies that the request's `from` address and `chainId` match the connected wallet. Cast may ask the wallet to switch to the RPC network; approve that switch before the transaction request. Forge commands should start with the wallet already on the target network.
+Foundry records the address and chain ID reported at connection time. Before a transaction is sent, it verifies that the request's `from` address and `chainId` match the connected wallet. It also verifies that personal-message and EIP-712 signatures recover to the connected address. Cast may ask the wallet to switch to the RPC network; approve that switch before the transaction request. Forge commands should start with the wallet already on the target network.
 
 The CLI RPC and the browser wallet both participate in the flow. Foundry uses the CLI RPC for simulation, fee and gas estimation, and receipt polling, while the browser wallet submits the approved transaction through its provider. Make sure both point to the same chain.
 
@@ -108,4 +141,4 @@ Browser signing is a useful boundary between preparation and authorization:
 
 An agent should not treat a connected browser as blanket permission to send transactions. Keep the final `--broadcast --browser` invocation and wallet approvals as an explicit user-authorized step. For unattended CI, use a purpose-built keystore, hardware, KMS, or remote signer workflow with scoped credentials and policy controls.
 
-See the [`cast send`](/reference/cast/send), [`forge create`](/reference/forge/create), and [`forge script`](/reference/forge/script) references for transaction-specific options.
+See the [`cast wallet sign`](/reference/cast/wallet/sign), [`cast call`](/reference/cast/call), [`cast estimate`](/reference/cast/estimate), [`cast access-list`](/reference/cast/access-list), [`cast send`](/reference/cast/send), [`forge create`](/reference/forge/create), and [`forge script`](/reference/forge/script) references for command-specific options.

--- a/src/pages/reference/cast/access-list.mdx
+++ b/src/pages/reference/cast/access-list.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Create an access list for a transaction"
+description: "Create an access list for a transaction Examples: - cast access-list vitalik.eth --value 0.1ether - cast access-list $TOKEN \"transfer(address,uint256)\" vitalik.eth 100"
 ---
 
 _Generated from `cast access-list --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,10 @@ _Generated from `cast access-list --help`; see [CLI reference versions](/referen
 ## cast access-list
 
 Create an access list for a transaction
+
+Examples:
+- cast access-list vitalik.eth --value 0.1ether
+- cast access-list $TOKEN "transfer(address,uint256)" vitalik.eth 100
 
 :::terminal
 
@@ -29,8 +33,8 @@ Arguments:
 
 Options:
       --data <DATA>
-          Raw hex-encoded data for the transaction. Used instead of \[SIG\] and
-          \[ARGS\]
+          Raw hex-encoded data for the transaction. Used instead of `SIG` and
+          `ARGS`
 
   -B, --block <BLOCK>
           The block height to query at.
@@ -113,9 +117,9 @@ Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
           
-          When set, Foundry resolves the session from
-          `$TEMPO_HOME/wallet/sessions.toml` and signs Tempo transactions with
-          the session's temporary access key on behalf of its root account.
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
 
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
@@ -185,15 +189,19 @@ Tempo:
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
-          Remote sponsor (fee payer) service URL.
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
           
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
           
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+
           Example: `cast send 0x... --sponsor-url
-          https://sponsor.tempo.xyz/tp_abc123`
+          https://sponsor.moderato.tempo.xyz`
           
           [env: TEMPO_SPONSOR_URL=]
 
@@ -405,6 +413,18 @@ Wallet options - Tempo:
           Required when `--tempo.access-key` is set.
           
           [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
 
 Display options:
       --color <COLOR>

--- a/src/pages/reference/cast/call.mdx
+++ b/src/pages/reference/cast/call.mdx
@@ -174,9 +174,9 @@ Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
           
-          When set, Foundry resolves the session from
-          `$TEMPO_HOME/wallet/sessions.toml` and signs Tempo transactions with
-          the session's temporary access key on behalf of its root account.
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
 
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
@@ -401,37 +401,6 @@ Wallet options - raw:
           
           [default: 0]
 
-  -c, --chain <CHAIN>
-          [env: CHAIN=]
-
-      --with-local-artifacts
-          Use current project artifacts for trace decoding
-          
-          [alias: --la]
-
-      --override-balance <ADDRESS:BALANCE>
-          Override account balances. Format: "address:balance,address:balance"
-
-      --override-nonce <ADDRESS:NONCE>
-          Override account nonces. Format: "address:nonce,address:nonce"
-
-      --override-code <ADDRESS:CODE>
-          Override account code. Format: "address:code,address:code"
-
-      --override-state <ADDRESS:SLOT:VALUE>
-          Override account state and replace the current state entirely with the
-          new one. Format: "address:slot:value,address:slot:value"
-
-      --override-state-diff <ADDRESS:SLOT:VALUE>
-          Override specific account storage slots and preserve the rest of the
-          state. Format: "address:slot:value,address:slot:value"
-
-      --block.time <TIME>
-          Override the block timestamp
-
-      --block.number <NUMBER>
-          Override the block number
-
 Wallet options - keystore:
       --keystore <PATH>
           Use the keystore in the given folder or file
@@ -501,6 +470,49 @@ Wallet options - Tempo:
           Required when `--tempo.access-key` is set.
           
           [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+  -c, --chain <CHAIN>
+          [env: CHAIN=]
+
+      --with-local-artifacts
+          Use current project artifacts for trace decoding
+
+          [alias: --la]
+
+      --override-balance <ADDRESS:BALANCE>
+          Override account balances. Format: "address:balance,address:balance"
+
+      --override-nonce <ADDRESS:NONCE>
+          Override account nonces. Format: "address:nonce,address:nonce"
+
+      --override-code <ADDRESS:CODE>
+          Override account code. Format: "address:code,address:code"
+
+      --override-state <ADDRESS:SLOT:VALUE>
+          Override account state and replace the current state entirely with the
+          new one. Format: "address:slot:value,address:slot:value"
+
+      --override-state-diff <ADDRESS:SLOT:VALUE>
+          Override specific account storage slots and preserve the rest of the
+          state. Format: "address:slot:value,address:slot:value"
+
+      --block.time <TIME>
+          Override the block timestamp
+
+      --block.number <NUMBER>
+          Override the block number
 
 Display options:
       --color <COLOR>

--- a/src/pages/reference/cast/estimate.mdx
+++ b/src/pages/reference/cast/estimate.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Estimate the gas cost of a transaction"
+description: "Estimate the gas cost of a transaction Examples: - cast estimate vitalik.eth --value 0.1ether - cast estimate $CONTRACT \"deposit()\" --value 1ether"
 ---
 
 _Generated from `cast estimate --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,10 @@ _Generated from `cast estimate --help`; see [CLI reference versions](/reference/
 ## cast estimate
 
 Estimate the gas cost of a transaction
+
+Examples:
+- cast estimate vitalik.eth --value 0.1ether
+- cast estimate $CONTRACT "deposit()" --value 1ether
 
 :::terminal
 
@@ -154,6 +158,18 @@ Wallet options - Tempo:
           
           [env: TEMPO_ROOT_ACCOUNT=]
 
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
 Transaction options:
       --gas-limit <GAS_LIMIT>
           Gas limit for the transaction
@@ -218,9 +234,9 @@ Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
           
-          When set, Foundry resolves the session from
-          `$TEMPO_HOME/wallet/sessions.toml` and signs Tempo transactions with
-          the session's temporary access key on behalf of its root account.
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
 
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
@@ -290,15 +306,19 @@ Tempo:
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
-          Remote sponsor (fee payer) service URL.
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
           
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
           
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+
           Example: `cast send 0x... --sponsor-url
-          https://sponsor.tempo.xyz/tp_abc123`
+          https://sponsor.moderato.tempo.xyz`
           
           [env: TEMPO_SPONSOR_URL=]
 

--- a/src/pages/reference/cast/wallet/address.mdx
+++ b/src/pages/reference/cast/wallet/address.mdx
@@ -135,6 +135,18 @@ Wallet options - Tempo:
           
           [env: TEMPO_ROOT_ACCOUNT=]
 
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
 Display options:
       --color <COLOR>
           The color of the log messages

--- a/src/pages/reference/cast/wallet/sign.mdx
+++ b/src/pages/reference/cast/wallet/sign.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Sign a message or typed data"
+description: "Sign a message or typed data Examples: - cast wallet sign \"hello\" --account dev - cast wallet sign \"hello\" --private-key $PK - cast wallet sign --data --from-file typed_data.json --ledger"
 ---
 
 _Generated from `cast wallet sign --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
@@ -7,6 +7,11 @@ _Generated from `cast wallet sign --help`; see [CLI reference versions](/referen
 ## cast wallet sign
 
 Sign a message or typed data
+
+Examples:
+- cast wallet sign "hello" --account dev
+- cast wallet sign "hello" --private-key $PK
+- cast wallet sign --data --from-file typed_data.json --ledger
 
 :::terminal
 
@@ -156,6 +161,18 @@ Wallet options - Tempo:
           Required when `--tempo.access-key` is set.
           
           [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
 
 Display options:
       --color <COLOR>

--- a/src/pages/reference/versions.mdx
+++ b/src/pages/reference/versions.mdx
@@ -9,35 +9,35 @@ The CLI pages under `/reference` are generated from the following installed bina
 ### `forge`
 
 ```text
-forge Version: 1.7.2-nightly
-Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
-Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
+forge Version: 1.8.0-nightly
+Commit SHA: fa8b5fc25b5b4340152dea9010777f9e5cb2fc8a
+Build Timestamp: 2026-08-04T06:53:31.479266000Z (1785826411)
 Build Profile: dist
 ```
 
 ### `cast`
 
 ```text
-cast Version: 1.7.2-nightly
-Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
-Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
+cast Version: 1.8.0-nightly
+Commit SHA: fa8b5fc25b5b4340152dea9010777f9e5cb2fc8a
+Build Timestamp: 2026-08-04T06:53:31.479266000Z (1785826411)
 Build Profile: dist
 ```
 
 ### `anvil`
 
 ```text
-anvil Version: 1.7.2-nightly
-Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
-Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
+anvil Version: 1.8.0-nightly
+Commit SHA: fa8b5fc25b5b4340152dea9010777f9e5cb2fc8a
+Build Timestamp: 2026-08-04T06:53:31.479266000Z (1785826411)
 Build Profile: dist
 ```
 
 ### `chisel`
 
 ```text
-chisel Version: 1.7.2-nightly
-Commit SHA: 043d28e25b23905d37e0fa03a4d95c42933791f8
-Build Timestamp: 2026-07-28T06:53:15.988178000Z (1785221595)
+chisel Version: 1.8.0-nightly
+Commit SHA: fa8b5fc25b5b4340152dea9010777f9e5cb2fc8a
+Build Timestamp: 2026-08-04T06:53:31.479266000Z (1785826411)
 Build Profile: dist
 ```


### PR DESCRIPTION
## Summary

- document restored browser-wallet signing for personal messages and EIP-712 typed data
- document browser address resolution for `cast wallet address`, `cast call`, `cast estimate`, and `cast access-list`
- regenerate the affected Cast references with Foundry `1.8.0-nightly` (`fa8b5fc25b`)

## Motivation

Foundry [#16012](https://github.com/foundry-rs/foundry/pull/16012) restored `cast wallet sign --browser`, and [#16015](https://github.com/foundry-rs/foundry/pull/16015) restored browser-wallet support for the read-only Cast commands. The browser-wallet guide still said that `cast wallet sign` did not support browser wallets, and the affected generated references did not expose the restored options.

The guide now also calls out the intentional limitations: raw-hash signing is unsupported, and `cast call --browser --curl` must use an explicit `--from` address instead.

This PR was written with Codex assistance, including documentation updates and validation.
