### PR TITLE
chore(bench): refresh v1.8.0 results

### DIFF
--- a/src/pages/benchmarks.mdx
+++ b/src/pages/benchmarks.mdx
@@ -1,4 +1,4 @@
-{/* Auto-generated from 2026-05-02 21:53:46 UTC. Do not edit manually. */}
+{/* Auto-generated from 2026-08-26 18:51:58 UTC. Do not edit manually. */}
 
 # Benchmarks
 
@@ -10,76 +10,76 @@ Performance comparison between Foundry releases.
   <p style={{ fontSize: '0.875rem', color: 'var(--vocs-color_text3)', marginBottom: '1rem' }}>Aggregated change per benchmark category (sum of wallclock time across all repositories).</p>
   <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', padding: '1rem', background: 'rgba(255,255,255,0.02)' }}>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Test <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Test <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 5 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>29.7s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓55.2%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>3m 23s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓18.4%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '42.84%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '81.29%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>13.3s</span>
+      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>2m 45s</span>
     </div>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Fuzz Test <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Fuzz Test <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 5 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>12.2s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓59.1%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>3m 8.7s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓19.1%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '39.07%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '80.58%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>4.97s</span>
+      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>2m 33s</span>
     </div>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Test (Isolated) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Test (Isolated) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 5 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>32.7s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓55.0%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>3m 57s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓18.0%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '42.99%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '81.70%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>14.7s</span>
+      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>3m 14s</span>
     </div>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Build (No Cache) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Build (No Cache) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 5 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>3m 19s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: 'var(--vocs-color_text3)', background: 'rgba(148,163,184,0.18)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓0.6%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>5m 51s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: 'var(--vocs-color_text3)', background: 'rgba(148,163,184,0.18)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↑0.3%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '95.02%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(148, 163, 184, 0.6)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '100.00%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(148, 163, 184, 0.6)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>3m 18s</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>5m 52s</span>
     </div>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Build (With Cache) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Build (With Cache) <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 5 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>0.28s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#ef4444', background: 'rgba(239,68,68,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↑4.6%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>0.90s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓43.2%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '100.00%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(239, 68, 68, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '56.62%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: '#ef4444', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>0.29s</span>
+      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>0.51s</span>
     </div>
     <div style={{ display: 'grid', gridTemplateColumns: '1fr 3.5rem 4rem', columnGap: '0.75rem', rowGap: '0.25rem', alignItems: 'center' }}>
-      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Coverage <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 3 repos</span></div>
+      <div style={{ gridColumn: '1 / -1', fontSize: '0.875rem', fontWeight: 600, marginBottom: '0.375rem' }}>Forge Coverage <span style={{ color: 'var(--vocs-color_text3)', fontWeight: 400 }}>· 4 repos</span></div>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ width: '95.59%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
+        <div style={{ width: '99.67%', height: '100%', background: 'rgba(148, 163, 184, 0.25)', borderRadius: '4px' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>3m 58s</span>
-      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓28.0%</span>
+      <span style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>13m 53s</span>
+      <span style={{ gridRow: 'span 2', justifySelf: 'start', fontSize: '0.75rem', fontWeight: 600, color: '#22c55e', background: 'rgba(34,197,94,0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontVariantNumeric: 'tabular-nums' }}>↓12.8%</span>
       <div style={{ height: '0.75rem', borderRadius: '4px', overflow: 'hidden' }}>
-        <div style={{ ['--bench-bar-from']: '95.59%', ['--bench-bar-to']: '68.83%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
+        <div style={{ ['--bench-bar-from']: '99.67%', ['--bench-bar-to']: '86.94%', width: 'var(--bench-bar-to)', height: '100%', background: 'rgba(34, 197, 94, 0.85)', borderRadius: '4px', animation: 'bench-bar-grow 800ms ease-out' }} />
       </div>
-      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>2m 51s</span>
+      <span style={{ fontSize: '0.7rem', color: '#22c55e', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>12m 6.7s</span>
     </div>
   </div>
 </div>
@@ -87,15 +87,58 @@ Performance comparison between Foundry releases.
 <div style={{ display: 'flex', gap: '2rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
   <div>
     <span style={{ fontSize: '0.75rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Baseline</span>
-    <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>[v1.5.1](https://github.com/foundry-rs/foundry/releases/tag/v1.5.1)</div>
+    <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>[v1.7.1](https://github.com/foundry-rs/foundry/releases/tag/v1.7.1)</div>
   </div>
   <div>
     <span style={{ fontSize: '0.75rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Latest</span>
-    <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>[v1.7.0](https://github.com/foundry-rs/foundry/releases/tag/v1.7.0)</div>
+    <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>[v1.8.0](https://github.com/foundry-rs/foundry/releases/tag/v1.8.0)</div>
   </div>
 </div>
 
 <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+  <div style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', overflow: 'hidden' }}>
+    <div style={{ padding: '0.75rem 1rem', borderBottom: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.03)' }}>
+      <a href="https://github.com/aave/aave-v4" style={{ fontWeight: 600, color: 'var(--vocs-color_text)', textDecoration: 'none' }}>aave-aave-v4 <span style={{ opacity: 0.5, fontSize: '0.875em' }}>↗</span></a>
+    </div>
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
+      <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Test</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2m 27.0s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>3m 1.5s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓19.0%</div>
+      </div>
+      <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Fuzz</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2m 27.4s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>3m 2.8s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓19.4%</div>
+      </div>
+      <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Isolated</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2m 55.8s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>3m 34.7s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓18.1%</div>
+      </div>
+      <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Build</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>3m 14.1s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>3m 14.3s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓0.1%</div>
+      </div>
+      <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Cached</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.207s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.290s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓28.6%</div>
+      </div>
+      <div style={{ padding: '0.875rem 1rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Coverage</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>8m 50.0s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>10m 28.4s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓15.7%</div>
+      </div>
+    </div>
+  </div>
   <div style={{ border: '1px solid rgba(255,255,255,0.1)', borderRadius: '8px', overflow: 'hidden' }}>
     <div style={{ padding: '0.75rem 1rem', borderBottom: '1px solid rgba(255,255,255,0.1)', background: 'rgba(255,255,255,0.03)' }}>
       <a href="https://github.com/ithacaxyz/account" style={{ fontWeight: 600, color: 'var(--vocs-color_text)', textDecoration: 'none' }}>ithacaxyz-account <span style={{ opacity: 0.5, fontSize: '0.875em' }}>↗</span></a>
@@ -103,39 +146,39 @@ Performance comparison between Foundry releases.
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Test</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.965s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.78s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓65.3%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.03s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.984s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑4.7%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Fuzz</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.923s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.54s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓63.7%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.955s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>1.07s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓10.7%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Isolated</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.02s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>3.05s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓66.6%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.05s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>1.06s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓0.9%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Build</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>33.29s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>34.58s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓3.7%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>23.84s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>23.43s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑1.7%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Cached</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.089s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.083s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#ef4444', background: 'rgba(239, 68, 68, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑7.2%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.083s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.214s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓61.2%</div>
       </div>
       <div style={{ padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Coverage</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>18.69s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>29.35s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓36.3%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>17.83s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>17.70s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑0.7%</div>
       </div>
     </div>
   </div>
@@ -146,39 +189,39 @@ Performance comparison between Foundry releases.
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Test</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>10.20s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>19.98s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓48.9%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>14.42s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>17.07s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓15.5%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Fuzz</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2.03s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.25s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓9.8%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.54s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>1.75s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓12.0%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Isolated</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>11.26s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>21.96s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓48.7%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>14.45s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>18.00s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓19.7%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Build</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>12.61s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>12.62s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓0.1%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>13.33s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>13.08s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑1.9%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Cached</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.068s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.066s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑3.0%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.061s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.147s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓58.5%</div>
       </div>
       <div style={{ padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Coverage</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1m 28.4s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2m 1.6s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓27.3%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2m 0.2s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2m 9.5s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓7.2%</div>
       </div>
     </div>
   </div>
@@ -189,39 +232,39 @@ Performance comparison between Foundry releases.
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Test</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.51s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>5.97s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓74.7%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2.18s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.33s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓6.4%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Fuzz</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.40s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>6.44s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓78.3%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2.00s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.26s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓11.5%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Isolated</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1.68s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>6.81s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓75.3%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2.17s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2.37s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓8.4%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Build</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>2m 17.7s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>2m 17.6s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑0.1%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1m 48.8s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>1m 48.1s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑0.6%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Cached</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.074s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.071s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑4.2%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.055s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.138s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓60.1%</div>
       </div>
       <div style={{ padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Coverage</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>1m 4.1s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>1m 26.8s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓26.2%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>58.64s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>57.41s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑2.1%</div>
       </div>
     </div>
   </div>
@@ -232,33 +275,33 @@ Performance comparison between Foundry releases.
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)' }}>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Test</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.645s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.995s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓35.2%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.764s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.904s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓15.5%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Fuzz</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.617s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.929s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓33.6%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.699s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.853s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓18.1%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Isolated</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.741s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.871s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓14.9%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.879s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.955s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓8.0%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Build</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>14.41s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>14.40s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑0.1%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>12.30s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>12.28s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑0.2%</div>
       </div>
       <div style={{ borderRight: '1px solid var(--vocs-color_border)', padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Cached</div>
-        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.064s</div>
-        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.062s</div>
-        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: 'var(--vocs-color_text3)', background: 'transparent', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↑3.2%</div>
+        <div style={{ fontSize: '1.1rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginBottom: '0.25rem' }}>0.103s</div>
+        <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text4)', marginBottom: '0.375rem' }}>0.107s</div>
+        <div style={{ display: 'inline-block', fontSize: '0.75rem', fontWeight: 500, color: '#22c55e', background: 'rgba(34, 197, 94, 0.15)', padding: '0.125rem 0.5rem', borderRadius: '9999px' }}>↓3.7%</div>
       </div>
       <div style={{ padding: '0.875rem 1rem', textAlign: 'center' }}>
         <div style={{ fontSize: '0.7rem', color: 'var(--vocs-color_text3)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>Coverage</div>


### PR DESCRIPTION
Regenerates the getfoundry benchmark page from the results merged in foundry-rs/foundry#16393. This updates the v1.7.1 versus v1.8.0 comparison and restores the five-repository cached-build section measured with the fixed candidate from foundry-rs/foundry#16395.

Only the generator-owned `src/pages/benchmarks.mdx` output changes; there are no generator or workflow changes. Merging this PR will give the book repository a new deployment commit so the live site can pick up the merged Foundry data.

Validated with `bun run build`.

Prepared with Codex.
