### PR TITLE
docs(config): update default lint severities

### DIFF
--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -911,7 +911,7 @@ ignore = []
 
 [lint]
 # Specifies which lints to run based on severity
-# If uninformed, all severities are checked
+# Defaults to high, medium, and low severity lints
 # Options: "high", "medium", "low", "info", "gas", "code-size"
 # Default: ["high", "medium", "low"]
 severity = ["high", "medium", "low"]

--- a/src/pages/config/reference/linter.mdx
+++ b/src/pages/config/reference/linter.mdx
@@ -13,7 +13,7 @@ Whether to run linting during `forge build`. Set to `false` to disable automatic
 ##### `severity`
 
 - Type: array of strings
-- Default: `[]`
+- Default: `["high", "medium", "low"]`
 - Environment: `FOUNDRY_LINT_SEVERITY`
 
 Specifies which lints to run based on severity. Valid values are:
@@ -25,9 +25,8 @@ Specifies which lints to run based on severity. Valid values are:
 - `gas`
 - `code-size` (or `codesize`, `size`)
 
-An empty list means no severity filter is applied, so all severity buckets are
-enabled. To run only warning-level lints, set this explicitly to
-`["high", "medium", "low"]`.
+By default, Forge runs high, medium, and low severity lints. An empty list means no severity filter
+is applied, enabling all severity buckets, including informational, gas, and code-size lints.
 
 ##### `exclude_lints`
 


### PR DESCRIPTION
## Summary

- document high, medium, and low as the default lint severities
- clarify that an empty severity list enables informational, gas, and code-size lints too

Tracks foundry-rs/foundry#16622.

## Testing

- `vp exec vocs build`
