### PR TITLE
docs(cast): add bytes memory reference

### DIFF
--- a/scripts/gen_output/help.rs
+++ b/scripts/gen_output/help.rs
@@ -422,7 +422,7 @@ fn categorize_command(cmd_name: &str, tool_name: &str) -> &'static str {
             "lookup-address" | "resolve-name" | "namehash" => "ENS Commands",
             "etherscan-source" | "source" => "Etherscan Commands",
             "abi-encode" | "4byte" | "4byte-calldata" | "4byte-event" | "calldata" | "decode-abi" | "decode-calldata" | "pretty-calldata" | "selectors" | "upload-signature" => "ABI Commands",
-            "format-bytes32-string" | "from-bin" | "from-fixed-point" | "from-rlp" | "from-utf8" | "from-wei" | "parse-bytes32-address" | "parse-bytes32-string" | "to-ascii" | "to-base" | "to-bytes32" | "to-dec" | "to-fixed-point" | "to-hex" | "to-hexdata" | "to-int256" | "to-rlp" | "to-uint256" | "to-unit" | "to-wei" | "shl" | "shr" => "Conversion Commands",
+            "format-bytes32-string" | "from-bin" | "from-fixed-point" | "from-rlp" | "from-utf8" | "from-wei" | "parse-bytes32-address" | "parse-bytes32-string" | "to-ascii" | "to-base" | "to-bytes-memory" | "to-bytes32" | "to-dec" | "to-fixed-point" | "to-hex" | "to-hexdata" | "to-int256" | "to-rlp" | "to-uint256" | "to-unit" | "to-wei" | "shl" | "shr" => "Conversion Commands",
             "address-zero" | "sig" | "sig-event" | "keccak" | "compute-address" | "create2" | "interface" | "index" | "concat-hex" | "max-int" | "min-int" | "max-uint" | "to-check-sum-address" => "Utility Commands",
             "wallet" => "Wallet Commands",
             _ => "Utility Commands",

--- a/sidebar/cast-cli-reference.ts
+++ b/sidebar/cast-cli-reference.ts
@@ -72,6 +72,7 @@ export const castCliReference: SidebarItem = {
                 { text: "cast shr", link: "/reference/cast/shr" },
                 { text: "cast to-ascii", link: "/reference/cast/to-ascii" },
                 { text: "cast to-base", link: "/reference/cast/to-base" },
+                { text: "cast to-bytes-memory", link: "/reference/cast/to-bytes-memory" },
                 { text: "cast to-bytes32", link: "/reference/cast/to-bytes32" },
                 { text: "cast to-dec", link: "/reference/cast/to-dec" },
                 { text: "cast to-fixed-point", link: "/reference/cast/to-fixed-point" },

--- a/src/pages/reference/cast/cast.mdx
+++ b/src/pages/reference/cast/cast.mdx
@@ -174,6 +174,8 @@ Commands:
                          --to-ascii, tas, 2as]
   to-base                Converts a number of one base to another [aliases:
                          --to-base, --to-radix, to-radix, tr, 2r]
+  to-bytes-memory        Convert hex data to the word-aligned layout of a
+                         Solidity `bytes memory` value [alias: tbm]
   to-bytes32             Right-pads hex data to 32 bytes [aliases: --to-bytes32,
                          tb, 2b]
   to-check-sum-address   Convert an address to a checksummed format (EIP-55)

--- a/src/pages/reference/cast/to-bytes-memory.mdx
+++ b/src/pages/reference/cast/to-bytes-memory.mdx
@@ -1,0 +1,75 @@
+---
+description: "Convert hex data to the word-aligned layout of a Solidity `bytes memory` value. The output contains a 32-byte length prefix followed by the data, right-padded with zeros to a whole number of 32-byte words."
+---
+
+_Generated from `cast to-bytes-memory --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast to-bytes-memory
+
+Convert hex data to the word-aligned layout of a Solidity `bytes memory` value.
+
+The output contains a 32-byte length prefix followed by the data, right-padded
+with zeros to a whole number of 32-byte words.
+
+:::terminal
+
+```bash
+$ cast to-bytes-memory --help
+```
+
+```txt
+Usage: cast to-bytes-memory [OPTIONS] [DATA]
+
+Arguments:
+  [DATA]
+          The hex data to convert
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::


### PR DESCRIPTION
Adds the generated CLI reference for `cast to-bytes-memory`, exposes the `tbm` alias in the root Cast reference, and teaches the sidebar generator to keep the command under Conversion Commands. This lets the documentation land alongside the new command instead of waiting for the next full CLI reference refresh.

Depends on [foundry-rs/foundry#16103](https://github.com/foundry-rs/foundry/pull/16103).

This PR was implemented and validated with OpenAI Codex; the contributor requested and reviewed the scope.
