### PR TITLE
docs(forge): clarify Vocs migration

### DIFF
--- a/src/pages/forge/documentation.mdx
+++ b/src/pages/forge/documentation.mdx
@@ -44,6 +44,10 @@ docs/
         └── interface.ICounter.mdx
 ```
 
+::::note[Foundry 1.7.1 and earlier]
+Prior Foundry releases generate an mdBook site with `book.toml`, `book.css`, and Markdown pages under `docs/src/`. The Vocs migration replaces that layout with the scaffold above. When upgrading an existing project, generate into a clean output directory so legacy mdBook files are not mixed into the Vocs site.
+::::
+
 Use `--out <PATH>` to generate elsewhere. By default, Forge documents the project's source directory and excludes external libraries. Pass `--include-libraries` when library APIs belong in the published site.
 
 ### Configure generation


### PR DESCRIPTION
Clarifies that Foundry 1.7.1 and earlier generate the legacy mdBook layout, while the current `forge doc` implementation emits the canonical Vocs scaffold. It also recommends generating into a clean output directory when upgrading so legacy mdBook files are not mixed into the Vocs site.

Closes foundry-rs/foundry#16132.

This PR was prepared with assistance from Codex.
