### PR TITLE
docs(config): explain network selection

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -74,6 +74,7 @@ const docs = [
     items: [
       { text: "Overview", link: "/config" },
       { text: "Profiles", link: "/config/profiles" },
+      { text: "Network Selection", link: "/config/networks" },
       { text: "Compiler", link: "/config/compiler" },
       { text: "Testing", link: "/config/testing" },
       { text: "MESC", link: "/config/mesc" },

--- a/src/pages/anvil/forking.mdx
+++ b/src/pages/anvil/forking.mdx
@@ -82,4 +82,7 @@ $ anvil --fork-url https://mainnet.optimism.io
 $ anvil --fork-url https://forno.celo.org --celo
 ```
 
-Use `--network` to select a network family explicitly; see the [`anvil` reference](/reference/anvil/anvil) for the supported values.
+Use `--network` to select a network family explicitly. See
+[Network configuration](/config/networks) for selection and inference behavior,
+and the [`anvil` reference](/reference/anvil/anvil) for the values supported by
+your installed binary.

--- a/src/pages/config/networks.mdx
+++ b/src/pages/config/networks.mdx
@@ -1,0 +1,105 @@
+---
+description: Select Ethereum or a custom EVM network family for Foundry tests, scripts, forks, and local nodes.
+---
+
+## Network configuration
+
+Foundry can execute against several EVM network families from the same toolchain. Network selection
+controls execution rules such as transaction types, hardforks, precompiles, and trace decoding. It
+is separate from choosing an RPC URL or setting the numeric chain ID.
+
+### Select a network
+
+Set `network` in your project when local tests and scripts should use a non-default execution
+family:
+
+```toml [foundry.toml]
+[profile.default]
+network = "tempo"
+```
+
+Use `--network` to select a family for one command:
+
+```bash
+$ forge test --network tempo
+$ forge script script/Deploy.s.sol --network optimism
+$ anvil --network monad
+```
+
+The available values depend on how the binary was built. `ethereum` and `tempo` are always
+available. `optimism` and `monad` require their matching Cargo features; official Foundry release
+builds currently include both. Run the command with `--help` to see the values supported by your
+installed binary.
+
+:::note
+Compiling support for a network makes it available to the binary; it does not activate that network.
+Use `network`, `--network`, a namespaced hardfork, or fork inference to select it at runtime.
+:::
+
+### Fork inference
+
+When you use a live fork, Foundry normally infers the execution family from a known chain ID or
+from metadata exposed by an Anvil endpoint:
+
+```bash
+$ forge test --fork-url $RPC_URL
+$ anvil --fork-url $RPC_URL
+```
+
+You do not need `--network` for a recognized network family. Select the network explicitly when the
+endpoint uses an unknown chain ID, does not expose enough metadata, or when you intentionally need
+a specific execution family. Compatibility profiles exposed through separate switches, such as
+Celo, still require their switch. The selected execution profile must be compatible with the fork
+source.
+
+Optional metadata methods are capability probes. A standard RPC endpoint can reject an Anvil-only
+method and still be a valid fork source; Foundry falls back to standard chain and block methods
+until an endpoint identifies itself as Anvil.
+
+See [Anvil forking](/anvil/forking) for block pinning, caching, headers, and fork configuration.
+
+### Select a hardfork
+
+Use `hardfork` when you need deterministic semantics for a particular activation. A namespaced
+hardfork also selects its network family:
+
+```toml [foundry.toml]
+[profile.default]
+hardfork = "optimism:holocene"
+```
+
+```toml [foundry.toml]
+[profile.default]
+hardfork = "tempo:T6"
+```
+
+For normal current behavior, prefer `network` or live fork inference. Pin a hardfork for historical
+testing, compatibility checks, or regression coverage.
+
+### Celo features
+
+Celo compatibility remains a separate switch rather than a `network` family:
+
+```toml [foundry.toml]
+[profile.default]
+celo = true
+```
+
+```bash
+$ anvil --fork-url https://forno.celo.org --celo
+```
+
+### Legacy settings
+
+Foundry still accepts `optimism = true`, `tempo = true`, and `monad = true` for compatibility when
+the corresponding family is available. New configuration should use the canonical `network` field.
+
+Inspect the resolved project configuration with:
+
+```bash
+$ forge config --json
+```
+
+See the [`network`](/config/reference/testing#network) and
+[`hardfork`](/config/reference/testing#hardfork) reference entries for environment variables and
+field details. For Tempo-specific workflows, see [Foundry on Tempo](/guides/tempo).

--- a/src/pages/config/reference/testing.mdx
+++ b/src/pages/config/reference/testing.mdx
@@ -79,14 +79,21 @@ The value of the `chainid` opcode in tests.
 - Default: none
 - Environment: `FOUNDRY_NETWORK`
 
-Selects the active non-Ethereum network family for tests, scripts, and local execution.
+Selects the active network family for tests, scripts, and local execution.
 
 Valid values include:
 
+- `ethereum`
 - `optimism`
 - `tempo`
+- `monad`
 
-Use this when Foundry is not forking a live RPC endpoint and therefore cannot infer the network from chain ID. Foundry still accepts the legacy boolean forms such as `optimism = true` and `tempo = true`.
+The values exposed by a binary depend on its compiled features. Use this setting
+when Foundry is not forking a recognized live RPC endpoint and therefore cannot
+infer the execution family. Foundry still accepts the legacy boolean forms such
+as `optimism = true`, `tempo = true`, and `monad = true` when the corresponding
+family is available. See [Network configuration](/config/networks) for runtime
+selection, fork inference, and build availability.
 
 ```toml
 [profile.default]

--- a/src/pages/config/reference/tooling.mdx
+++ b/src/pages/config/reference/tooling.mdx
@@ -49,7 +49,7 @@ level of `[profile.<name>]`.
 
 | Field | Default | Description |
 | --- | --- | --- |
-| `network` | none | Selects the network family: `ethereum`, `optimism`, or `tempo`. |
+| `network` | none | Selects an available network family: `ethereum`, `optimism`, `tempo`, or `monad`. |
 | `celo` | `false` | Enables Celo network features such as the Celo transfer precompile. |
 | `bypass_prevrandao` | `false` | Uses a random `prevrandao` when the forked block does not provide one. |
 
@@ -57,8 +57,11 @@ Selecting a network family enables its execution rules and precompiles — for
 example the Tempo system precompiles, which are also labeled in traces. When
 forking, Foundry infers the network from the chain ID, so `network` mainly
 matters for local execution; see the
-[`network`](/config/reference/testing#network) entry for details. The legacy
-boolean forms `optimism = true` and `tempo = true` are still accepted.
+[`network`](/config/reference/testing#network) entry and the
+[network selection guide](/config/networks) for details. The values exposed by
+a binary depend on its compiled features. The legacy boolean forms
+`optimism = true`, `tempo = true`, and `monad = true` are still accepted when
+the corresponding family is available.
 
 ```toml
 [profile.default]


### PR DESCRIPTION
Adds a user-facing network configuration guide that distinguishes compiled support from runtime selection and explains configuration, CLI overrides, fork inference, namespaced hardforks, Celo, and legacy selectors. It also links the guide from the network reference and Anvil forking documentation.

Companion to [foundry-rs/foundry#16430](https://github.com/foundry-rs/foundry/pull/16430) and addresses the user-facing documentation gap tracked in [foundry-rs/foundry#16248](https://github.com/foundry-rs/foundry/issues/16248).

AI assistance was used to audit current Foundry behavior, draft the guide, and validate the rendered site.

Prompted by: fig
