### PR TITLE
docs(tempo): document sponsorship flows and anvil built-in fee payer

### DIFF
--- a/src/pages/anvil/rpc-methods.mdx
+++ b/src/pages/anvil/rpc-methods.mdx
@@ -562,6 +562,16 @@ Parameters: `rawTransaction` — raw signed transaction as hex.
 $ cast rpc anvil_classifyTransaction $RAW_TX
 ```
 
+#### eth_signRawTransaction
+
+Signs a sender-signed Tempo transaction as the node's fee payer (sponsor) and returns the fully signed raw transaction without broadcasting it. This is the sign-only mode of the Tempo fee payer service contract, so `cast send --sponsor-url` and the Tempo SDK relay transport can point directly at Anvil; raw transactions submitted to `eth_sendRawTransaction` with the sponsorship placeholder are sponsored automatically instead. The sponsor account defaults to the last dev account and is configurable with Anvil's `--tempo.fee-payer` option; it selects the fee token when the sender left it open and must not equal the transaction sender. See the [sponsorship guide](/guides/tempo#sponsorship) for the end-to-end flow.
+
+Parameters: `rawTransaction` — sender-signed Tempo transaction as hex, carrying the fee payer signature placeholder.
+
+```bash [Sponsor-sign a raw transaction]
+$ cast rpc eth_signRawTransaction $RAW_TX
+```
+
 ### Nonstandard eth_ methods
 
 Anvil also serves a number of `eth_` methods beyond the standard Ethereum JSON-RPC specification.

--- a/src/pages/guides/tempo.mdx
+++ b/src/pages/guides/tempo.mdx
@@ -154,7 +154,9 @@ Use [`cast batch-mktx`](/reference/cast/batch-mktx) to build a signed or unsigne
 
 ### Sponsorship
 
-Tempo sponsorship lets a fee payer sponsor another account's transaction. Foundry supports:
+Tempo sponsorship lets a fee payer pay gas for another account's transaction. The sender signs the transaction with a fee payer placeholder, leaving the two sponsor-owned fields open: the fee token and the fee payer signature. The sponsor fills them by signing the sponsor digest, which commits to the full transaction, so nonce, gas, and fee fields are pinned once the digest exists. Protocol details live in Tempo's [fee sponsorship guide](https://docs.tempo.xyz/docs/guide/payments/sponsor-user-fees).
+
+Foundry supports:
 
 - `--tempo.sponsor` for the sponsor address.
 - `--tempo.sponsor-signer` for in-band sponsor signing.
@@ -163,6 +165,34 @@ Tempo sponsorship lets a fee payer sponsor another account's transaction. Foundr
 - `--tempo.print-sponsor-hash` when the sponsor needs the hash to sign out of band.
 
 For multi-transaction `forge script --broadcast` runs, prefer `--tempo.sponsor-signer` over a static `--tempo.sponsor-sig` so retries and later transactions can receive fresh sponsor signatures.
+
+#### Remote sponsor services
+
+With `--sponsor-url`, the sender-signed transaction is forwarded to a sponsor service via `eth_signRawTransaction`. The service selects the fee token it pays with, adds its fee payer signature, and returns the fully sponsored transaction, which is then submitted through the regular RPC; no local sponsor key is required. Hosted Tempo networks run such a service, built on the Accounts SDK [relay handler](https://docs.tempo.xyz/docs/server/relay-handler); the deployed worker is public at [`tempoxyz/tempo-apps`](https://github.com/tempoxyz/tempo-apps/tree/main/apps/fee-payer).
+
+```bash
+$ cast send $TOKEN "transfer(address,uint256)" $RECIPIENT 1000 \
+    --rpc-url tempo \
+    --sponsor-url https://sponsor.tempo.xyz \
+    --private-key $PRIVATE_KEY
+```
+
+#### Anvil's built-in fee payer
+
+In Tempo mode, Anvil serves the sponsor service contract itself, so sponsored flows work locally without hosting a separate service: [`eth_signRawTransaction`](/anvil/rpc-methods#eth_signrawtransaction) sponsor-signs a sender-signed Tempo transaction, and raw transactions submitted with the sponsorship placeholder are sponsored automatically on submission. Point `--sponsor-url` at the node itself:
+
+```bash
+$ anvil --network tempo
+```
+
+```bash
+$ cast send $TOKEN "transfer(address,uint256)" $RECIPIENT 1000 \
+    --rpc-url http://127.0.0.1:8545 \
+    --sponsor-url http://127.0.0.1:8545 \
+    --private-key $PRIVATE_KEY
+```
+
+The sponsor account defaults to the last dev account and pays with its stored fee token. Pass `--tempo.fee-payer` to Anvil to sponsor with a different unlocked account; the sponsor must not equal the transaction sender.
 
 ### Access-key and session signing
 


### PR DESCRIPTION
Expands the Tempo guide's sponsorship section with how fee payer sponsorship works (the sponsor-owned fields and digest pinning), the remote sponsor service flow behind `--sponsor-url`, and the anvil built-in fee payer added in foundry-rs/foundry#16278, including an `eth_signRawTransaction` entry in the anvil RPC method reference. Links Tempo's fee sponsorship guide, the Accounts relay handler docs, and the public fee payer worker as protocol references.

The `--tempo.fee-payer` anvil flag is mentioned in prose only, since the generated anvil CLI reference regenerates with the next foundry release.

> Written primarily by Claude Code, reviewed by me.