### PR TITLE
chore(ci): speed up Vocs checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
     branches: [master]
 
 jobs:
-  test:
-    name: vocs build
+  checks:
+    name: checks
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,6 +44,27 @@ jobs:
 
       - name: Test
         run: vp run test
+
+  build:
+    name: vocs build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+        with:
+          cache: true
+          node-version: "24"
+          run-install: false
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
 
       - name: Build Vocs
         run: vp exec vocs build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
         run: vp run test
 
       - name: Build Vocs
-        run: vp run build
+        run: vp exec vocs build


### PR DESCRIPTION
## Summary

- run the pure Vocs build in CI without refreshing remote benchmark and changelog data
- run checks and tests concurrently with the Vocs build
- keep the production `build` script and scheduled update workflow unchanged

## Investigation

The baseline job took 2m32s, including 1m55s in `Build Vocs`. Its production wrapper spent about 9s refreshing remote data, but CI did not check or commit those changes.

The checks and tests took another 18s before the Vocs build could start. Running them in a separate job removes that work from the critical path while preserving the existing `vocs build` check name. The resulting workflow passed in 2m01s, while the independent checks finished in 38s.

I also tested persisting Vite Task's cache. An explicit cached cold run took 2m33s, and an identical rerun still performed the full build, so this draft excludes that added complexity and archive overhead.

The remaining cost is upstream in Vocs: search indexing took about 25s, repeated `vocs:llms` hooks about 31s across five environments, and sitemap generation about 17s.

## Validation

- `git diff --check`
- `checks`: passed in 38s
- `vocs build`: passed in 2m01s

Prompted by: @DaniPopes
