### PR TITLE
docs(config): document solc PATH names

### DIFF
--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -121,9 +121,10 @@ gas_snapshot_emit = true
 # =============================================================================
 
 # The Solc instance to use. Takes precedence over auto_detect_solc
-# Can be a version string like "0.8.20" or path to solc binary
+# Can be a version string, a path to a local binary, or an executable name on PATH
 # Default: None
 # solc = "0.8.20"
+# solc = "custom-solc"
 
 # Whether to autodetect the solc compiler version to use
 # Default: true

--- a/src/pages/config/reference/solidity-compiler.mdx
+++ b/src/pages/config/reference/solidity-compiler.mdx
@@ -82,15 +82,22 @@ See also [solc path resolution](https://docs.soliditylang.org/en/latest/path-res
 
 An array of libraries to link against in the following format: `<file>:<lib>:<address>`, for example: `src/MyLibrary.sol:MyLibrary:0xfD88CeE74f7D78697775aBDAE53f9Da1559728E4`.
 
-##### `solc_version`
+##### `solc`
 
-- Type: string (semver)
+- Type: string (semver, path, or executable name)
 - Default: none
 - Environment: `FOUNDRY_SOLC_VERSION` or `DAPP_SOLC_VERSION`
 
-If specified, overrides the auto-detection system (more below) and uses a single Solidity compiler version for the project.
+If specified, overrides the auto-detection system (more below) and uses a single Solidity compiler for the project.
 
-Only strict versions are supported (i.e. `0.8.11` is valid, but `^0.8.0` is not).
+The value can be a strict version, a path to a local compiler, or an executable name available on `PATH`:
+
+```toml
+solc = "custom-solc"
+```
+
+Version requirements are not supported (i.e. `0.8.28` is valid, but `^0.8.0` is not). The legacy
+`solc_version` key is still accepted for backwards compatibility.
 
 ##### `auto_detect_solc`
 
@@ -100,7 +107,7 @@ Only strict versions are supported (i.e. `0.8.11` is valid, but `^0.8.0` is not)
 
 If enabled, Foundry will automatically try to resolve appropriate Solidity compiler versions to compile your project.
 
-This key is ignored if `solc_version` is set.
+This key is ignored if `solc` is set.
 
 ##### `offline`
 
@@ -579,7 +586,7 @@ There are several configurable values for an compilation restriction:
 
 - Type: string (semver)
 
-Restrict compilation for specific [solc_version](#solc_version).
+Restrict compilation for a specific [`solc`](#solc) version.
 
 ##### `compilation_restriction.via_ir`
 


### PR DESCRIPTION
Documents the canonical `solc` setting as accepting a strict version, a local binary path, or an executable name resolved from `PATH`, with `solc = "custom-solc"` as the executable-name example. It also synchronizes the default configuration reference and notes that `solc_version` remains accepted as a compatibility alias.

This follows up on [foundry-rs/foundry#16494](https://github.com/foundry-rs/foundry/pull/16494) and [the review discussion](https://github.com/foundry-rs/foundry/pull/16494#discussion_r3893156620).

This PR was written with Codex assistance.
