### PR TITLE
docs: improve agent discovery guidance

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -13,6 +13,7 @@ import { SponsorCards } from './components/Sponsors'
 
 <HomePage.Root>
   <img src="/foundry-banner.png" alt="Foundry" className="max-w-[600px] w-full mx-auto rounded-xl" />
+  <h1 className="sr-only">Foundry</h1>
   <HomePage.Tagline>Blazing fast smart contract development toolkit</HomePage.Tagline>
 
 <div className="max-md:-mx-[var(--vocs-content_horizontalPadding,24px)] max-md:[&_[data-v-code-container]]:!rounded-none max-md:[&_pre]:!whitespace-pre-wrap max-md:[&_pre]:!overflow-x-hidden max-md:[&_pre]:!break-all max-md:[&_code]:!block max-md:[&_code]:!whitespace-pre-wrap max-md:[&_code]:!break-all max-md:[&_.line]:!whitespace-pre-wrap max-md:[&_.line]:!break-all">

--- a/src/pages/introduction/agents.mdx
+++ b/src/pages/introduction/agents.mdx
@@ -6,6 +6,19 @@ description: Retrieve Foundry documentation efficiently from AI agents and other
 
 The Foundry documentation is available as rendered HTML, page-level Markdown, compact and full text indexes, and an MCP server. Use the smallest source that answers the task instead of loading the entire book.
 
+### When to use Foundry
+
+Use Foundry when a task involves a Solidity project or direct EVM interaction. Its four tools cover the common development loop:
+
+- **Forge** compiles, tests, fuzzes, debugs, deploys, verifies, formats, and lints Solidity projects.
+- **Cast** reads chain data, encodes and decodes ABI values, manages wallets, signs messages, and sends transactions from the command line.
+- **Anvil** runs a local Ethereum node for deterministic tests, state manipulation, mining control, and forks of live networks.
+- **Chisel** provides an interactive Solidity REPL for evaluating expressions and prototyping contract logic.
+
+Reach for a narrower tool when the task is outside that loop: use a Solidity compiler directly for compiler-only integration, a Rust or JavaScript Ethereum library for application code, and a browser wallet for user-mediated signing. Within a Foundry project, call the installed CLI from the project root so it reads the project's `foundry.toml`, remappings, dependencies, and profiles.
+
+Start with read-only commands such as `forge build`, `forge test`, `forge config`, `cast call`, or `cast rpc`. Treat `cast send`, `forge create`, and `forge script --broadcast` as state-changing operations: confirm the target chain, signer, value, and user authorization before running them.
+
 ### Retrieval interfaces
 
 | Interface | URL pattern | Use it for |

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   accentColor: "light-dark(#f6b128, #f9c22f)",
   title: "foundry - Ethereum Development Framework",
   description:
-    "Documentation for Foundry's Forge, Cast, Anvil, and Chisel Ethereum development tools.",
+    "Use Foundry's Forge, Cast, Anvil, and Chisel tools to build, test, fuzz, debug, deploy, and inspect Ethereum smart contracts.",
   baseUrl: "https://www.getfoundry.sh",
   // Keep assets on the current origin so Vercel previews do not load them cross-origin.
   // `baseUrl` still provides the production origin for canonical and Open Graph metadata.


### PR DESCRIPTION
The [Is Agentic scan](https://is-agentic.com/scan/www.getfoundry.sh) scored the Foundry documentation 82/100 and highlighted unclear agent-selection guidance and homepage semantics. Live verification showed that the site already serves clean Markdown through content negotiation, sends the correct `Vary` header, and returns a true HTTP 404, so this change focuses on gaps that belong in the documentation source.

The agent guide now explains when to choose Forge, Cast, Anvil, or Chisel, when a narrower tool is a better fit, and which commands require explicit confirmation because they change on-chain state. The site description now carries that task-oriented guidance into generated agent artifacts, while a screen-reader-only homepage heading gives nonvisual clients an unambiguous product identity without duplicating the visual banner.

AI disclosure: This pull request was written and validated by OpenAI Codex at the contributor's request.
