### PR TITLE
docs: document expectCallMinGas

### DIFF
--- a/scripts/cheatcode-coverage.json
+++ b/scripts/cheatcode-coverage.json
@@ -352,7 +352,6 @@
     "deleteSnapshots",
     "envExists",
     "eth_getLogs",
-    "expectCallMinGas",
     "expectCreate",
     "expectCreate2",
     "fromRlp",

--- a/src/pages/reference/cheatcodes/expect-call.mdx
+++ b/src/pages/reference/cheatcodes/expect-call.mdx
@@ -9,8 +9,10 @@ description: Asserts that a specific call is made during test execution
 ```solidity
 function expectCall(address callee, bytes calldata data) external;
 function expectCall(address callee, bytes calldata data, uint64 count) external;
-function expectCall(address callee, uint256 value, bytes calldata data) external;
-function expectCall(address callee, uint256 value, bytes calldata data, uint64 count) external;
+function expectCall(address callee, uint256 msgValue, bytes calldata data) external;
+function expectCall(address callee, uint256 msgValue, bytes calldata data, uint64 count) external;
+function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data) external;
+function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data, uint64 count) external;
 function expectDelegateCall(address callee, bytes calldata data) external;
 ```
 
@@ -20,11 +22,14 @@ Expects a call to a specified address `callee`, where the call data either stric
 
 Use `expectDelegateCall` when only a delegate call should satisfy the expectation. It uses the same calldata matching behavior as `expectCall`, but an ordinary call does not match it.
 
+Use `expectCallMinGas` to additionally require that the call is supplied with at least `minGas` gas. The minimum applies to the gas supplied to the call, not the gas consumed during execution.
+
 | Signature Variant | Description |
 |-------------------|-------------|
 | Without `count` | Call must be made at least once (can be called multiple times to expect multiple calls) |
 | With `count` | Call must be made exactly `count` times |
-| With `value` | Also checks that the call was made with the specified `msg.value` |
+| With `msgValue` | Also checks that the call was made with the specified `msg.value` |
+| With `minGas` | Uses `expectCallMinGas` to require at least the specified gas for the matching call |
 
 Set `count` to 0 to assert that a call is **not** made.
 
@@ -36,7 +41,8 @@ If the test terminates without the expected call being made, the test fails.
 |-----------|-----------|-------------------------------------------------------|
 | `callee`  | `address` | The address expected to be called                     |
 | `data`    | `bytes`   | The expected calldata (can be partial, matching from first byte) |
-| `value`   | `uint256` | The expected `msg.value` for the call                 |
+| `msgValue` | `uint256` | The expected `msg.value` for the call                |
+| `minGas`  | `uint64`  | The minimum gas that must be supplied to the call     |
 | `count`   | `uint64`  | Exact number of times the call should be made         |
 
 ### Examples
@@ -130,6 +136,12 @@ function testExpectCallWithValue() public {
     
     target.pay{value: 1 ether}(2);
 }
+```
+
+#### Expect a call with minimum gas
+
+```solidity [test/ExpectCallMinGas.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/ExpectCallMinGas.t.sol:minimum-gas]
 ```
 
 ### Gotchas

--- a/src/snippets/projects/cheatcodes/test/ExpectCallMinGas.t.sol
+++ b/src/snippets/projects/cheatcodes/test/ExpectCallMinGas.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+contract MinimumGasTarget {
+    function add(uint256 a, uint256 b) external pure returns (uint256) {
+        return a + b;
+    }
+}
+
+contract MinimumGasCaller {
+    MinimumGasTarget private immutable target;
+
+    constructor(MinimumGasTarget target_) {
+        target = target_;
+    }
+
+    function addWithGasLimit(uint256 a, uint256 b) external view returns (uint256) {
+        return target.add{gas: 50_000}(a, b);
+    }
+}
+
+contract ExpectCallMinGasTest is Test {
+    // [!region minimum-gas]
+    function testExpectCallWithMinimumGas() public {
+        MinimumGasTarget target = new MinimumGasTarget();
+        MinimumGasCaller caller = new MinimumGasCaller(target);
+
+        vm.expectCallMinGas(address(target), 0, 25_000, abi.encodeCall(target.add, (1, 2)));
+
+        assertEq(caller.addWithGasLimit(1, 2), 3);
+    }
+    // [!endregion minimum-gas]
+}


### PR DESCRIPTION
This documents both `expectCallMinGas` overloads, explains that `minGas` checks the gas supplied to the matching call rather than gas consumed during execution, adds a runnable Solidity example, and removes the cheatcode from `knownMissing`.

The focused example test passes with 1 test passed and 0 failed. `bun run check:cheatcodes` passes with 234 of 315 function names mentioned and 81 known gaps. The added Solidity file passes its focused `forge fmt --check`, and `git diff --check` passes.

On this Windows environment, `bunx vocs build` is blocked by the same pre-existing Vocs failure reproduced before this change: `Maximum call stack size exceeded` from `getMdxLayoutImport` under Node.js v24.14.0. It is therefore not reported as a passing check.

AI assistance disclosure: This PR was prepared with Codex. Codex helped draft the documentation and Solidity example, inspect the relevant Foundry source, run validation, and prepare the submission. I directed the scope and authorized the final submission.

Closes #878