### PR TITLE
docs(cast): document ERC-4626 commands

### DIFF
--- a/scripts/gen_output/help.rs
+++ b/scripts/gen_output/help.rs
@@ -403,7 +403,11 @@ impl<'a> fmt::Display for Cmd<'a> {
 }
 
 /// Categorize commands for sidebar generation
-fn categorize_command(cmd_name: &str, tool_name: &str) -> &'static str {
+fn categorize_command(cmd: &Cmd<'_>, tool_name: &str) -> &'static str {
+    let cmd_name = cmd.subcommands.last().map(String::as_str).unwrap_or_default();
+    if tool_name == "cast" && cmd.subcommands.first().is_some_and(|name| name == "erc4626") {
+        return "Vault Commands"
+    }
     match tool_name {
         "forge" => match cmd_name {
             "help" | "completions" => "General Commands",
@@ -450,8 +454,7 @@ fn generate_sidebar(output: &[(Cmd, String)], _out_dir: &Path, sidebar_file: &Pa
             continue; // Skip root command
         }
         
-        let cmd_name = cmd.subcommands.last().unwrap();
-        let category = categorize_command(cmd_name, tool_name);
+        let category = categorize_command(cmd, tool_name);
         categories.entry(category).or_insert_with(Vec::new).push(cmd);
     }
     

--- a/sidebar/cast-cli-reference.ts
+++ b/sidebar/cast-cli-reference.ts
@@ -291,6 +291,7 @@ export const castCliReference: SidebarItem = {
       items: [
         { text: "cast erc4626", link: "/reference/cast/erc4626" },
         { text: "cast erc4626 asset", link: "/reference/cast/erc4626/asset" },
+        { text: "cast erc4626 check", link: "/reference/cast/erc4626/check" },
         {
           text: "cast erc4626 convert-to-assets",
           link: "/reference/cast/erc4626/convert-to-assets",
@@ -300,11 +301,13 @@ export const castCliReference: SidebarItem = {
           link: "/reference/cast/erc4626/convert-to-shares",
         },
         { text: "cast erc4626 deposit", link: "/reference/cast/erc4626/deposit" },
+        { text: "cast erc4626 info", link: "/reference/cast/erc4626/info" },
         { text: "cast erc4626 max-deposit", link: "/reference/cast/erc4626/max-deposit" },
         { text: "cast erc4626 max-mint", link: "/reference/cast/erc4626/max-mint" },
         { text: "cast erc4626 max-redeem", link: "/reference/cast/erc4626/max-redeem" },
         { text: "cast erc4626 max-withdraw", link: "/reference/cast/erc4626/max-withdraw" },
         { text: "cast erc4626 mint", link: "/reference/cast/erc4626/mint" },
+        { text: "cast erc4626 position", link: "/reference/cast/erc4626/position" },
         {
           text: "cast erc4626 preview-deposit",
           link: "/reference/cast/erc4626/preview-deposit",
@@ -330,4 +333,3 @@ export const castCliReference: SidebarItem = {
     },
   ],
 };
-

--- a/sidebar/cast-cli-reference.ts
+++ b/sidebar/cast-cli-reference.ts
@@ -286,9 +286,48 @@ export const castCliReference: SidebarItem = {
       ],
     },
     {
+      text: "Vault Commands",
+      collapsed: true,
+      items: [
+        { text: "cast erc4626", link: "/reference/cast/erc4626" },
+        { text: "cast erc4626 asset", link: "/reference/cast/erc4626/asset" },
+        {
+          text: "cast erc4626 convert-to-assets",
+          link: "/reference/cast/erc4626/convert-to-assets",
+        },
+        {
+          text: "cast erc4626 convert-to-shares",
+          link: "/reference/cast/erc4626/convert-to-shares",
+        },
+        { text: "cast erc4626 deposit", link: "/reference/cast/erc4626/deposit" },
+        { text: "cast erc4626 max-deposit", link: "/reference/cast/erc4626/max-deposit" },
+        { text: "cast erc4626 max-mint", link: "/reference/cast/erc4626/max-mint" },
+        { text: "cast erc4626 max-redeem", link: "/reference/cast/erc4626/max-redeem" },
+        { text: "cast erc4626 max-withdraw", link: "/reference/cast/erc4626/max-withdraw" },
+        { text: "cast erc4626 mint", link: "/reference/cast/erc4626/mint" },
+        {
+          text: "cast erc4626 preview-deposit",
+          link: "/reference/cast/erc4626/preview-deposit",
+        },
+        { text: "cast erc4626 preview-mint", link: "/reference/cast/erc4626/preview-mint" },
+        {
+          text: "cast erc4626 preview-redeem",
+          link: "/reference/cast/erc4626/preview-redeem",
+        },
+        {
+          text: "cast erc4626 preview-withdraw",
+          link: "/reference/cast/erc4626/preview-withdraw",
+        },
+        { text: "cast erc4626 redeem", link: "/reference/cast/erc4626/redeem" },
+        { text: "cast erc4626 total-assets", link: "/reference/cast/erc4626/total-assets" },
+        { text: "cast erc4626 withdraw", link: "/reference/cast/erc4626/withdraw" },
+      ],
+    },
+    {
       text: "Wallet Commands",
       collapsed: true,
       items: [{ text: "cast wallet", link: "/reference/cast/wallet" }],
     },
   ],
 };
+

--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -37,6 +37,7 @@ const docs = [
       { text: "Overview", link: "/cast" },
       { text: "Reading Chain Data", link: "/cast/reading-chain-data" },
       { text: "Sending Transactions", link: "/cast/sending-transactions" },
+      { text: "Tokenized Vaults", link: "/cast/tokenized-vaults" },
       { text: "Wallet Operations", link: "/cast/wallet-operations" },
       { text: "EIP-7702 Delegation", link: "/cast/eip-7702-delegation" },
       { text: "ABI Encoding", link: "/cast/abi-encoding" },

--- a/src/pages/cast/index.mdx
+++ b/src/pages/cast/index.mdx
@@ -44,6 +44,7 @@ $ cast balance $ADDRESS
 
 - [Reading chain data](/cast/reading-chain-data) — Query blocks, transactions, and state
 - [Sending transactions](/cast/sending-transactions) — Execute on-chain operations
+- [Tokenized vaults](/cast/tokenized-vaults) — Inspect and transact with synchronous ERC-4626 vaults
 - [Wallet operations](/cast/wallet-operations) — Key management and signing
 - [EIP-7702 delegation](/cast/eip-7702-delegation) — Delegate EOA execution with signed authorizations
 - [ABI encoding](/cast/abi-encoding) — Encode and decode contract data

--- a/src/pages/cast/tokenized-vaults.mdx
+++ b/src/pages/cast/tokenized-vaults.mdx
@@ -1,0 +1,81 @@
+---
+description: Inspect and transact with synchronous ERC-4626 tokenized vaults using Cast.
+---
+
+## Tokenized vaults
+
+Cast provides typed commands for the complete synchronous base interface defined by [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626). Use `cast erc4626` or its `cast vault` alias to inspect exchange rates and limits, preview operations, and deposit, mint, withdraw, or redeem without writing ABI signatures by hand.
+
+The commands accept integer amounts in the underlying asset's or vault share's smallest unit. Use `cast erc20-token decimals` and `cast parse-units` when you need to convert human-readable amounts.
+
+### Command surface
+
+Each state-changing operation has a limit query and a preview query:
+
+| Operation | Limit | Preview | Transaction |
+| --- | --- | --- | --- |
+| Deposit an asset amount for a receiver | [`max-deposit`](/reference/cast/erc4626/max-deposit) | [`preview-deposit`](/reference/cast/erc4626/preview-deposit) | [`deposit`](/reference/cast/erc4626/deposit) |
+| Mint a share amount for a receiver | [`max-mint`](/reference/cast/erc4626/max-mint) | [`preview-mint`](/reference/cast/erc4626/preview-mint) | [`mint`](/reference/cast/erc4626/mint) |
+| Withdraw an asset amount owned by an account | [`max-withdraw`](/reference/cast/erc4626/max-withdraw) | [`preview-withdraw`](/reference/cast/erc4626/preview-withdraw) | [`withdraw`](/reference/cast/erc4626/withdraw) |
+| Redeem a share amount owned by an account | [`max-redeem`](/reference/cast/erc4626/max-redeem) | [`preview-redeem`](/reference/cast/erc4626/preview-redeem) | [`redeem`](/reference/cast/erc4626/redeem) |
+
+You can also query the [`asset`](/reference/cast/erc4626/asset) address, [`total-assets`](/reference/cast/erc4626/total-assets), or use [`convert-to-shares`](/reference/cast/erc4626/convert-to-shares) and [`convert-to-assets`](/reference/cast/erc4626/convert-to-assets) for caller-independent conversions.
+
+The vault contract is also the ERC-20 share token. Use `cast erc20-token` for inherited operations such as `balance`, `allowance`, `approve`, and `transfer`.
+
+### Inspect a vault
+
+Set the vault and RPC endpoint, then read its underlying asset and accounting state:
+
+```bash
+$ export VAULT=0x...
+$ export RPC_URL=https://...
+$ cast erc4626 asset $VAULT --rpc-url $RPC_URL
+$ cast erc4626 total-assets $VAULT --rpc-url $RPC_URL
+$ cast erc4626 convert-to-shares $VAULT $ASSETS --rpc-url $RPC_URL
+```
+
+`convert-to-shares` and `convert-to-assets` provide idealized, caller-independent conversions. Use the corresponding preview command when you are preparing a specific operation because previews account for the vault's operation-specific fees and rounding.
+
+### Deposit assets
+
+An ERC-4626 deposit pulls the underlying ERC-20 asset from the sender. Approve the vault to spend the asset before submitting the deposit:
+
+```bash
+$ ASSET=$(cast erc4626 asset $VAULT --rpc-url $RPC_URL)
+$ cast erc4626 max-deposit $VAULT $RECEIVER --rpc-url $RPC_URL
+$ cast erc4626 preview-deposit $VAULT $ASSETS --rpc-url $RPC_URL
+$ cast erc20-token approve $ASSET $VAULT $ASSETS --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+$ cast erc4626 deposit $VAULT $ASSETS $RECEIVER --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+```
+
+`mint` follows the same approval flow, but takes the exact number of shares to mint. Use `preview-mint` to calculate the assets the vault expects to pull.
+
+State-changing vault commands use the same signer, fee, hardware wallet, browser wallet, and Tempo options as `cast send`. See [Sending transactions](/cast/sending-transactions) for those options.
+
+### Withdraw assets
+
+Choose `withdraw` when you know the asset amount to receive, or `redeem` when you know the share amount to burn:
+
+```bash
+$ cast erc4626 max-redeem $VAULT $OWNER --rpc-url $RPC_URL
+$ cast erc4626 preview-redeem $VAULT $SHARES --rpc-url $RPC_URL
+$ cast erc4626 redeem $VAULT $SHARES $RECEIVER $OWNER --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+```
+
+The signing account must be `OWNER` or have sufficient allowance to spend the owner's vault shares. `RECEIVER` receives the withdrawn underlying assets.
+
+### Compatibility and safety
+
+`cast erc4626` calls the standard selectors directly; it does not certify that a contract implements every ERC-4626 requirement. Cast reports targeted warnings for compatibility cases it can identify:
+
+- A zero `max-deposit` or `max-mint` may be a conservative limit rather than proof that the operation is permanently disabled.
+- A zero `max-withdraw` or `max-redeem` for an owner with shares may reflect temporary liquidity, authorization, or integration constraints.
+- The [ERC-7535](https://eips.ethereum.org/EIPS/eip-7535) native-asset sentinel requires a payable, value-bearing call; the typed write commands currently encode ERC-20-style calldata only.
+- Preview calls can revert by design for the corresponding asynchronous flow in [ERC-7540](https://eips.ethereum.org/EIPS/eip-7540).
+
+The transaction commands invoke the base ERC-4626 methods without minimum-output or maximum-input slippage fields. A preview can become stale before the transaction executes, so use a protocol router or a vault-specific extension such as [ERC-5143](https://eips.ethereum.org/EIPS/eip-5143) when the operation needs on-chain price bounds.
+
+Asynchronous ERC-7540 request and claim flows, [ERC-7575](https://eips.ethereum.org/EIPS/eip-7575) multi-asset vaults, native-value deposits, permit composition, and router-specific methods are outside this synchronous base interface. Use `cast call` or `cast send` with the project's ABI for those extensions.
+
+See the [`cast erc4626` reference](/reference/cast/erc4626) for the complete option list.

--- a/src/pages/cast/tokenized-vaults.mdx
+++ b/src/pages/cast/tokenized-vaults.mdx
@@ -21,6 +21,8 @@ Each state-changing operation has a limit query and a preview query:
 
 You can also query the [`asset`](/reference/cast/erc4626/asset) address, [`total-assets`](/reference/cast/erc4626/total-assets), or use [`convert-to-shares`](/reference/cast/erc4626/convert-to-shares) and [`convert-to-assets`](/reference/cast/erc4626/convert-to-assets) for caller-independent conversions.
 
+For a combined view, [`info`](/reference/cast/erc4626/info) summarizes the vault and its exchange rate, [`position`](/reference/cast/erc4626/position) summarizes one owner's shares and exit limits, and [`check`](/reference/cast/erc4626/check) probes whether the synchronous read interface behaves as expected.
+
 The vault contract is also the ERC-20 share token. Use `cast erc20-token` for inherited operations such as `balance`, `allowance`, `approve`, and `transfer`.
 
 ### Inspect a vault
@@ -30,10 +32,12 @@ Set the vault and RPC endpoint, then read its underlying asset and accounting st
 ```bash
 $ export VAULT=0x...
 $ export RPC_URL=https://...
-$ cast erc4626 asset $VAULT --rpc-url $RPC_URL
-$ cast erc4626 total-assets $VAULT --rpc-url $RPC_URL
-$ cast erc4626 convert-to-shares $VAULT $ASSETS --rpc-url $RPC_URL
+$ cast erc4626 info $VAULT --rpc-url $RPC_URL
+$ cast erc4626 info $VAULT --human --rpc-url $RPC_URL
+$ cast erc4626 position $VAULT $OWNER --human --rpc-url $RPC_URL
 ```
+
+`info` reports vault and asset metadata, total assets and shares, and normalized conversions in both directions. `position` reports an owner's share balance, its asset equivalent, and the owner's current `max-withdraw` and `max-redeem` values. Text output uses exact integer amounts by default; pass `--human` to format them using the on-chain token decimals. JSON output always preserves each integer as `raw` and includes `formatted` when decimals are available.
 
 `convert-to-shares` and `convert-to-assets` provide idealized, caller-independent conversions. Use the corresponding preview command when you are preparing a specific operation because previews account for the vault's operation-specific fees and rounding.
 
@@ -67,12 +71,20 @@ The signing account must be `OWNER` or have sufficient allowance to spend the ow
 
 ### Compatibility and safety
 
-`cast erc4626` calls the standard selectors directly; it does not certify that a contract implements every ERC-4626 requirement. Cast reports targeted warnings for compatibility cases it can identify:
+Probe a vault before relying on the synchronous read interface:
+
+```bash
+$ cast erc4626 check $VAULT --account $OWNER --rpc-url $RPC_URL
+```
+
+`check` makes only read calls. It verifies contract code, the base accounting, conversion, limit, and preview calls, inherited ERC-20 reads, and the underlying asset contract. It prints the full report and exits nonzero when a required check fails; warnings do not make the command fail. Omit `--account` to use the zero address for account-dependent probes.
+
+This is a compatibility probe, not a compliance certificate. It does not invoke state-changing selectors or prove the standard's semantic requirements. Cast reports targeted warnings for compatibility cases it can identify:
 
 - A zero `max-deposit` or `max-mint` may be a conservative limit rather than proof that the operation is permanently disabled.
 - A zero `max-withdraw` or `max-redeem` for an owner with shares may reflect temporary liquidity, authorization, or integration constraints.
 - The [ERC-7535](https://eips.ethereum.org/EIPS/eip-7535) native-asset sentinel requires a payable, value-bearing call; the typed write commands currently encode ERC-20-style calldata only.
-- Preview calls can revert by design for the corresponding asynchronous flow in [ERC-7540](https://eips.ethereum.org/EIPS/eip-7540).
+- Preview calls can revert by design for the corresponding asynchronous flow in [ERC-7540](https://eips.ethereum.org/EIPS/eip-7540). `check` treats these reverts as expected warnings only when the vault advertises the mandated ERC-165 interface ID for that flow; an unadvertised preview failure remains a failed check.
 
 The transaction commands invoke the base ERC-4626 methods without minimum-output or maximum-input slippage fields. A preview can become stale before the transaction executes, so use a protocol router or a vault-specific extension such as [ERC-5143](https://eips.ethereum.org/EIPS/eip-5143) when the operation needs on-chain price bounds.
 

--- a/src/pages/reference/cast/cast.mdx
+++ b/src/pages/reference/cast/cast.mdx
@@ -88,6 +88,7 @@ Commands:
   disassemble            Disassembles a hex-encoded bytecode into a
                          human-readable representation [alias: da]
   erc20-token            ERC20 token operations [alias: erc20]
+  erc4626                ERC-4626 tokenized vault operations [alias: vault]
   estimate               Estimate the gas cost of a transaction [alias: e]
   find-block             Get the block number closest to the provided timestamp
                          [alias: f]

--- a/src/pages/reference/cast/erc4626.mdx
+++ b/src/pages/reference/cast/erc4626.mdx
@@ -18,6 +18,10 @@ $ cast erc4626 --help
 Usage: cast erc4626 [OPTIONS] <COMMAND>
 
 Commands:
+  info               Show vault, asset, and exchange-rate information
+  position           Show an account's shares, asset value, and withdrawal
+                     limits
+  check              Probe synchronous ERC-4626 interface compatibility
   asset              Query the vault's underlying asset token
   total-assets       Query the total amount of underlying assets managed by the
                      vault
@@ -45,7 +49,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -71,11 +75,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626.mdx
+++ b/src/pages/reference/cast/erc4626.mdx
@@ -1,0 +1,89 @@
+---
+description: "ERC-4626 tokenized vault operations"
+---
+
+_Generated from `cast erc4626 --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626
+
+ERC-4626 tokenized vault operations
+
+:::terminal
+
+```bash
+$ cast erc4626 --help
+```
+
+```txt
+Usage: cast erc4626 [OPTIONS] <COMMAND>
+
+Commands:
+  asset              Query the vault's underlying asset token
+  total-assets       Query the total amount of underlying assets managed by the
+                     vault
+  convert-to-shares  Convert an asset amount to the corresponding share amount
+  convert-to-assets  Convert a share amount to the corresponding asset amount
+  max-deposit        Query the maximum assets that may be deposited for a
+                     receiver
+  preview-deposit    Preview the shares received by depositing an asset amount
+  deposit            Deposit assets into the vault
+  max-mint           Query the maximum shares that may be minted for a receiver
+  preview-mint       Preview the assets required to mint a share amount
+  mint               Mint vault shares
+  max-withdraw       Query the maximum assets that an owner may withdraw
+  preview-withdraw   Preview the shares burned to withdraw an asset amount
+  withdraw           Withdraw assets from the vault
+  max-redeem         Query the maximum shares that an owner may redeem
+  preview-redeem     Preview the assets received by redeeming a share amount
+  redeem             Redeem vault shares for assets
+  help               Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/asset.mdx
+++ b/src/pages/reference/cast/erc4626/asset.mdx
@@ -31,7 +31,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -40,28 +40,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -70,46 +70,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -135,11 +135,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/asset.mdx
+++ b/src/pages/reference/cast/erc4626/asset.mdx
@@ -1,0 +1,153 @@
+---
+description: "Query the vault's underlying asset token"
+---
+
+_Generated from `cast erc4626 asset --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 asset
+
+Query the vault's underlying asset token
+
+:::terminal
+
+```bash
+$ cast erc4626 asset --help
+```
+
+```txt
+Usage: cast erc4626 asset [OPTIONS] <VAULT>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/check.mdx
+++ b/src/pages/reference/cast/erc4626/check.mdx
@@ -1,30 +1,30 @@
 ---
-description: "Preview the assets required to mint a share amount"
+description: "Probe synchronous ERC-4626 interface compatibility"
 ---
 
-_Generated from `cast erc4626 preview-mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+_Generated from `cast erc4626 check --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
 
-## cast erc4626 preview-mint
+## cast erc4626 check
 
-Preview the assets required to mint a share amount
+Probe synchronous ERC-4626 interface compatibility
 
 :::terminal
 
 ```bash
-$ cast erc4626 preview-mint --help
+$ cast erc4626 check --help
 ```
 
 ```txt
-Usage: cast erc4626 preview-mint [OPTIONS] <VAULT> <SHARES>
+Usage: cast erc4626 check [OPTIONS] <VAULT>
 
 Arguments:
   <VAULT>
           The ERC-4626 vault contract address
 
-  <SHARES>
-          The amount of vault shares
-
 Options:
+      --account <ACCOUNT>
+          The account used for limit and balance probes
+
   -B, --block <BLOCK>
           The block height to query at
 

--- a/src/pages/reference/cast/erc4626/convert-to-assets.mdx
+++ b/src/pages/reference/cast/erc4626/convert-to-assets.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/convert-to-assets.mdx
+++ b/src/pages/reference/cast/erc4626/convert-to-assets.mdx
@@ -1,0 +1,156 @@
+---
+description: "Convert a share amount to the corresponding asset amount"
+---
+
+_Generated from `cast erc4626 convert-to-assets --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 convert-to-assets
+
+Convert a share amount to the corresponding asset amount
+
+:::terminal
+
+```bash
+$ cast erc4626 convert-to-assets --help
+```
+
+```txt
+Usage: cast erc4626 convert-to-assets [OPTIONS] <VAULT> <SHARES>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <SHARES>
+          The amount of vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/convert-to-shares.mdx
+++ b/src/pages/reference/cast/erc4626/convert-to-shares.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/convert-to-shares.mdx
+++ b/src/pages/reference/cast/erc4626/convert-to-shares.mdx
@@ -1,0 +1,156 @@
+---
+description: "Convert an asset amount to the corresponding share amount"
+---
+
+_Generated from `cast erc4626 convert-to-shares --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 convert-to-shares
+
+Convert an asset amount to the corresponding share amount
+
+:::terminal
+
+```bash
+$ cast erc4626 convert-to-shares --help
+```
+
+```txt
+Usage: cast erc4626 convert-to-shares [OPTIONS] <VAULT> <ASSETS>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <ASSETS>
+          The amount of underlying assets
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/deposit.mdx
+++ b/src/pages/reference/cast/erc4626/deposit.mdx
@@ -30,7 +30,7 @@ Arguments:
 Options:
       --async
           Only print the transaction hash and exit immediately
-          
+
           [env: CAST_ASYNC=]
 
       --sync
@@ -40,17 +40,17 @@ Options:
 
       --confirmations <CONFIRMATIONS>
           The number of confirmations until the receipt is fetched
-          
+
           [default: 1]
 
       --timeout <TIMEOUT>
           Timeout for sending the transaction
-          
+
           [env: ETH_TIMEOUT=]
 
       --poll-interval <POLL_INTERVAL>
           Polling interval for transaction receipts (in seconds)
-          
+
           [env: ETH_POLL_INTERVAL=]
 
   -h, --help
@@ -59,7 +59,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -68,28 +68,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -98,46 +98,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -145,18 +145,18 @@ Rpc options:
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key
-          
+
           [env: ETHERSCAN_API_KEY=]
 
   -c, --chain <CHAIN>
           The chain name or EIP-155 chain ID
-          
+
           [env: CHAIN=]
 
 Wallet options - raw:
   -f, --from <ADDRESS>
           The sender account
-          
+
           [env: ETH_FROM=]
 
   -i, --interactive
@@ -173,38 +173,38 @@ Wallet options - raw:
 
       --mnemonic-derivation-path <PATH>
           The wallet derivation path.
-          
+
           Works with both --mnemonic-path and hardware wallets.
 
       --mnemonic-index <INDEX>
           Use the private key from the given mnemonic index.
-          
+
           Used with --mnemonic-path.
-          
+
           [default: 0]
 
 Wallet options - keystore:
       --keystore <PATH>
           Use the keystore in the given folder or file
-          
+
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
           Use a keystore from the default keystores folder
           (~/.foundry/keystores) by its filename
-          
+
           [env: ETH_KEYSTORE_ACCOUNT=]
 
       --password <PASSWORD>
           The keystore password.
-          
+
           Used with --keystore.
 
       --password-file <PASSWORD_FILE>
           The keystore password file path.
-          
+
           Used with --keystore.
-          
+
           [env: ETH_PASSWORD=]
 
 Wallet options - hardware wallet:
@@ -217,18 +217,18 @@ Wallet options - hardware wallet:
 Wallet options - Tempo:
       --tempo.access-key <PRIVATE_KEY>
           Tempo access key private key.
-          
+
           When set, the transaction is signed with this access key on behalf of
           `--tempo.root-account`.
-          
+
           [env: TEMPO_ACCESS_KEY=]
 
       --tempo.root-account <ADDRESS>
           Tempo root account address (the `from` address for keychain
           transactions).
-          
+
           Required when `--tempo.access-key` is set.
-          
+
           [env: TEMPO_ROOT_ACCOUNT=]
 
 Wallet options - browser wallet:
@@ -237,7 +237,7 @@ Wallet options - browser wallet:
 
       --browser-port <PORT>
           Port for the browser wallet server
-          
+
           [default: 9545]
 
       --browser-disable-open
@@ -246,18 +246,18 @@ Wallet options - browser wallet:
 Transaction options:
       --gas-limit <GAS_LIMIT>
           Gas limit for the transaction
-          
+
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <GAS_PRICE>
           Gas price for legacy transactions, or max fee per gas for EIP1559
           transactions
-          
+
           [env: ETH_GAS_PRICE=]
 
       --priority-gas-price <PRIORITY_GAS_PRICE>
           Max priority fee per gas for EIP1559 transactions
-          
+
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --nonce <NONCE>
@@ -266,7 +266,7 @@ Transaction options:
 Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
-          
+
           When set, Foundry resolves the authorization witness from
           `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
           key on behalf of its root account.
@@ -274,21 +274,21 @@ Tempo:
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
           transactions.
-          
+
           When set, builds a Tempo (type 0x76) transaction that pays gas fees in
           the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
           ThetaUSD.
-          
+
           If this is not set, the fee token is chosen according to network
           rules. See the Tempo docs for more information.
 
       --tempo.expires <SECONDS>
           Opt into TIP-1009 expiring-nonce mode with a validity window.
-          
+
           Convenience flag that combines `--tempo.expiring-nonce` with a
           relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
           0, and valid_before = now + seconds.
-          
+
           Maximum value is 30 seconds. The transaction must be mined before the
           deadline or it becomes permanently invalid, giving safe retry
           semantics: retries produce a fresh tx hash and the old tx can never
@@ -296,30 +296,30 @@ Tempo:
 
       --tempo.nonce-key <NONCE_KEY>
           Nonce key for Tempo parallelizable nonces.
-          
+
           When set, builds a Tempo (type 0x76) transaction with the specified
           nonce key, allowing multiple transactions with the same nonce but
           different keys to be executed in parallel. If not set, the protocol
           nonce key (0) will be used.
-          
+
           For more information see
           [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
 
       --tempo.lane <NAME>
           Named nonce lane for Tempo parallelizable nonces.
-          
+
           Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
           `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
           the project root). The lanes file is a TOML map of `name = <U256>`
           entries, e.g.:
-          
+
           ```toml deploy   = 1 ops      = 2 payments = 3 ```
-          
+
           Mutually exclusive with `--tempo.nonce-key`.
 
       --tempo.lanes-file <PATH>
           Path to the Tempo lanes file used by `--tempo.lane`.
-          
+
           Defaults to `tempo.lanes.toml` at the project root.
 
       --tempo.sponsor <ADDRESS>
@@ -327,62 +327,62 @@ Tempo:
 
       --tempo.sponsor-signer <SIGNER>
           Sign Tempo sponsor digests in-band with the given signer URI.
-          
+
           Supported forms include `env://VAR`, `keystore://PATH`,
           `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
           `turnkey://`, and `private-key://KEY`.
 
       --tempo.sponsor-sig <SPONSOR_SIG>
           Sponsor (fee payer) signature for Tempo sponsored transactions.
-          
+
           The sponsor signs the `fee_payer_signature_hash` to commit to paying
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
           Remote sponsor (fee payer) service URL for Cast transaction commands.
-          
+
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
-          
+
           This option is supported by `cast send` and `cast erc20`. Forge
           commands currently support local sponsorship through `--tempo.sponsor`
           and `--tempo.sponsor-signer` instead.
-          
+
           Example: `cast send 0x... --sponsor-url
           https://sponsor.moderato.tempo.xyz`
-          
+
           [env: TEMPO_SPONSOR_URL=]
 
       --tempo.print-sponsor-hash
           Print the sponsor signature hash and exit.
-          
+
           Computes the `fee_payer_signature_hash` for the transaction so that a
           sponsor knows what hash to sign. The transaction is not sent.
 
       --tempo.key-id <KEY_ID>
           Access key ID for Tempo Keychain signature transactions.
-          
+
           Used during gas estimation to override the key_id that would normally
           be recovered from the signature.
 
       --tempo.expiring-nonce
           Enable expiring nonce mode for Tempo transactions.
-          
+
           Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
           transaction validity via `--tempo.valid-before` and
           `--tempo.valid-after`.
 
       --tempo.valid-before <VALID_BEFORE>
           Upper bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid before this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
       --tempo.valid-after <VALID_AFTER>
           Lower bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid after this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
@@ -406,11 +406,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/deposit.mdx
+++ b/src/pages/reference/cast/erc4626/deposit.mdx
@@ -1,0 +1,424 @@
+---
+description: "Deposit assets into the vault"
+---
+
+_Generated from `cast erc4626 deposit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 deposit
+
+Deposit assets into the vault
+
+:::terminal
+
+```bash
+$ cast erc4626 deposit --help
+```
+
+```txt
+Usage: cast erc4626 deposit [OPTIONS] <VAULT> <ASSETS> <RECEIVER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <ASSETS>
+          The amount of underlying assets
+
+  <RECEIVER>
+          The receiver of the resulting vault shares
+
+Options:
+      --async
+          Only print the transaction hash and exit immediately
+          
+          [env: CAST_ASYNC=]
+
+      --sync
+          Wait for transaction receipt synchronously instead of polling. Note:
+          uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which
+          may not be supported by all clients
+
+      --confirmations <CONFIRMATIONS>
+          The number of confirmations until the receipt is fetched
+          
+          [default: 1]
+
+      --timeout <TIMEOUT>
+          Timeout for sending the transaction
+          
+          [env: ETH_TIMEOUT=]
+
+      --poll-interval <POLL_INTERVAL>
+          Polling interval for transaction receipts (in seconds)
+          
+          [env: ETH_POLL_INTERVAL=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key
+          
+          [env: ETHERSCAN_API_KEY=]
+
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID
+          
+          [env: CHAIN=]
+
+Wallet options - raw:
+  -f, --from <ADDRESS>
+          The sender account
+          
+          [env: ETH_FROM=]
+
+  -i, --interactive
+          Open an interactive prompt to enter your private key
+
+      --private-key <RAW_PRIVATE_KEY>
+          Use the provided private key
+
+      --mnemonic <MNEMONIC>
+          Use the mnemonic phrase of mnemonic file at the specified path
+
+      --mnemonic-passphrase <PASSPHRASE>
+          Use a BIP39 passphrase for the mnemonic
+
+      --mnemonic-derivation-path <PATH>
+          The wallet derivation path.
+          
+          Works with both --mnemonic-path and hardware wallets.
+
+      --mnemonic-index <INDEX>
+          Use the private key from the given mnemonic index.
+          
+          Used with --mnemonic-path.
+          
+          [default: 0]
+
+Wallet options - keystore:
+      --keystore <PATH>
+          Use the keystore in the given folder or file
+          
+          [env: ETH_KEYSTORE=]
+
+      --account <ACCOUNT_NAME>
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
+          
+          [env: ETH_KEYSTORE_ACCOUNT=]
+
+      --password <PASSWORD>
+          The keystore password.
+          
+          Used with --keystore.
+
+      --password-file <PASSWORD_FILE>
+          The keystore password file path.
+          
+          Used with --keystore.
+          
+          [env: ETH_PASSWORD=]
+
+Wallet options - hardware wallet:
+  -l, --ledger
+          Use a Ledger hardware wallet
+
+  -t, --trezor
+          Use a Trezor hardware wallet
+
+Wallet options - Tempo:
+      --tempo.access-key <PRIVATE_KEY>
+          Tempo access key private key.
+          
+          When set, the transaction is signed with this access key on behalf of
+          `--tempo.root-account`.
+          
+          [env: TEMPO_ACCESS_KEY=]
+
+      --tempo.root-account <ADDRESS>
+          Tempo root account address (the `from` address for keychain
+          transactions).
+          
+          Required when `--tempo.access-key` is set.
+          
+          [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+          
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+Transaction options:
+      --gas-limit <GAS_LIMIT>
+          Gas limit for the transaction
+          
+          [env: ETH_GAS_LIMIT=]
+
+      --gas-price <GAS_PRICE>
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions
+          
+          [env: ETH_GAS_PRICE=]
+
+      --priority-gas-price <PRIORITY_GAS_PRICE>
+          Max priority fee per gas for EIP1559 transactions
+          
+          [env: ETH_PRIORITY_GAS_PRICE=]
+
+      --nonce <NONCE>
+          Nonce for the transaction
+
+Tempo:
+      --tempo.session <SESSION_ID>
+          Use a live Tempo wallet session for signing.
+          
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
+
+      --tempo.fee-token <FEE_TOKEN>
+          Fee token address, numeric TIP-20 token id, or known symbol for Tempo
+          transactions.
+          
+          When set, builds a Tempo (type 0x76) transaction that pays gas fees in
+          the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
+          ThetaUSD.
+          
+          If this is not set, the fee token is chosen according to network
+          rules. See the Tempo docs for more information.
+
+      --tempo.expires <SECONDS>
+          Opt into TIP-1009 expiring-nonce mode with a validity window.
+          
+          Convenience flag that combines `--tempo.expiring-nonce` with a
+          relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
+          0, and valid_before = now + seconds.
+          
+          Maximum value is 30 seconds. The transaction must be mined before the
+          deadline or it becomes permanently invalid, giving safe retry
+          semantics: retries produce a fresh tx hash and the old tx can never
+          land late.
+
+      --tempo.nonce-key <NONCE_KEY>
+          Nonce key for Tempo parallelizable nonces.
+          
+          When set, builds a Tempo (type 0x76) transaction with the specified
+          nonce key, allowing multiple transactions with the same nonce but
+          different keys to be executed in parallel. If not set, the protocol
+          nonce key (0) will be used.
+          
+          For more information see
+          [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
+
+      --tempo.lane <NAME>
+          Named nonce lane for Tempo parallelizable nonces.
+          
+          Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
+          `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
+          the project root). The lanes file is a TOML map of `name = <U256>`
+          entries, e.g.:
+          
+          ```toml deploy   = 1 ops      = 2 payments = 3 ```
+          
+          Mutually exclusive with `--tempo.nonce-key`.
+
+      --tempo.lanes-file <PATH>
+          Path to the Tempo lanes file used by `--tempo.lane`.
+          
+          Defaults to `tempo.lanes.toml` at the project root.
+
+      --tempo.sponsor <ADDRESS>
+          Sponsor (fee payer) address for Tempo sponsored transactions
+
+      --tempo.sponsor-signer <SIGNER>
+          Sign Tempo sponsor digests in-band with the given signer URI.
+          
+          Supported forms include `env://VAR`, `keystore://PATH`,
+          `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
+          `turnkey://`, and `private-key://KEY`.
+
+      --tempo.sponsor-sig <SPONSOR_SIG>
+          Sponsor (fee payer) signature for Tempo sponsored transactions.
+          
+          The sponsor signs the `fee_payer_signature_hash` to commit to paying
+          gas fees on behalf of the sender. Provide as a hex-encoded signature.
+
+      --sponsor-url <URL>
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
+          
+          When set, the user-signed transaction is forwarded to this URL via
+          `eth_signRawTransaction`. The service adds its fee payer signature and
+          returns the fully-sponsored transaction, which is then submitted via
+          the regular RPC. No local sponsor key is required.
+          
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+          
+          Example: `cast send 0x... --sponsor-url
+          https://sponsor.moderato.tempo.xyz`
+          
+          [env: TEMPO_SPONSOR_URL=]
+
+      --tempo.print-sponsor-hash
+          Print the sponsor signature hash and exit.
+          
+          Computes the `fee_payer_signature_hash` for the transaction so that a
+          sponsor knows what hash to sign. The transaction is not sent.
+
+      --tempo.key-id <KEY_ID>
+          Access key ID for Tempo Keychain signature transactions.
+          
+          Used during gas estimation to override the key_id that would normally
+          be recovered from the signature.
+
+      --tempo.expiring-nonce
+          Enable expiring nonce mode for Tempo transactions.
+          
+          Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
+          transaction validity via `--tempo.valid-before` and
+          `--tempo.valid-after`.
+
+      --tempo.valid-before <VALID_BEFORE>
+          Upper bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid before this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+      --tempo.valid-after <VALID_AFTER>
+          Lower bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid after this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/info.mdx
+++ b/src/pages/reference/cast/erc4626/info.mdx
@@ -1,30 +1,30 @@
 ---
-description: "Preview the assets required to mint a share amount"
+description: "Show vault, asset, and exchange-rate information"
 ---
 
-_Generated from `cast erc4626 preview-mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+_Generated from `cast erc4626 info --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
 
-## cast erc4626 preview-mint
+## cast erc4626 info
 
-Preview the assets required to mint a share amount
+Show vault, asset, and exchange-rate information
 
 :::terminal
 
 ```bash
-$ cast erc4626 preview-mint --help
+$ cast erc4626 info --help
 ```
 
 ```txt
-Usage: cast erc4626 preview-mint [OPTIONS] <VAULT> <SHARES>
+Usage: cast erc4626 info [OPTIONS] <VAULT>
 
 Arguments:
   <VAULT>
           The ERC-4626 vault contract address
 
-  <SHARES>
-          The amount of vault shares
-
 Options:
+      --human
+          Use formatted token amounts in text output
+
   -B, --block <BLOCK>
           The block height to query at
 

--- a/src/pages/reference/cast/erc4626/max-deposit.mdx
+++ b/src/pages/reference/cast/erc4626/max-deposit.mdx
@@ -1,0 +1,156 @@
+---
+description: "Query the maximum assets that may be deposited for a receiver"
+---
+
+_Generated from `cast erc4626 max-deposit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 max-deposit
+
+Query the maximum assets that may be deposited for a receiver
+
+:::terminal
+
+```bash
+$ cast erc4626 max-deposit --help
+```
+
+```txt
+Usage: cast erc4626 max-deposit [OPTIONS] <VAULT> <RECEIVER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <RECEIVER>
+          The receiver of the resulting vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/max-deposit.mdx
+++ b/src/pages/reference/cast/erc4626/max-deposit.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/max-mint.mdx
+++ b/src/pages/reference/cast/erc4626/max-mint.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/max-mint.mdx
+++ b/src/pages/reference/cast/erc4626/max-mint.mdx
@@ -1,0 +1,156 @@
+---
+description: "Query the maximum shares that may be minted for a receiver"
+---
+
+_Generated from `cast erc4626 max-mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 max-mint
+
+Query the maximum shares that may be minted for a receiver
+
+:::terminal
+
+```bash
+$ cast erc4626 max-mint --help
+```
+
+```txt
+Usage: cast erc4626 max-mint [OPTIONS] <VAULT> <RECEIVER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <RECEIVER>
+          The receiver of the resulting vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/max-redeem.mdx
+++ b/src/pages/reference/cast/erc4626/max-redeem.mdx
@@ -1,0 +1,156 @@
+---
+description: "Query the maximum shares that an owner may redeem"
+---
+
+_Generated from `cast erc4626 max-redeem --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 max-redeem
+
+Query the maximum shares that an owner may redeem
+
+:::terminal
+
+```bash
+$ cast erc4626 max-redeem --help
+```
+
+```txt
+Usage: cast erc4626 max-redeem [OPTIONS] <VAULT> <OWNER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <OWNER>
+          The owner of the vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/max-redeem.mdx
+++ b/src/pages/reference/cast/erc4626/max-redeem.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/max-withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/max-withdraw.mdx
@@ -1,0 +1,156 @@
+---
+description: "Query the maximum assets that an owner may withdraw"
+---
+
+_Generated from `cast erc4626 max-withdraw --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 max-withdraw
+
+Query the maximum assets that an owner may withdraw
+
+:::terminal
+
+```bash
+$ cast erc4626 max-withdraw --help
+```
+
+```txt
+Usage: cast erc4626 max-withdraw [OPTIONS] <VAULT> <OWNER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <OWNER>
+          The owner of the vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/max-withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/max-withdraw.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/mint.mdx
+++ b/src/pages/reference/cast/erc4626/mint.mdx
@@ -1,0 +1,424 @@
+---
+description: "Mint vault shares"
+---
+
+_Generated from `cast erc4626 mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 mint
+
+Mint vault shares
+
+:::terminal
+
+```bash
+$ cast erc4626 mint --help
+```
+
+```txt
+Usage: cast erc4626 mint [OPTIONS] <VAULT> <SHARES> <RECEIVER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <SHARES>
+          The amount of vault shares
+
+  <RECEIVER>
+          The receiver of the resulting vault shares
+
+Options:
+      --async
+          Only print the transaction hash and exit immediately
+          
+          [env: CAST_ASYNC=]
+
+      --sync
+          Wait for transaction receipt synchronously instead of polling. Note:
+          uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which
+          may not be supported by all clients
+
+      --confirmations <CONFIRMATIONS>
+          The number of confirmations until the receipt is fetched
+          
+          [default: 1]
+
+      --timeout <TIMEOUT>
+          Timeout for sending the transaction
+          
+          [env: ETH_TIMEOUT=]
+
+      --poll-interval <POLL_INTERVAL>
+          Polling interval for transaction receipts (in seconds)
+          
+          [env: ETH_POLL_INTERVAL=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key
+          
+          [env: ETHERSCAN_API_KEY=]
+
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID
+          
+          [env: CHAIN=]
+
+Wallet options - raw:
+  -f, --from <ADDRESS>
+          The sender account
+          
+          [env: ETH_FROM=]
+
+  -i, --interactive
+          Open an interactive prompt to enter your private key
+
+      --private-key <RAW_PRIVATE_KEY>
+          Use the provided private key
+
+      --mnemonic <MNEMONIC>
+          Use the mnemonic phrase of mnemonic file at the specified path
+
+      --mnemonic-passphrase <PASSPHRASE>
+          Use a BIP39 passphrase for the mnemonic
+
+      --mnemonic-derivation-path <PATH>
+          The wallet derivation path.
+          
+          Works with both --mnemonic-path and hardware wallets.
+
+      --mnemonic-index <INDEX>
+          Use the private key from the given mnemonic index.
+          
+          Used with --mnemonic-path.
+          
+          [default: 0]
+
+Wallet options - keystore:
+      --keystore <PATH>
+          Use the keystore in the given folder or file
+          
+          [env: ETH_KEYSTORE=]
+
+      --account <ACCOUNT_NAME>
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
+          
+          [env: ETH_KEYSTORE_ACCOUNT=]
+
+      --password <PASSWORD>
+          The keystore password.
+          
+          Used with --keystore.
+
+      --password-file <PASSWORD_FILE>
+          The keystore password file path.
+          
+          Used with --keystore.
+          
+          [env: ETH_PASSWORD=]
+
+Wallet options - hardware wallet:
+  -l, --ledger
+          Use a Ledger hardware wallet
+
+  -t, --trezor
+          Use a Trezor hardware wallet
+
+Wallet options - Tempo:
+      --tempo.access-key <PRIVATE_KEY>
+          Tempo access key private key.
+          
+          When set, the transaction is signed with this access key on behalf of
+          `--tempo.root-account`.
+          
+          [env: TEMPO_ACCESS_KEY=]
+
+      --tempo.root-account <ADDRESS>
+          Tempo root account address (the `from` address for keychain
+          transactions).
+          
+          Required when `--tempo.access-key` is set.
+          
+          [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+          
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+Transaction options:
+      --gas-limit <GAS_LIMIT>
+          Gas limit for the transaction
+          
+          [env: ETH_GAS_LIMIT=]
+
+      --gas-price <GAS_PRICE>
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions
+          
+          [env: ETH_GAS_PRICE=]
+
+      --priority-gas-price <PRIORITY_GAS_PRICE>
+          Max priority fee per gas for EIP1559 transactions
+          
+          [env: ETH_PRIORITY_GAS_PRICE=]
+
+      --nonce <NONCE>
+          Nonce for the transaction
+
+Tempo:
+      --tempo.session <SESSION_ID>
+          Use a live Tempo wallet session for signing.
+          
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
+
+      --tempo.fee-token <FEE_TOKEN>
+          Fee token address, numeric TIP-20 token id, or known symbol for Tempo
+          transactions.
+          
+          When set, builds a Tempo (type 0x76) transaction that pays gas fees in
+          the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
+          ThetaUSD.
+          
+          If this is not set, the fee token is chosen according to network
+          rules. See the Tempo docs for more information.
+
+      --tempo.expires <SECONDS>
+          Opt into TIP-1009 expiring-nonce mode with a validity window.
+          
+          Convenience flag that combines `--tempo.expiring-nonce` with a
+          relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
+          0, and valid_before = now + seconds.
+          
+          Maximum value is 30 seconds. The transaction must be mined before the
+          deadline or it becomes permanently invalid, giving safe retry
+          semantics: retries produce a fresh tx hash and the old tx can never
+          land late.
+
+      --tempo.nonce-key <NONCE_KEY>
+          Nonce key for Tempo parallelizable nonces.
+          
+          When set, builds a Tempo (type 0x76) transaction with the specified
+          nonce key, allowing multiple transactions with the same nonce but
+          different keys to be executed in parallel. If not set, the protocol
+          nonce key (0) will be used.
+          
+          For more information see
+          [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
+
+      --tempo.lane <NAME>
+          Named nonce lane for Tempo parallelizable nonces.
+          
+          Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
+          `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
+          the project root). The lanes file is a TOML map of `name = <U256>`
+          entries, e.g.:
+          
+          ```toml deploy   = 1 ops      = 2 payments = 3 ```
+          
+          Mutually exclusive with `--tempo.nonce-key`.
+
+      --tempo.lanes-file <PATH>
+          Path to the Tempo lanes file used by `--tempo.lane`.
+          
+          Defaults to `tempo.lanes.toml` at the project root.
+
+      --tempo.sponsor <ADDRESS>
+          Sponsor (fee payer) address for Tempo sponsored transactions
+
+      --tempo.sponsor-signer <SIGNER>
+          Sign Tempo sponsor digests in-band with the given signer URI.
+          
+          Supported forms include `env://VAR`, `keystore://PATH`,
+          `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
+          `turnkey://`, and `private-key://KEY`.
+
+      --tempo.sponsor-sig <SPONSOR_SIG>
+          Sponsor (fee payer) signature for Tempo sponsored transactions.
+          
+          The sponsor signs the `fee_payer_signature_hash` to commit to paying
+          gas fees on behalf of the sender. Provide as a hex-encoded signature.
+
+      --sponsor-url <URL>
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
+          
+          When set, the user-signed transaction is forwarded to this URL via
+          `eth_signRawTransaction`. The service adds its fee payer signature and
+          returns the fully-sponsored transaction, which is then submitted via
+          the regular RPC. No local sponsor key is required.
+          
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+          
+          Example: `cast send 0x... --sponsor-url
+          https://sponsor.moderato.tempo.xyz`
+          
+          [env: TEMPO_SPONSOR_URL=]
+
+      --tempo.print-sponsor-hash
+          Print the sponsor signature hash and exit.
+          
+          Computes the `fee_payer_signature_hash` for the transaction so that a
+          sponsor knows what hash to sign. The transaction is not sent.
+
+      --tempo.key-id <KEY_ID>
+          Access key ID for Tempo Keychain signature transactions.
+          
+          Used during gas estimation to override the key_id that would normally
+          be recovered from the signature.
+
+      --tempo.expiring-nonce
+          Enable expiring nonce mode for Tempo transactions.
+          
+          Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
+          transaction validity via `--tempo.valid-before` and
+          `--tempo.valid-after`.
+
+      --tempo.valid-before <VALID_BEFORE>
+          Upper bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid before this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+      --tempo.valid-after <VALID_AFTER>
+          Lower bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid after this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/mint.mdx
+++ b/src/pages/reference/cast/erc4626/mint.mdx
@@ -30,7 +30,7 @@ Arguments:
 Options:
       --async
           Only print the transaction hash and exit immediately
-          
+
           [env: CAST_ASYNC=]
 
       --sync
@@ -40,17 +40,17 @@ Options:
 
       --confirmations <CONFIRMATIONS>
           The number of confirmations until the receipt is fetched
-          
+
           [default: 1]
 
       --timeout <TIMEOUT>
           Timeout for sending the transaction
-          
+
           [env: ETH_TIMEOUT=]
 
       --poll-interval <POLL_INTERVAL>
           Polling interval for transaction receipts (in seconds)
-          
+
           [env: ETH_POLL_INTERVAL=]
 
   -h, --help
@@ -59,7 +59,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -68,28 +68,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -98,46 +98,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -145,18 +145,18 @@ Rpc options:
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key
-          
+
           [env: ETHERSCAN_API_KEY=]
 
   -c, --chain <CHAIN>
           The chain name or EIP-155 chain ID
-          
+
           [env: CHAIN=]
 
 Wallet options - raw:
   -f, --from <ADDRESS>
           The sender account
-          
+
           [env: ETH_FROM=]
 
   -i, --interactive
@@ -173,38 +173,38 @@ Wallet options - raw:
 
       --mnemonic-derivation-path <PATH>
           The wallet derivation path.
-          
+
           Works with both --mnemonic-path and hardware wallets.
 
       --mnemonic-index <INDEX>
           Use the private key from the given mnemonic index.
-          
+
           Used with --mnemonic-path.
-          
+
           [default: 0]
 
 Wallet options - keystore:
       --keystore <PATH>
           Use the keystore in the given folder or file
-          
+
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
           Use a keystore from the default keystores folder
           (~/.foundry/keystores) by its filename
-          
+
           [env: ETH_KEYSTORE_ACCOUNT=]
 
       --password <PASSWORD>
           The keystore password.
-          
+
           Used with --keystore.
 
       --password-file <PASSWORD_FILE>
           The keystore password file path.
-          
+
           Used with --keystore.
-          
+
           [env: ETH_PASSWORD=]
 
 Wallet options - hardware wallet:
@@ -217,18 +217,18 @@ Wallet options - hardware wallet:
 Wallet options - Tempo:
       --tempo.access-key <PRIVATE_KEY>
           Tempo access key private key.
-          
+
           When set, the transaction is signed with this access key on behalf of
           `--tempo.root-account`.
-          
+
           [env: TEMPO_ACCESS_KEY=]
 
       --tempo.root-account <ADDRESS>
           Tempo root account address (the `from` address for keychain
           transactions).
-          
+
           Required when `--tempo.access-key` is set.
-          
+
           [env: TEMPO_ROOT_ACCOUNT=]
 
 Wallet options - browser wallet:
@@ -237,7 +237,7 @@ Wallet options - browser wallet:
 
       --browser-port <PORT>
           Port for the browser wallet server
-          
+
           [default: 9545]
 
       --browser-disable-open
@@ -246,18 +246,18 @@ Wallet options - browser wallet:
 Transaction options:
       --gas-limit <GAS_LIMIT>
           Gas limit for the transaction
-          
+
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <GAS_PRICE>
           Gas price for legacy transactions, or max fee per gas for EIP1559
           transactions
-          
+
           [env: ETH_GAS_PRICE=]
 
       --priority-gas-price <PRIORITY_GAS_PRICE>
           Max priority fee per gas for EIP1559 transactions
-          
+
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --nonce <NONCE>
@@ -266,7 +266,7 @@ Transaction options:
 Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
-          
+
           When set, Foundry resolves the authorization witness from
           `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
           key on behalf of its root account.
@@ -274,21 +274,21 @@ Tempo:
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
           transactions.
-          
+
           When set, builds a Tempo (type 0x76) transaction that pays gas fees in
           the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
           ThetaUSD.
-          
+
           If this is not set, the fee token is chosen according to network
           rules. See the Tempo docs for more information.
 
       --tempo.expires <SECONDS>
           Opt into TIP-1009 expiring-nonce mode with a validity window.
-          
+
           Convenience flag that combines `--tempo.expiring-nonce` with a
           relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
           0, and valid_before = now + seconds.
-          
+
           Maximum value is 30 seconds. The transaction must be mined before the
           deadline or it becomes permanently invalid, giving safe retry
           semantics: retries produce a fresh tx hash and the old tx can never
@@ -296,30 +296,30 @@ Tempo:
 
       --tempo.nonce-key <NONCE_KEY>
           Nonce key for Tempo parallelizable nonces.
-          
+
           When set, builds a Tempo (type 0x76) transaction with the specified
           nonce key, allowing multiple transactions with the same nonce but
           different keys to be executed in parallel. If not set, the protocol
           nonce key (0) will be used.
-          
+
           For more information see
           [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
 
       --tempo.lane <NAME>
           Named nonce lane for Tempo parallelizable nonces.
-          
+
           Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
           `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
           the project root). The lanes file is a TOML map of `name = <U256>`
           entries, e.g.:
-          
+
           ```toml deploy   = 1 ops      = 2 payments = 3 ```
-          
+
           Mutually exclusive with `--tempo.nonce-key`.
 
       --tempo.lanes-file <PATH>
           Path to the Tempo lanes file used by `--tempo.lane`.
-          
+
           Defaults to `tempo.lanes.toml` at the project root.
 
       --tempo.sponsor <ADDRESS>
@@ -327,62 +327,62 @@ Tempo:
 
       --tempo.sponsor-signer <SIGNER>
           Sign Tempo sponsor digests in-band with the given signer URI.
-          
+
           Supported forms include `env://VAR`, `keystore://PATH`,
           `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
           `turnkey://`, and `private-key://KEY`.
 
       --tempo.sponsor-sig <SPONSOR_SIG>
           Sponsor (fee payer) signature for Tempo sponsored transactions.
-          
+
           The sponsor signs the `fee_payer_signature_hash` to commit to paying
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
           Remote sponsor (fee payer) service URL for Cast transaction commands.
-          
+
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
-          
+
           This option is supported by `cast send` and `cast erc20`. Forge
           commands currently support local sponsorship through `--tempo.sponsor`
           and `--tempo.sponsor-signer` instead.
-          
+
           Example: `cast send 0x... --sponsor-url
           https://sponsor.moderato.tempo.xyz`
-          
+
           [env: TEMPO_SPONSOR_URL=]
 
       --tempo.print-sponsor-hash
           Print the sponsor signature hash and exit.
-          
+
           Computes the `fee_payer_signature_hash` for the transaction so that a
           sponsor knows what hash to sign. The transaction is not sent.
 
       --tempo.key-id <KEY_ID>
           Access key ID for Tempo Keychain signature transactions.
-          
+
           Used during gas estimation to override the key_id that would normally
           be recovered from the signature.
 
       --tempo.expiring-nonce
           Enable expiring nonce mode for Tempo transactions.
-          
+
           Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
           transaction validity via `--tempo.valid-before` and
           `--tempo.valid-after`.
 
       --tempo.valid-before <VALID_BEFORE>
           Upper bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid before this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
       --tempo.valid-after <VALID_AFTER>
           Lower bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid after this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
@@ -406,11 +406,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/position.mdx
+++ b/src/pages/reference/cast/erc4626/position.mdx
@@ -1,30 +1,33 @@
 ---
-description: "Preview the assets required to mint a share amount"
+description: "Show an account's shares, asset value, and withdrawal limits"
 ---
 
-_Generated from `cast erc4626 preview-mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+_Generated from `cast erc4626 position --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
 
-## cast erc4626 preview-mint
+## cast erc4626 position
 
-Preview the assets required to mint a share amount
+Show an account's shares, asset value, and withdrawal limits
 
 :::terminal
 
 ```bash
-$ cast erc4626 preview-mint --help
+$ cast erc4626 position --help
 ```
 
 ```txt
-Usage: cast erc4626 preview-mint [OPTIONS] <VAULT> <SHARES>
+Usage: cast erc4626 position [OPTIONS] <VAULT> <OWNER>
 
 Arguments:
   <VAULT>
           The ERC-4626 vault contract address
 
-  <SHARES>
-          The amount of vault shares
+  <OWNER>
+          The owner of the vault shares
 
 Options:
+      --human
+          Use formatted token amounts in text output
+
   -B, --block <BLOCK>
           The block height to query at
 

--- a/src/pages/reference/cast/erc4626/preview-deposit.mdx
+++ b/src/pages/reference/cast/erc4626/preview-deposit.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/preview-deposit.mdx
+++ b/src/pages/reference/cast/erc4626/preview-deposit.mdx
@@ -1,0 +1,156 @@
+---
+description: "Preview the shares received by depositing an asset amount"
+---
+
+_Generated from `cast erc4626 preview-deposit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 preview-deposit
+
+Preview the shares received by depositing an asset amount
+
+:::terminal
+
+```bash
+$ cast erc4626 preview-deposit --help
+```
+
+```txt
+Usage: cast erc4626 preview-deposit [OPTIONS] <VAULT> <ASSETS>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <ASSETS>
+          The amount of underlying assets
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/preview-mint.mdx
+++ b/src/pages/reference/cast/erc4626/preview-mint.mdx
@@ -1,0 +1,156 @@
+---
+description: "Preview the assets required to mint a share amount"
+---
+
+_Generated from `cast erc4626 preview-mint --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 preview-mint
+
+Preview the assets required to mint a share amount
+
+:::terminal
+
+```bash
+$ cast erc4626 preview-mint --help
+```
+
+```txt
+Usage: cast erc4626 preview-mint [OPTIONS] <VAULT> <SHARES>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <SHARES>
+          The amount of vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/preview-redeem.mdx
+++ b/src/pages/reference/cast/erc4626/preview-redeem.mdx
@@ -1,0 +1,156 @@
+---
+description: "Preview the assets received by redeeming a share amount"
+---
+
+_Generated from `cast erc4626 preview-redeem --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 preview-redeem
+
+Preview the assets received by redeeming a share amount
+
+:::terminal
+
+```bash
+$ cast erc4626 preview-redeem --help
+```
+
+```txt
+Usage: cast erc4626 preview-redeem [OPTIONS] <VAULT> <SHARES>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <SHARES>
+          The amount of vault shares
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/preview-redeem.mdx
+++ b/src/pages/reference/cast/erc4626/preview-redeem.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/preview-withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/preview-withdraw.mdx
@@ -1,0 +1,156 @@
+---
+description: "Preview the shares burned to withdraw an asset amount"
+---
+
+_Generated from `cast erc4626 preview-withdraw --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 preview-withdraw
+
+Preview the shares burned to withdraw an asset amount
+
+:::terminal
+
+```bash
+$ cast erc4626 preview-withdraw --help
+```
+
+```txt
+Usage: cast erc4626 preview-withdraw [OPTIONS] <VAULT> <ASSETS>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <ASSETS>
+          The amount of underlying assets
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/preview-withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/preview-withdraw.mdx
@@ -34,7 +34,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -43,28 +43,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -73,46 +73,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -138,11 +138,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/redeem.mdx
+++ b/src/pages/reference/cast/erc4626/redeem.mdx
@@ -33,7 +33,7 @@ Arguments:
 Options:
       --async
           Only print the transaction hash and exit immediately
-          
+
           [env: CAST_ASYNC=]
 
       --sync
@@ -43,17 +43,17 @@ Options:
 
       --confirmations <CONFIRMATIONS>
           The number of confirmations until the receipt is fetched
-          
+
           [default: 1]
 
       --timeout <TIMEOUT>
           Timeout for sending the transaction
-          
+
           [env: ETH_TIMEOUT=]
 
       --poll-interval <POLL_INTERVAL>
           Polling interval for transaction receipts (in seconds)
-          
+
           [env: ETH_POLL_INTERVAL=]
 
   -h, --help
@@ -62,7 +62,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -71,28 +71,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -101,46 +101,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -148,18 +148,18 @@ Rpc options:
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key
-          
+
           [env: ETHERSCAN_API_KEY=]
 
   -c, --chain <CHAIN>
           The chain name or EIP-155 chain ID
-          
+
           [env: CHAIN=]
 
 Wallet options - raw:
   -f, --from <ADDRESS>
           The sender account
-          
+
           [env: ETH_FROM=]
 
   -i, --interactive
@@ -176,38 +176,38 @@ Wallet options - raw:
 
       --mnemonic-derivation-path <PATH>
           The wallet derivation path.
-          
+
           Works with both --mnemonic-path and hardware wallets.
 
       --mnemonic-index <INDEX>
           Use the private key from the given mnemonic index.
-          
+
           Used with --mnemonic-path.
-          
+
           [default: 0]
 
 Wallet options - keystore:
       --keystore <PATH>
           Use the keystore in the given folder or file
-          
+
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
           Use a keystore from the default keystores folder
           (~/.foundry/keystores) by its filename
-          
+
           [env: ETH_KEYSTORE_ACCOUNT=]
 
       --password <PASSWORD>
           The keystore password.
-          
+
           Used with --keystore.
 
       --password-file <PASSWORD_FILE>
           The keystore password file path.
-          
+
           Used with --keystore.
-          
+
           [env: ETH_PASSWORD=]
 
 Wallet options - hardware wallet:
@@ -220,18 +220,18 @@ Wallet options - hardware wallet:
 Wallet options - Tempo:
       --tempo.access-key <PRIVATE_KEY>
           Tempo access key private key.
-          
+
           When set, the transaction is signed with this access key on behalf of
           `--tempo.root-account`.
-          
+
           [env: TEMPO_ACCESS_KEY=]
 
       --tempo.root-account <ADDRESS>
           Tempo root account address (the `from` address for keychain
           transactions).
-          
+
           Required when `--tempo.access-key` is set.
-          
+
           [env: TEMPO_ROOT_ACCOUNT=]
 
 Wallet options - browser wallet:
@@ -240,7 +240,7 @@ Wallet options - browser wallet:
 
       --browser-port <PORT>
           Port for the browser wallet server
-          
+
           [default: 9545]
 
       --browser-disable-open
@@ -249,18 +249,18 @@ Wallet options - browser wallet:
 Transaction options:
       --gas-limit <GAS_LIMIT>
           Gas limit for the transaction
-          
+
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <GAS_PRICE>
           Gas price for legacy transactions, or max fee per gas for EIP1559
           transactions
-          
+
           [env: ETH_GAS_PRICE=]
 
       --priority-gas-price <PRIORITY_GAS_PRICE>
           Max priority fee per gas for EIP1559 transactions
-          
+
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --nonce <NONCE>
@@ -269,7 +269,7 @@ Transaction options:
 Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
-          
+
           When set, Foundry resolves the authorization witness from
           `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
           key on behalf of its root account.
@@ -277,21 +277,21 @@ Tempo:
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
           transactions.
-          
+
           When set, builds a Tempo (type 0x76) transaction that pays gas fees in
           the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
           ThetaUSD.
-          
+
           If this is not set, the fee token is chosen according to network
           rules. See the Tempo docs for more information.
 
       --tempo.expires <SECONDS>
           Opt into TIP-1009 expiring-nonce mode with a validity window.
-          
+
           Convenience flag that combines `--tempo.expiring-nonce` with a
           relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
           0, and valid_before = now + seconds.
-          
+
           Maximum value is 30 seconds. The transaction must be mined before the
           deadline or it becomes permanently invalid, giving safe retry
           semantics: retries produce a fresh tx hash and the old tx can never
@@ -299,30 +299,30 @@ Tempo:
 
       --tempo.nonce-key <NONCE_KEY>
           Nonce key for Tempo parallelizable nonces.
-          
+
           When set, builds a Tempo (type 0x76) transaction with the specified
           nonce key, allowing multiple transactions with the same nonce but
           different keys to be executed in parallel. If not set, the protocol
           nonce key (0) will be used.
-          
+
           For more information see
           [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
 
       --tempo.lane <NAME>
           Named nonce lane for Tempo parallelizable nonces.
-          
+
           Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
           `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
           the project root). The lanes file is a TOML map of `name = <U256>`
           entries, e.g.:
-          
+
           ```toml deploy   = 1 ops      = 2 payments = 3 ```
-          
+
           Mutually exclusive with `--tempo.nonce-key`.
 
       --tempo.lanes-file <PATH>
           Path to the Tempo lanes file used by `--tempo.lane`.
-          
+
           Defaults to `tempo.lanes.toml` at the project root.
 
       --tempo.sponsor <ADDRESS>
@@ -330,62 +330,62 @@ Tempo:
 
       --tempo.sponsor-signer <SIGNER>
           Sign Tempo sponsor digests in-band with the given signer URI.
-          
+
           Supported forms include `env://VAR`, `keystore://PATH`,
           `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
           `turnkey://`, and `private-key://KEY`.
 
       --tempo.sponsor-sig <SPONSOR_SIG>
           Sponsor (fee payer) signature for Tempo sponsored transactions.
-          
+
           The sponsor signs the `fee_payer_signature_hash` to commit to paying
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
           Remote sponsor (fee payer) service URL for Cast transaction commands.
-          
+
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
-          
+
           This option is supported by `cast send` and `cast erc20`. Forge
           commands currently support local sponsorship through `--tempo.sponsor`
           and `--tempo.sponsor-signer` instead.
-          
+
           Example: `cast send 0x... --sponsor-url
           https://sponsor.moderato.tempo.xyz`
-          
+
           [env: TEMPO_SPONSOR_URL=]
 
       --tempo.print-sponsor-hash
           Print the sponsor signature hash and exit.
-          
+
           Computes the `fee_payer_signature_hash` for the transaction so that a
           sponsor knows what hash to sign. The transaction is not sent.
 
       --tempo.key-id <KEY_ID>
           Access key ID for Tempo Keychain signature transactions.
-          
+
           Used during gas estimation to override the key_id that would normally
           be recovered from the signature.
 
       --tempo.expiring-nonce
           Enable expiring nonce mode for Tempo transactions.
-          
+
           Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
           transaction validity via `--tempo.valid-before` and
           `--tempo.valid-after`.
 
       --tempo.valid-before <VALID_BEFORE>
           Upper bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid before this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
       --tempo.valid-after <VALID_AFTER>
           Lower bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid after this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
@@ -409,11 +409,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/redeem.mdx
+++ b/src/pages/reference/cast/erc4626/redeem.mdx
@@ -1,0 +1,427 @@
+---
+description: "Redeem vault shares for assets"
+---
+
+_Generated from `cast erc4626 redeem --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 redeem
+
+Redeem vault shares for assets
+
+:::terminal
+
+```bash
+$ cast erc4626 redeem --help
+```
+
+```txt
+Usage: cast erc4626 redeem [OPTIONS] <VAULT> <SHARES> <RECEIVER> <OWNER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <SHARES>
+          The amount of vault shares
+
+  <RECEIVER>
+          The receiver of the redeemed assets
+
+  <OWNER>
+          The owner of the vault shares
+
+Options:
+      --async
+          Only print the transaction hash and exit immediately
+          
+          [env: CAST_ASYNC=]
+
+      --sync
+          Wait for transaction receipt synchronously instead of polling. Note:
+          uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which
+          may not be supported by all clients
+
+      --confirmations <CONFIRMATIONS>
+          The number of confirmations until the receipt is fetched
+          
+          [default: 1]
+
+      --timeout <TIMEOUT>
+          Timeout for sending the transaction
+          
+          [env: ETH_TIMEOUT=]
+
+      --poll-interval <POLL_INTERVAL>
+          Polling interval for transaction receipts (in seconds)
+          
+          [env: ETH_POLL_INTERVAL=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key
+          
+          [env: ETHERSCAN_API_KEY=]
+
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID
+          
+          [env: CHAIN=]
+
+Wallet options - raw:
+  -f, --from <ADDRESS>
+          The sender account
+          
+          [env: ETH_FROM=]
+
+  -i, --interactive
+          Open an interactive prompt to enter your private key
+
+      --private-key <RAW_PRIVATE_KEY>
+          Use the provided private key
+
+      --mnemonic <MNEMONIC>
+          Use the mnemonic phrase of mnemonic file at the specified path
+
+      --mnemonic-passphrase <PASSPHRASE>
+          Use a BIP39 passphrase for the mnemonic
+
+      --mnemonic-derivation-path <PATH>
+          The wallet derivation path.
+          
+          Works with both --mnemonic-path and hardware wallets.
+
+      --mnemonic-index <INDEX>
+          Use the private key from the given mnemonic index.
+          
+          Used with --mnemonic-path.
+          
+          [default: 0]
+
+Wallet options - keystore:
+      --keystore <PATH>
+          Use the keystore in the given folder or file
+          
+          [env: ETH_KEYSTORE=]
+
+      --account <ACCOUNT_NAME>
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
+          
+          [env: ETH_KEYSTORE_ACCOUNT=]
+
+      --password <PASSWORD>
+          The keystore password.
+          
+          Used with --keystore.
+
+      --password-file <PASSWORD_FILE>
+          The keystore password file path.
+          
+          Used with --keystore.
+          
+          [env: ETH_PASSWORD=]
+
+Wallet options - hardware wallet:
+  -l, --ledger
+          Use a Ledger hardware wallet
+
+  -t, --trezor
+          Use a Trezor hardware wallet
+
+Wallet options - Tempo:
+      --tempo.access-key <PRIVATE_KEY>
+          Tempo access key private key.
+          
+          When set, the transaction is signed with this access key on behalf of
+          `--tempo.root-account`.
+          
+          [env: TEMPO_ACCESS_KEY=]
+
+      --tempo.root-account <ADDRESS>
+          Tempo root account address (the `from` address for keychain
+          transactions).
+          
+          Required when `--tempo.access-key` is set.
+          
+          [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+          
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+Transaction options:
+      --gas-limit <GAS_LIMIT>
+          Gas limit for the transaction
+          
+          [env: ETH_GAS_LIMIT=]
+
+      --gas-price <GAS_PRICE>
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions
+          
+          [env: ETH_GAS_PRICE=]
+
+      --priority-gas-price <PRIORITY_GAS_PRICE>
+          Max priority fee per gas for EIP1559 transactions
+          
+          [env: ETH_PRIORITY_GAS_PRICE=]
+
+      --nonce <NONCE>
+          Nonce for the transaction
+
+Tempo:
+      --tempo.session <SESSION_ID>
+          Use a live Tempo wallet session for signing.
+          
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
+
+      --tempo.fee-token <FEE_TOKEN>
+          Fee token address, numeric TIP-20 token id, or known symbol for Tempo
+          transactions.
+          
+          When set, builds a Tempo (type 0x76) transaction that pays gas fees in
+          the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
+          ThetaUSD.
+          
+          If this is not set, the fee token is chosen according to network
+          rules. See the Tempo docs for more information.
+
+      --tempo.expires <SECONDS>
+          Opt into TIP-1009 expiring-nonce mode with a validity window.
+          
+          Convenience flag that combines `--tempo.expiring-nonce` with a
+          relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
+          0, and valid_before = now + seconds.
+          
+          Maximum value is 30 seconds. The transaction must be mined before the
+          deadline or it becomes permanently invalid, giving safe retry
+          semantics: retries produce a fresh tx hash and the old tx can never
+          land late.
+
+      --tempo.nonce-key <NONCE_KEY>
+          Nonce key for Tempo parallelizable nonces.
+          
+          When set, builds a Tempo (type 0x76) transaction with the specified
+          nonce key, allowing multiple transactions with the same nonce but
+          different keys to be executed in parallel. If not set, the protocol
+          nonce key (0) will be used.
+          
+          For more information see
+          [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
+
+      --tempo.lane <NAME>
+          Named nonce lane for Tempo parallelizable nonces.
+          
+          Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
+          `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
+          the project root). The lanes file is a TOML map of `name = <U256>`
+          entries, e.g.:
+          
+          ```toml deploy   = 1 ops      = 2 payments = 3 ```
+          
+          Mutually exclusive with `--tempo.nonce-key`.
+
+      --tempo.lanes-file <PATH>
+          Path to the Tempo lanes file used by `--tempo.lane`.
+          
+          Defaults to `tempo.lanes.toml` at the project root.
+
+      --tempo.sponsor <ADDRESS>
+          Sponsor (fee payer) address for Tempo sponsored transactions
+
+      --tempo.sponsor-signer <SIGNER>
+          Sign Tempo sponsor digests in-band with the given signer URI.
+          
+          Supported forms include `env://VAR`, `keystore://PATH`,
+          `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
+          `turnkey://`, and `private-key://KEY`.
+
+      --tempo.sponsor-sig <SPONSOR_SIG>
+          Sponsor (fee payer) signature for Tempo sponsored transactions.
+          
+          The sponsor signs the `fee_payer_signature_hash` to commit to paying
+          gas fees on behalf of the sender. Provide as a hex-encoded signature.
+
+      --sponsor-url <URL>
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
+          
+          When set, the user-signed transaction is forwarded to this URL via
+          `eth_signRawTransaction`. The service adds its fee payer signature and
+          returns the fully-sponsored transaction, which is then submitted via
+          the regular RPC. No local sponsor key is required.
+          
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+          
+          Example: `cast send 0x... --sponsor-url
+          https://sponsor.moderato.tempo.xyz`
+          
+          [env: TEMPO_SPONSOR_URL=]
+
+      --tempo.print-sponsor-hash
+          Print the sponsor signature hash and exit.
+          
+          Computes the `fee_payer_signature_hash` for the transaction so that a
+          sponsor knows what hash to sign. The transaction is not sent.
+
+      --tempo.key-id <KEY_ID>
+          Access key ID for Tempo Keychain signature transactions.
+          
+          Used during gas estimation to override the key_id that would normally
+          be recovered from the signature.
+
+      --tempo.expiring-nonce
+          Enable expiring nonce mode for Tempo transactions.
+          
+          Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
+          transaction validity via `--tempo.valid-before` and
+          `--tempo.valid-after`.
+
+      --tempo.valid-before <VALID_BEFORE>
+          Upper bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid before this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+      --tempo.valid-after <VALID_AFTER>
+          Lower bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid after this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/total-assets.mdx
+++ b/src/pages/reference/cast/erc4626/total-assets.mdx
@@ -31,7 +31,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -40,28 +40,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -70,46 +70,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -135,11 +135,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/total-assets.mdx
+++ b/src/pages/reference/cast/erc4626/total-assets.mdx
@@ -1,0 +1,153 @@
+---
+description: "Query the total amount of underlying assets managed by the vault"
+---
+
+_Generated from `cast erc4626 total-assets --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 total-assets
+
+Query the total amount of underlying assets managed by the vault
+
+:::terminal
+
+```bash
+$ cast erc4626 total-assets --help
+```
+
+```txt
+Usage: cast erc4626 total-assets [OPTIONS] <VAULT>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+Options:
+  -B, --block <BLOCK>
+          The block height to query at
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::

--- a/src/pages/reference/cast/erc4626/withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/withdraw.mdx
@@ -33,7 +33,7 @@ Arguments:
 Options:
       --async
           Only print the transaction hash and exit immediately
-          
+
           [env: CAST_ASYNC=]
 
       --sync
@@ -43,17 +43,17 @@ Options:
 
       --confirmations <CONFIRMATIONS>
           The number of confirmations until the receipt is fetched
-          
+
           [default: 1]
 
       --timeout <TIMEOUT>
           Timeout for sending the transaction
-          
+
           [env: ETH_TIMEOUT=]
 
       --poll-interval <POLL_INTERVAL>
           Polling interval for transaction receipts (in seconds)
-          
+
           [env: ETH_POLL_INTERVAL=]
 
   -h, --help
@@ -62,7 +62,7 @@ Options:
   -j, --threads <THREADS>
           Number of threads to use. Specifying 0 defaults to the number of
           logical cores
-          
+
           [alias: --jobs]
 
       --profile <PROFILE>
@@ -71,28 +71,28 @@ Options:
 Rpc options:
   -r, --rpc-url <URL>
           The RPC endpoint
-          
+
           [alias: --fork-url]
 
   -k, --insecure
           Allow insecure RPC connections (accept invalid HTTPS certificates).
-          
+
           When the provider's inner runtime transport variant is HTTP, this
           configures the reqwest client to accept invalid certificates.
 
       --rpc-timeout <RPC_TIMEOUT>
           Timeout for the RPC request in seconds.
-          
+
           The specified timeout will be used to override the default timeout for
           RPC requests.
-          
+
           Default value: 45
-          
+
           [env: ETH_RPC_TIMEOUT=]
 
       --no-proxy
           Disable automatic proxy detection.
-          
+
           Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
           App Sandbox) where system proxy detection causes crashes. When
           enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
@@ -101,46 +101,46 @@ Rpc options:
       --compute-units-per-second <CUPS>
           Sets the number of assumed available compute units per second for this
           provider.
-          
+
           default value: 330
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
 
       --no-rpc-rate-limit
           Disables rate limiting for this node's provider.
-          
+
           See also
           [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
-          
+
           [alias: --no-rate-limit]
 
       --flashbots
           Use the Flashbots RPC URL with fast mode
           ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
-          
+
           This shares the transaction privately with all registered builders.
-          
+
           See:
           [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
 
       --jwt-secret <JWT_SECRET>
           JWT Secret for the RPC endpoint.
-          
+
           The JWT secret will be used to create a JWT for an RPC. For example,
           the following can be used to simulate a CL `engine_forkchoiceUpdated`
           call:
-          
+
           cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
           '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
           "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
-          
+
           [env: ETH_RPC_JWT_SECRET=]
 
       --rpc-headers <RPC_HEADERS>
           Specify custom headers for RPC requests
-          
+
           [env: ETH_RPC_HEADERS=]
 
       --curl
@@ -148,18 +148,18 @@ Rpc options:
 
   -e, --etherscan-api-key <KEY>
           The Etherscan (or equivalent) API key
-          
+
           [env: ETHERSCAN_API_KEY=]
 
   -c, --chain <CHAIN>
           The chain name or EIP-155 chain ID
-          
+
           [env: CHAIN=]
 
 Wallet options - raw:
   -f, --from <ADDRESS>
           The sender account
-          
+
           [env: ETH_FROM=]
 
   -i, --interactive
@@ -176,38 +176,38 @@ Wallet options - raw:
 
       --mnemonic-derivation-path <PATH>
           The wallet derivation path.
-          
+
           Works with both --mnemonic-path and hardware wallets.
 
       --mnemonic-index <INDEX>
           Use the private key from the given mnemonic index.
-          
+
           Used with --mnemonic-path.
-          
+
           [default: 0]
 
 Wallet options - keystore:
       --keystore <PATH>
           Use the keystore in the given folder or file
-          
+
           [env: ETH_KEYSTORE=]
 
       --account <ACCOUNT_NAME>
           Use a keystore from the default keystores folder
           (~/.foundry/keystores) by its filename
-          
+
           [env: ETH_KEYSTORE_ACCOUNT=]
 
       --password <PASSWORD>
           The keystore password.
-          
+
           Used with --keystore.
 
       --password-file <PASSWORD_FILE>
           The keystore password file path.
-          
+
           Used with --keystore.
-          
+
           [env: ETH_PASSWORD=]
 
 Wallet options - hardware wallet:
@@ -220,18 +220,18 @@ Wallet options - hardware wallet:
 Wallet options - Tempo:
       --tempo.access-key <PRIVATE_KEY>
           Tempo access key private key.
-          
+
           When set, the transaction is signed with this access key on behalf of
           `--tempo.root-account`.
-          
+
           [env: TEMPO_ACCESS_KEY=]
 
       --tempo.root-account <ADDRESS>
           Tempo root account address (the `from` address for keychain
           transactions).
-          
+
           Required when `--tempo.access-key` is set.
-          
+
           [env: TEMPO_ROOT_ACCOUNT=]
 
 Wallet options - browser wallet:
@@ -240,7 +240,7 @@ Wallet options - browser wallet:
 
       --browser-port <PORT>
           Port for the browser wallet server
-          
+
           [default: 9545]
 
       --browser-disable-open
@@ -249,18 +249,18 @@ Wallet options - browser wallet:
 Transaction options:
       --gas-limit <GAS_LIMIT>
           Gas limit for the transaction
-          
+
           [env: ETH_GAS_LIMIT=]
 
       --gas-price <GAS_PRICE>
           Gas price for legacy transactions, or max fee per gas for EIP1559
           transactions
-          
+
           [env: ETH_GAS_PRICE=]
 
       --priority-gas-price <PRIORITY_GAS_PRICE>
           Max priority fee per gas for EIP1559 transactions
-          
+
           [env: ETH_PRIORITY_GAS_PRICE=]
 
       --nonce <NONCE>
@@ -269,7 +269,7 @@ Transaction options:
 Tempo:
       --tempo.session <SESSION_ID>
           Use a live Tempo wallet session for signing.
-          
+
           When set, Foundry resolves the authorization witness from
           `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
           key on behalf of its root account.
@@ -277,21 +277,21 @@ Tempo:
       --tempo.fee-token <FEE_TOKEN>
           Fee token address, numeric TIP-20 token id, or known symbol for Tempo
           transactions.
-          
+
           When set, builds a Tempo (type 0x76) transaction that pays gas fees in
           the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
           ThetaUSD.
-          
+
           If this is not set, the fee token is chosen according to network
           rules. See the Tempo docs for more information.
 
       --tempo.expires <SECONDS>
           Opt into TIP-1009 expiring-nonce mode with a validity window.
-          
+
           Convenience flag that combines `--tempo.expiring-nonce` with a
           relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
           0, and valid_before = now + seconds.
-          
+
           Maximum value is 30 seconds. The transaction must be mined before the
           deadline or it becomes permanently invalid, giving safe retry
           semantics: retries produce a fresh tx hash and the old tx can never
@@ -299,30 +299,30 @@ Tempo:
 
       --tempo.nonce-key <NONCE_KEY>
           Nonce key for Tempo parallelizable nonces.
-          
+
           When set, builds a Tempo (type 0x76) transaction with the specified
           nonce key, allowing multiple transactions with the same nonce but
           different keys to be executed in parallel. If not set, the protocol
           nonce key (0) will be used.
-          
+
           For more information see
           [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
 
       --tempo.lane <NAME>
           Named nonce lane for Tempo parallelizable nonces.
-          
+
           Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
           `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
           the project root). The lanes file is a TOML map of `name = <U256>`
           entries, e.g.:
-          
+
           ```toml deploy   = 1 ops      = 2 payments = 3 ```
-          
+
           Mutually exclusive with `--tempo.nonce-key`.
 
       --tempo.lanes-file <PATH>
           Path to the Tempo lanes file used by `--tempo.lane`.
-          
+
           Defaults to `tempo.lanes.toml` at the project root.
 
       --tempo.sponsor <ADDRESS>
@@ -330,62 +330,62 @@ Tempo:
 
       --tempo.sponsor-signer <SIGNER>
           Sign Tempo sponsor digests in-band with the given signer URI.
-          
+
           Supported forms include `env://VAR`, `keystore://PATH`,
           `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
           `turnkey://`, and `private-key://KEY`.
 
       --tempo.sponsor-sig <SPONSOR_SIG>
           Sponsor (fee payer) signature for Tempo sponsored transactions.
-          
+
           The sponsor signs the `fee_payer_signature_hash` to commit to paying
           gas fees on behalf of the sender. Provide as a hex-encoded signature.
 
       --sponsor-url <URL>
           Remote sponsor (fee payer) service URL for Cast transaction commands.
-          
+
           When set, the user-signed transaction is forwarded to this URL via
           `eth_signRawTransaction`. The service adds its fee payer signature and
           returns the fully-sponsored transaction, which is then submitted via
           the regular RPC. No local sponsor key is required.
-          
+
           This option is supported by `cast send` and `cast erc20`. Forge
           commands currently support local sponsorship through `--tempo.sponsor`
           and `--tempo.sponsor-signer` instead.
-          
+
           Example: `cast send 0x... --sponsor-url
           https://sponsor.moderato.tempo.xyz`
-          
+
           [env: TEMPO_SPONSOR_URL=]
 
       --tempo.print-sponsor-hash
           Print the sponsor signature hash and exit.
-          
+
           Computes the `fee_payer_signature_hash` for the transaction so that a
           sponsor knows what hash to sign. The transaction is not sent.
 
       --tempo.key-id <KEY_ID>
           Access key ID for Tempo Keychain signature transactions.
-          
+
           Used during gas estimation to override the key_id that would normally
           be recovered from the signature.
 
       --tempo.expiring-nonce
           Enable expiring nonce mode for Tempo transactions.
-          
+
           Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
           transaction validity via `--tempo.valid-before` and
           `--tempo.valid-after`.
 
       --tempo.valid-before <VALID_BEFORE>
           Upper bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid before this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
       --tempo.valid-after <VALID_AFTER>
           Lower bound timestamp for Tempo expiring nonce transactions.
-          
+
           The transaction is only valid after this unix timestamp. Requires
           `--tempo.expiring-nonce`.
 
@@ -409,11 +409,11 @@ Display options:
 
   -v, --verbosity...
           Verbosity level of the log messages.
-          
+
           Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
-          
+
           Depending on the context the verbosity levels have different meanings.
-          
+
           For example, the verbosity levels of the EVM are:
           - 2 (-vv): Print logs for all tests.
           - 3 (-vvv): Print execution traces for failing tests.

--- a/src/pages/reference/cast/erc4626/withdraw.mdx
+++ b/src/pages/reference/cast/erc4626/withdraw.mdx
@@ -1,0 +1,427 @@
+---
+description: "Withdraw assets from the vault"
+---
+
+_Generated from `cast erc4626 withdraw --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc4626 withdraw
+
+Withdraw assets from the vault
+
+:::terminal
+
+```bash
+$ cast erc4626 withdraw --help
+```
+
+```txt
+Usage: cast erc4626 withdraw [OPTIONS] <VAULT> <ASSETS> <RECEIVER> <OWNER>
+
+Arguments:
+  <VAULT>
+          The ERC-4626 vault contract address
+
+  <ASSETS>
+          The amount of underlying assets
+
+  <RECEIVER>
+          The receiver of the withdrawn assets
+
+  <OWNER>
+          The owner of the vault shares
+
+Options:
+      --async
+          Only print the transaction hash and exit immediately
+          
+          [env: CAST_ASYNC=]
+
+      --sync
+          Wait for transaction receipt synchronously instead of polling. Note:
+          uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which
+          may not be supported by all clients
+
+      --confirmations <CONFIRMATIONS>
+          The number of confirmations until the receipt is fetched
+          
+          [default: 1]
+
+      --timeout <TIMEOUT>
+          Timeout for sending the transaction
+          
+          [env: ETH_TIMEOUT=]
+
+      --poll-interval <POLL_INTERVAL>
+          Polling interval for transaction receipts (in seconds)
+          
+          [env: ETH_POLL_INTERVAL=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key
+          
+          [env: ETHERSCAN_API_KEY=]
+
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID
+          
+          [env: CHAIN=]
+
+Wallet options - raw:
+  -f, --from <ADDRESS>
+          The sender account
+          
+          [env: ETH_FROM=]
+
+  -i, --interactive
+          Open an interactive prompt to enter your private key
+
+      --private-key <RAW_PRIVATE_KEY>
+          Use the provided private key
+
+      --mnemonic <MNEMONIC>
+          Use the mnemonic phrase of mnemonic file at the specified path
+
+      --mnemonic-passphrase <PASSPHRASE>
+          Use a BIP39 passphrase for the mnemonic
+
+      --mnemonic-derivation-path <PATH>
+          The wallet derivation path.
+          
+          Works with both --mnemonic-path and hardware wallets.
+
+      --mnemonic-index <INDEX>
+          Use the private key from the given mnemonic index.
+          
+          Used with --mnemonic-path.
+          
+          [default: 0]
+
+Wallet options - keystore:
+      --keystore <PATH>
+          Use the keystore in the given folder or file
+          
+          [env: ETH_KEYSTORE=]
+
+      --account <ACCOUNT_NAME>
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
+          
+          [env: ETH_KEYSTORE_ACCOUNT=]
+
+      --password <PASSWORD>
+          The keystore password.
+          
+          Used with --keystore.
+
+      --password-file <PASSWORD_FILE>
+          The keystore password file path.
+          
+          Used with --keystore.
+          
+          [env: ETH_PASSWORD=]
+
+Wallet options - hardware wallet:
+  -l, --ledger
+          Use a Ledger hardware wallet
+
+  -t, --trezor
+          Use a Trezor hardware wallet
+
+Wallet options - Tempo:
+      --tempo.access-key <PRIVATE_KEY>
+          Tempo access key private key.
+          
+          When set, the transaction is signed with this access key on behalf of
+          `--tempo.root-account`.
+          
+          [env: TEMPO_ACCESS_KEY=]
+
+      --tempo.root-account <ADDRESS>
+          Tempo root account address (the `from` address for keychain
+          transactions).
+          
+          Required when `--tempo.access-key` is set.
+          
+          [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+          
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+Transaction options:
+      --gas-limit <GAS_LIMIT>
+          Gas limit for the transaction
+          
+          [env: ETH_GAS_LIMIT=]
+
+      --gas-price <GAS_PRICE>
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions
+          
+          [env: ETH_GAS_PRICE=]
+
+      --priority-gas-price <PRIORITY_GAS_PRICE>
+          Max priority fee per gas for EIP1559 transactions
+          
+          [env: ETH_PRIORITY_GAS_PRICE=]
+
+      --nonce <NONCE>
+          Nonce for the transaction
+
+Tempo:
+      --tempo.session <SESSION_ID>
+          Use a live Tempo wallet session for signing.
+          
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
+
+      --tempo.fee-token <FEE_TOKEN>
+          Fee token address, numeric TIP-20 token id, or known symbol for Tempo
+          transactions.
+          
+          When set, builds a Tempo (type 0x76) transaction that pays gas fees in
+          the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
+          ThetaUSD.
+          
+          If this is not set, the fee token is chosen according to network
+          rules. See the Tempo docs for more information.
+
+      --tempo.expires <SECONDS>
+          Opt into TIP-1009 expiring-nonce mode with a validity window.
+          
+          Convenience flag that combines `--tempo.expiring-nonce` with a
+          relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
+          0, and valid_before = now + seconds.
+          
+          Maximum value is 30 seconds. The transaction must be mined before the
+          deadline or it becomes permanently invalid, giving safe retry
+          semantics: retries produce a fresh tx hash and the old tx can never
+          land late.
+
+      --tempo.nonce-key <NONCE_KEY>
+          Nonce key for Tempo parallelizable nonces.
+          
+          When set, builds a Tempo (type 0x76) transaction with the specified
+          nonce key, allowing multiple transactions with the same nonce but
+          different keys to be executed in parallel. If not set, the protocol
+          nonce key (0) will be used.
+          
+          For more information see
+          [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
+
+      --tempo.lane <NAME>
+          Named nonce lane for Tempo parallelizable nonces.
+          
+          Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
+          `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
+          the project root). The lanes file is a TOML map of `name = <U256>`
+          entries, e.g.:
+          
+          ```toml deploy   = 1 ops      = 2 payments = 3 ```
+          
+          Mutually exclusive with `--tempo.nonce-key`.
+
+      --tempo.lanes-file <PATH>
+          Path to the Tempo lanes file used by `--tempo.lane`.
+          
+          Defaults to `tempo.lanes.toml` at the project root.
+
+      --tempo.sponsor <ADDRESS>
+          Sponsor (fee payer) address for Tempo sponsored transactions
+
+      --tempo.sponsor-signer <SIGNER>
+          Sign Tempo sponsor digests in-band with the given signer URI.
+          
+          Supported forms include `env://VAR`, `keystore://PATH`,
+          `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
+          `turnkey://`, and `private-key://KEY`.
+
+      --tempo.sponsor-sig <SPONSOR_SIG>
+          Sponsor (fee payer) signature for Tempo sponsored transactions.
+          
+          The sponsor signs the `fee_payer_signature_hash` to commit to paying
+          gas fees on behalf of the sender. Provide as a hex-encoded signature.
+
+      --sponsor-url <URL>
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
+          
+          When set, the user-signed transaction is forwarded to this URL via
+          `eth_signRawTransaction`. The service adds its fee payer signature and
+          returns the fully-sponsored transaction, which is then submitted via
+          the regular RPC. No local sponsor key is required.
+          
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+          
+          Example: `cast send 0x... --sponsor-url
+          https://sponsor.moderato.tempo.xyz`
+          
+          [env: TEMPO_SPONSOR_URL=]
+
+      --tempo.print-sponsor-hash
+          Print the sponsor signature hash and exit.
+          
+          Computes the `fee_payer_signature_hash` for the transaction so that a
+          sponsor knows what hash to sign. The transaction is not sent.
+
+      --tempo.key-id <KEY_ID>
+          Access key ID for Tempo Keychain signature transactions.
+          
+          Used during gas estimation to override the key_id that would normally
+          be recovered from the signature.
+
+      --tempo.expiring-nonce
+          Enable expiring nonce mode for Tempo transactions.
+          
+          Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
+          transaction validity via `--tempo.valid-before` and
+          `--tempo.valid-after`.
+
+      --tempo.valid-before <VALID_BEFORE>
+          Upper bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid before this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+      --tempo.valid-after <VALID_AFTER>
+          Lower bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid after this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::


### PR DESCRIPTION
Documents [foundry-rs/foundry#16601](https://github.com/foundry-rs/foundry/pull/16601) and its inspection follow-up [foundry-rs/foundry#16605](https://github.com/foundry-rs/foundry/pull/16605) with a Cast guide for the complete synchronous ERC-4626 base interface. The guide maps deposit, mint, withdraw, and redeem to their limit and preview calls, explains asset allowances and owner authorization, and covers the `cast vault` alias.

The guide also shows how to use `cast erc4626 info`, `position`, and `check`, including exact versus human-readable text amounts, stable JSON amount fields, account-specific probes, and the check command's exit-status behavior. The compatibility boundary is explicit: `check` probes safe read-call behavior but does not certify state-changing selector coverage or semantic ERC-4626 compliance. Targeted guidance covers conservative zero limits, ERC-7535 native assets, and ERC-165-gated handling of ERC-7540 asynchronous preview reverts.

The generated CLI reference pages come from the feature binaries for `cast erc4626` and all nineteen subcommands. The root Cast reference and navigation expose the command family under a dedicated Vault Commands section. Event history and decoding, ERC-5143 or router slippage bounds, ERC-7540 request/status/claim flows, ERC-7575 multi-asset and share indirection, native-value and permit composition, and project adapters remain follow-ups.

The base command surface from #16601 has merged; the inspection commands are tracked in #16605. Codex was used for implementation, documentation, validation, and PR text.
