### PR TITLE
docs: document Solar source installation

### DIFF
--- a/src/pages/introduction/installation.md
+++ b/src/pages/introduction/installation.md
@@ -109,7 +109,7 @@ $ rustup update stable
 ```
 
 ```bash [Install from GitHub]
-$ cargo install --git https://github.com/foundry-rs/foundry --profile release --locked forge cast chisel anvil
+$ cargo install --git https://github.com/foundry-rs/foundry --profile release --locked forge cast chisel anvil solar
 ```
 
 Or build from a local clone:
@@ -121,7 +121,10 @@ $ cargo install --path ./crates/forge --profile release --locked
 $ cargo install --path ./crates/cast --profile release --locked
 $ cargo install --path ./crates/anvil --profile release --locked
 $ cargo install --path ./crates/chisel --profile release --locked
+$ cargo install --path ./crates/solar --profile release --locked
 ```
+
+The `solar` package in the Foundry workspace builds the Solar compiler distributed with Foundry. The compiler's source is maintained in the separate [Solar repository](https://github.com/paradigmxyz/solar).
 
 You can also use foundryup to build from source:
 


### PR DESCRIPTION
Adds Solar to both source-installation commands and clarifies that Foundry's workspace package builds the compiler maintained in the separate Solar repository.

This PR was written with Codex.

Prompted by: @grandizzy
