### PR TITLE
docs(config): fix lint exception defaults

### DIFF
--- a/src/pages/config/reference/linter.mdx
+++ b/src/pages/config/reference/linter.mdx
@@ -48,10 +48,10 @@ List of files or patterns to ignore when running the linter. This is a comma-sep
 ##### `mixed_case_exceptions`
 
 - Type: array of strings
-- Default: `["ERC", "URI"]`
+- Default: `["ERC", "URI", "ID", "URL", "API", "JSON", "XML", "HTML", "HTTP", "HTTPS"]`
 - Environment: `FOUNDRY_LINT_MIXED_CASE_EXCEPTIONS`
 
-Configurable patterns that should be excluded when performing `mixedCase` and `PascalCase` lint checks. Defaults to `["ERC", "URI"]` to allow common names like `rescueERC20`, `ERC721TokenReceiver`, `tokenURI`, or `ERC20Data`.
+Configurable patterns that should be excluded when performing `mixedCase` and `PascalCase` lint checks. The defaults allow common names like `rescueERC20`, `ERC721TokenReceiver`, `tokenURI`, or `ERC20Data`.
 
 ## Inline Configuration
 


### PR DESCRIPTION
`mixed_case_exceptions` defaults to ten acronym patterns, but the config reference added in #2061 listed only `ERC` and `URI`. This aligns the reference with `LintSpecificConfig::default()` and removes the duplicated incomplete list from the explanatory text.

Prepared with Codex assistance.