### PR TITLE
docs(lint): document storage aliases, inheritance, and naming exceptions

### DIFF
--- a/src/pages/config/reference/linter.mdx
+++ b/src/pages/config/reference/linter.mdx
@@ -51,7 +51,7 @@ List of files or patterns to ignore when running the linter. This is a comma-sep
 - Default: `["ERC", "URI"]`
 - Environment: `FOUNDRY_LINT_MIXED_CASE_EXCEPTIONS`
 
-Configurable patterns that should be excluded when performing `mixedCase` lint checks. Defaults to `["ERC", "URI"]` to allow common names like `rescueERC20`, `ERC721TokenReceiver`, or `tokenURI`.
+Configurable patterns that should be excluded when performing `mixedCase` and `PascalCase` lint checks. Defaults to `["ERC", "URI"]` to allow common names like `rescueERC20`, `ERC721TokenReceiver`, `tokenURI`, or `ERC20Data`.
 
 ## Inline Configuration
 

--- a/src/pages/forge/linting/arbitrary-send-erc20.mdx
+++ b/src/pages/forge/linting/arbitrary-send-erc20.mdx
@@ -40,6 +40,11 @@ Safety is established by:
 - Inline equality guards in the prefix of a modifier body (statements
   strictly before its single top-level `_;` placeholder), mapped back to
   the caller's argument variables.
+- Parameters of internal functions and modifiers whose every call or
+  invocation site passes a safe expression.
+
+Modifier, `fallback`, and `receive` bodies are analyzed like ordinary
+functions; only constructors are skipped.
 
 Branch joins recognise `return`, custom-error `revert`, the `revert(...)`
 builtin, and `assert(false)` / `require(false, ...)` as always-exiting:

--- a/src/pages/forge/linting/ecrecover.mdx
+++ b/src/pages/forge/linting/ecrecover.mdx
@@ -12,7 +12,8 @@ to be in the canonical lower half of the secp256k1 curve order.
 
 ### What it does
 
-The lint follows simple local aliases and recognizes low-`s` bounds established by `require`,
+The lint follows simple local aliases and struct fields such as `sig.s`, and recognizes
+low-`s` bounds established by `require`,
 `assert`, conditionals, and early-return or revert branches. It accepts the canonical maximum
 `0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0`, stricter bounds, reversed
 comparisons, and the equivalent strict comparison against that value plus one. Facts are

--- a/src/pages/forge/linting/missing-events-arithmetic.mdx
+++ b/src/pages/forge/linting/missing-events-arithmetic.mdx
@@ -20,6 +20,9 @@ This lint looks for scalar `int`/`uint` state variables that are:
 - used in arithmetic by an unprotected public or external function, and
 - changed along a path that does not emit an event.
 
+State variables and entry points are collected across the whole inheritance chain, with
+overridden base functions resolved to the most derived implementation.
+
 It intentionally skips fixed-value writes, constructors, unprotected setters, mappings/arrays, and
 update paths that emit an event directly or through an internal helper. Those limits keep the rule
 focused on Slither's low-severity `events-maths` case while avoiding common false positives.

--- a/src/pages/forge/linting/pascal-case-struct.mdx
+++ b/src/pages/forge/linting/pascal-case-struct.mdx
@@ -12,7 +12,8 @@ Flags struct definitions whose names do not follow `PascalCase`.
 ### What it does
 
 Reports `struct` identifiers longer than one character that do not match the `PascalCase`
-convention. Single-character names are not checked.
+convention. Leading and trailing underscores are preserved, and single-character names are not
+checked.
 
 ### Why is this bad?
 
@@ -33,4 +34,16 @@ struct USERINFO   { uint256 balance; }
 
 ```solidity
 struct UserInfo { uint256 balance; }
+```
+
+### Configuration
+
+Set `mixed_case_exceptions` under `[lint.lint_specific]` in `foundry.toml` to replace the default
+list of allowed uppercase patterns (`ERC`, `URI`, `ID`, `URL`, `API`, `JSON`, `XML`, `HTML`, `HTTP`,
+and `HTTPS`). The same list is shared with the `mixed-case-*` lints, so a struct such as
+`ERC20Data` is not flagged:
+
+```toml
+[lint.lint_specific]
+mixed_case_exceptions = ["ERC", "URI", "NFT"]
 ```

--- a/src/pages/forge/linting/uninitialized-state.mdx
+++ b/src/pages/forge/linting/uninitialized-state.mdx
@@ -19,20 +19,22 @@ chain, the lint checks whether it is ever written, via an inline initialiser at 
 declaration site, any assignment (including compound assignments such as `+=`), `delete`,
 pre/post increment/decrement, or `push`/`pop` on a dynamic array, anywhere in any function
 or constructor in the hierarchy, including modifier call arguments and base-constructor
-arguments. If the variable is read (in a function body, state-variable initialiser,
-modifier argument, or compiler-synthesised public getter) but never written by any of the
-above, it is flagged.
+arguments. Writes through a local `storage` pointer (`Foo storage f = bar; f.x = 1;`) count
+as writes to every state variable the pointer may reference. If the variable is read (in a
+function body, state-variable initialiser, modifier argument, or compiler-synthesised public
+getter) but never written by any of the above, it is flagged.
 
 **Assembly bail-out**: if any function body in the inheritance chain contains inline assembly
 (which Solar lowers to an opaque AST node), the lint skips the entire contract conservatively
 to avoid false positives from untracked storage writes.
 
 **Known limitations**:
-- *Storage aliases*: `Foo storage f = bar; f.x = 1;` is not detected as a write to `bar`.
-- *Storage-parameter calls (partial)*: the lint detects when a state variable is passed as
-  a storage reference to a bare, qualified, or `super` internal call and treats it as a
-  write. What remains undetected are calls made through a local storage alias, or through
-  a member expression where the receiver is itself a state variable.
+- *Storage aliases*: pointer tracking is flow-insensitive, so a pointer that is reassigned
+  (`f = bar; f = baz; f.x = 1;`) counts as a write to both `bar` and `baz`.
+- *Storage-parameter calls (partial)*: the lint detects when a state variable or a local
+  storage pointer is passed as a storage reference to a bare, qualified, or `super` internal
+  call and treats it as a write. Calls through a member expression where the receiver is
+  itself a state variable remain undetected.
 - *Member calls*: any member call whose receiver is a state variable (e.g.
   `oracle.latestAnswer()`, `token.balanceOf(address)`) suppresses the warning for that
   variable. Without full call-graph resolution the lint conservatively treats the receiver

--- a/src/pages/forge/linting/uninitialized-state.mdx
+++ b/src/pages/forge/linting/uninitialized-state.mdx
@@ -30,14 +30,16 @@ to avoid false positives from untracked storage writes.
 
 **Known limitations**:
 - *Storage aliases*: pointer tracking is flow-insensitive, so a pointer that is reassigned
-  (`f = bar; f = baz; f.x = 1;`) counts as a write to both `bar` and `baz`.
+  (`f = bar; f = baz; f.x = 1;`) counts as a write to both `bar` and `baz`. A pointer
+  initialized from a function return value has no known target, so writes through it are
+  not attributed to any state variable.
 - *Storage-parameter calls (partial)*: the lint detects when a state variable or a local
   storage pointer is passed as a storage reference to a bare, qualified, or `super` internal
   call and treats it as a write. Calls through a member expression where the receiver is
   itself a state variable remain undetected.
-- *Member calls*: any member call whose receiver is a state variable (e.g.
-  `oracle.latestAnswer()`, `token.balanceOf(address)`) suppresses the warning for that
-  variable. Without full call-graph resolution the lint conservatively treats the receiver
+- *Member calls*: any member call whose receiver is a state variable or a local storage
+  pointer to one (e.g. `oracle.latestAnswer()`, `token.balanceOf(address)`) suppresses the
+  warning for that variable. Without full call-graph resolution the lint conservatively treats the receiver
   as potentially mutated, to avoid false positives from `push`/`pop` and library-dispatch
   patterns (`using Lib for T`). Read-only interface calls on uninitialized variables will
   therefore not be flagged.


### PR DESCRIPTION
Documents the lint behavior changes from foundry-rs/foundry#16578 (`pascal-case-struct` preserves leading and trailing underscores and honors `mixed_case_exceptions`), foundry-rs/foundry#16582 (`uninitialized-state` attributes writes through local storage pointers to the state variables they may reference), foundry-rs/foundry#16603 (`missing-events-arithmetic` collects state variables and entry points across the inheritance chain with overrides resolved), foundry-rs/foundry#16607 (`arbitrary-send-erc20` analyzes modifier bodies and treats modifier parameters as safe when every invocation site passes a safe expression), and foundry-rs/foundry#16608 (`ecrecover` tracks struct fields such as `sig.s`).

The `mixed_case_exceptions` entry in the linter config reference now mentions the PascalCase check as well.
