### PR TITLE
docs(cast): document ERC-2612 permits

### DIFF
--- a/sidebar/cast-cli-reference.ts
+++ b/sidebar/cast-cli-reference.ts
@@ -159,6 +159,7 @@ export const castCliReference: SidebarItem = {
         { text: "cast erc20-token decimals", link: "/reference/cast/erc20-token/decimals" },
         { text: "cast erc20-token mint", link: "/reference/cast/erc20-token/mint" },
         { text: "cast erc20-token name", link: "/reference/cast/erc20-token/name" },
+        { text: "cast erc20-token permit", link: "/reference/cast/erc20-token/permit" },
         { text: "cast erc20-token symbol", link: "/reference/cast/erc20-token/symbol" },
         { text: "cast erc20-token total-supply", link: "/reference/cast/erc20-token/total-supply" },
         { text: "cast erc20-token transfer", link: "/reference/cast/erc20-token/transfer" },

--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -37,6 +37,7 @@ const docs = [
       { text: "Overview", link: "/cast" },
       { text: "Reading Chain Data", link: "/cast/reading-chain-data" },
       { text: "Sending Transactions", link: "/cast/sending-transactions" },
+      { text: "Token Approvals", link: "/cast/token-approvals" },
       { text: "Tokenized Vaults", link: "/cast/tokenized-vaults" },
       { text: "Wallet Operations", link: "/cast/wallet-operations" },
       { text: "EIP-7702 Delegation", link: "/cast/eip-7702-delegation" },

--- a/src/pages/cast/token-approvals.mdx
+++ b/src/pages/cast/token-approvals.mdx
@@ -1,0 +1,78 @@
+---
+description: "Approve ERC-20 spending with an on-chain transaction or an ERC-2612 permit signature."
+---
+
+## Token Approvals
+
+An ERC-20 allowance authorizes a spender to use tokens owned by your account. You can set it with `cast erc20 approve`, or sign an [ERC-2612 permit](https://eips.ethereum.org/EIPS/eip-2612) with [`cast erc20 permit`](/reference/cast/erc20-token/permit) when the token supports that extension. `erc20` is an alias for `erc20-token`.
+
+A permit signature authorizes an allowance change. It does not transfer tokens, deposit into a vault, or change the allowance until someone submits it to the token contract.
+
+### Before you start
+
+Set `TOKEN`, `SPENDER`, and `RPC_URL` for the token, the contract that will spend it, and its chain. Set `AMOUNT` in the token's smallest unit. Set `DEADLINE` to an absolute Unix timestamp in seconds; it is the last time the permit may be submitted, not an expiry for the resulting allowance. The examples use `PRIVATE_KEY` for the token owner and `RELAYER_PRIVATE_KEY` for a relayer. You can instead select a keystore with `--account` or use the wallet options in [Sending transactions](/cast/sending-transactions).
+
+### Approve with a transaction
+
+You can use ordinary approval even when a token supports permits:
+
+```bash
+$ cast erc20 approve "$TOKEN" "$SPENDER" "$AMOUNT" --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL"
+```
+
+This sends a transaction and sets the allowance directly.
+
+### Sign a permit for an integration
+
+Generate a signature and calldata without broadcasting:
+
+```bash
+$ cast erc20 permit "$TOKEN" "$SPENDER" "$AMOUNT" --deadline "$DEADLINE" \
+    --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" --json > permit.json
+```
+
+The signing wallet is the owner. Cast reads `nonces(owner)` from the token and constructs the standard ERC-2612 `Permit` message. You do not supply the transaction nonce as the permit nonce.
+
+Without `--json`, stdout contains a 65-byte signature encoded as hex in `r || s || v` order. JSON output uses the Foundry envelope: `.data` contains `token`, `owner`, `spender`, decimal strings for `value`, `nonce`, and `deadline`, plus `signature`, `calldata`, and `typed_data`.
+
+An integration can use the signature in its permit-and-action transaction. Alternatively, a relayer can submit the calldata directly to the token:
+
+```bash
+$ cast send "$TOKEN" --data "$(jq -r '.data.calldata' permit.json)" \
+    --private-key "$RELAYER_PRIVATE_KEY" --rpc-url "$RPC_URL"
+```
+
+The relayer pays the transaction fee. The permit still authorizes only the spender and amount you signed. After the permit is accepted, its nonce is consumed and the same signature cannot be used again. Another permit submitted for that owner before yours may make your signature stale.
+
+### Broadcast from the signing wallet
+
+To sign and submit the permit in one command, add `--broadcast`:
+
+```bash
+$ cast erc20 permit "$TOKEN" "$SPENDER" "$AMOUNT" --deadline "$DEADLINE" \
+    --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" --broadcast
+```
+
+This prints the transaction receipt. Add `--async` to print the transaction hash without waiting for the receipt. Broadcasting a permit and then sending a separate deposit still takes two transactions.
+
+### Verify the allowance
+
+After the permit transaction is confirmed, query the resulting allowance:
+
+```bash
+$ cast erc20 allowance "$TOKEN" "$OWNER" "$SPENDER" --rpc-url "$RPC_URL"
+```
+
+### Domain discovery and compatibility
+
+Cast uses [EIP-5267](https://eips.ethereum.org/EIPS/eip-5267) `eip712Domain()` when the token exposes it, including optional domain fields and salt. It rejects unsupported domain extensions. Otherwise it constructs the common domain using `name()`, version `"1"`, the RPC chain ID, and the token address.
+
+If the token uses a different domain name or version, supply `--domain-name` or `--domain-version`. Cast checks the constructed domain against the token's `DOMAIN_SEPARATOR()` before asking the wallet to sign. A mismatch is an error; an override does not bypass verification. A discovered chain ID or verifying contract must also match the RPC chain or token address when present.
+
+This command supports standard ERC-2612 permits. DAI-style permits and Uniswap Permit2 use different signing formats and are not supported by this helper.
+
+### Permits and vault deposits
+
+For an [ERC-4626 deposit](/cast/tokenized-vaults), the vault spends your **underlying asset**. A direct deposit therefore needs an allowance on that asset with the vault as spender. The vault's own permit, if implemented, approves spending **vault shares** and does not approve the underlying asset.
+
+Router or bundler integrations may require a different spender and can combine permit submission with a deposit in one transaction. Use the integration's specified spender and transaction format. This command produces a standard permit; it does not build a Morpho or other protocol's bundled deposit transaction.

--- a/src/pages/cast/tokenized-vaults.mdx
+++ b/src/pages/cast/tokenized-vaults.mdx
@@ -53,6 +53,8 @@ $ cast erc20-token approve $ASSET $VAULT $ASSETS --rpc-url $RPC_URL --private-ke
 $ cast erc4626 deposit $VAULT $ASSETS $RECEIVER --rpc-url $RPC_URL --private-key $PRIVATE_KEY
 ```
 
+If the underlying asset supports ERC-2612, you can also authorize spending with a [permit signature](/cast/token-approvals). A permit on the vault itself approves its shares, not the underlying deposit asset.
+
 `mint` follows the same approval flow, but takes the exact number of shares to mint. Use `preview-mint` to calculate the assets the vault expects to pull.
 
 State-changing vault commands use the same signer, fee, hardware wallet, browser wallet, and Tempo options as `cast send`. See [Sending transactions](/cast/sending-transactions) for those options.

--- a/src/pages/reference/cast/erc20-token.mdx
+++ b/src/pages/reference/cast/erc20-token.mdx
@@ -18,6 +18,8 @@ $ cast erc20-token --help
 Usage: cast erc20-token [OPTIONS] <COMMAND>
 
 Commands:
+  permit        Sign an ERC-2612 approval without sending a transaction, or
+                submit it with --broadcast.
   balance       Query ERC20 token balance [alias: b]
   transfer      Transfer ERC20 tokens [aliases: t, send]
   approve       Approve ERC20 token spending [alias: a]

--- a/src/pages/reference/cast/erc20-token/permit.mdx
+++ b/src/pages/reference/cast/erc20-token/permit.mdx
@@ -1,0 +1,468 @@
+---
+description: "Sign an ERC-2612 approval without sending a transaction, or submit it with --broadcast. The owner is the signing wallet. Amounts are in raw token units and the deadline is an absolute Unix timestamp in seconds. This does not transfer tokens or deposit into a vault. For deposits, the permit must target the underlying asset, not the vault's share token. By default stdout contains the 65-byte signature (r, s, v). With --json, it contains the signature, permit calldata, owner, spender, value, nonce, deadline, token, and typed data. With --broadcast, output follows cast send: a receipt, or a transaction hash with --async. Anyone can submit the generated calldata to the token before the deadline. Uses EIP-5267 domain discovery when available. Otherwise uses name(), version \"1\", the RPC chain ID, and the token address. --domain-name and --domain-version override the name and version. The resulting domain must match DOMAIN_SEPARATOR() before signing. DAI-style permits and Permit2 are not supported. Example: ```text cast erc20 permit $TOKEN $SPENDER 1000000 --deadline $DEADLINE \\ --account owner --rpc-url $RPC_URL --json cast erc20 permit $TOKEN $SPENDER 1000000 --deadline $DEADLINE \\ --account owner --rpc-url $RPC_URL --broadcast --async ```"
+---
+
+_Generated from `cast erc20-token permit --help`; see [CLI reference versions](/reference/versions). Regenerate this page instead of editing it directly._
+
+## cast erc20-token permit
+
+Sign an ERC-2612 approval without sending a transaction, or submit it with
+--broadcast.
+
+The owner is the signing wallet. Amounts are in raw token units and the deadline
+is an
+absolute Unix timestamp in seconds. This does not transfer tokens or deposit
+into a vault.
+For deposits, the permit must target the underlying asset, not the vault's share
+token.
+
+By default stdout contains the 65-byte signature (r, s, v). With --json, it
+contains the
+signature, permit calldata, owner, spender, value, nonce, deadline, token, and
+typed data.
+With --broadcast, output follows cast send: a receipt, or a transaction hash
+with --async.
+Anyone can submit the generated calldata to the token before the deadline.
+
+Uses EIP-5267 domain discovery when available. Otherwise uses name(), version
+"1", the
+RPC chain ID, and the token address. --domain-name and --domain-version override
+the name
+and version. The resulting domain must match DOMAIN_SEPARATOR() before signing.
+DAI-style permits and Permit2 are not supported.
+
+Example:
+```text
+cast erc20 permit $TOKEN $SPENDER 1000000 --deadline $DEADLINE \
+    --account owner --rpc-url $RPC_URL --json
+cast erc20 permit $TOKEN $SPENDER 1000000 --deadline $DEADLINE \
+    --account owner --rpc-url $RPC_URL --broadcast --async
+```
+
+:::terminal
+
+```bash
+$ cast erc20-token permit --help
+```
+
+```txt
+Usage: cast erc20-token permit [OPTIONS] --deadline <DEADLINE> <TOKEN> <SPENDER> <AMOUNT>
+
+Arguments:
+  <TOKEN>
+          The ERC-2612 token contract address
+
+  <SPENDER>
+          The spender authorized by the permit
+
+  <AMOUNT>
+          The allowance to set, in raw token units
+
+Options:
+      --deadline <DEADLINE>
+          Absolute Unix timestamp in seconds after which the permit cannot be
+          submitted
+
+      --domain-name <DOMAIN_NAME>
+          Override the EIP-712 domain name
+
+      --domain-version <DOMAIN_VERSION>
+          Override the EIP-712 domain version (fallback: "1")
+
+      --broadcast
+          Submit the permit transaction using the signing wallet
+
+      --async
+          Only print the transaction hash and exit immediately
+          
+          [env: CAST_ASYNC=]
+
+      --sync
+          Wait for transaction receipt synchronously instead of polling. Note:
+          uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which
+          may not be supported by all clients
+
+      --confirmations <CONFIRMATIONS>
+          The number of confirmations until the receipt is fetched
+          
+          [default: 1]
+
+      --timeout <TIMEOUT>
+          Timeout for sending the transaction
+          
+          [env: ETH_TIMEOUT=]
+
+      --poll-interval <POLL_INTERVAL>
+          Polling interval for transaction receipts (in seconds)
+          
+          [env: ETH_POLL_INTERVAL=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -j, --threads <THREADS>
+          Number of threads to use. Specifying 0 defaults to the number of
+          logical cores
+          
+          [alias: --jobs]
+
+      --profile <PROFILE>
+          The configuration profile to use
+
+Rpc options:
+  -r, --rpc-url <URL>
+          The RPC endpoint
+          
+          [alias: --fork-url]
+
+  -k, --insecure
+          Allow insecure RPC connections (accept invalid HTTPS certificates).
+          
+          When the provider's inner runtime transport variant is HTTP, this
+          configures the reqwest client to accept invalid certificates.
+
+      --rpc-timeout <RPC_TIMEOUT>
+          Timeout for the RPC request in seconds.
+          
+          The specified timeout will be used to override the default timeout for
+          RPC requests.
+          
+          Default value: 45
+          
+          [env: ETH_RPC_TIMEOUT=]
+
+      --no-proxy
+          Disable automatic proxy detection.
+          
+          Use this in sandboxed environments (e.g., Cursor IDE sandbox, macOS
+          App Sandbox) where system proxy detection causes crashes. When
+          enabled, HTTP_PROXY/HTTPS_PROXY environment variables and system proxy
+          settings will be ignored.
+
+      --compute-units-per-second <CUPS>
+          Sets the number of assumed available compute units per second for this
+          provider.
+          
+          default value: 330
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+
+      --no-rpc-rate-limit
+          Disables rate limiting for this node's provider.
+          
+          See also
+          [https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second](https://docs.alchemy.com/reference/compute-units#what-are-cups-compute-units-per-second)
+          
+          [alias: --no-rate-limit]
+
+      --flashbots
+          Use the Flashbots RPC URL with fast mode
+          ([https://rpc.flashbots.net/fast](https://rpc.flashbots.net/fast)).
+          
+          This shares the transaction privately with all registered builders.
+          
+          See:
+          [https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions](https://docs.flashbots.net/flashbots-protect/quick-start#faster-transactions)
+
+      --jwt-secret <JWT_SECRET>
+          JWT Secret for the RPC endpoint.
+          
+          The JWT secret will be used to create a JWT for an RPC. For example,
+          the following can be used to simulate a CL `engine_forkchoiceUpdated`
+          call:
+          
+          cast rpc --jwt-secret <JWT_SECRET> engine_forkchoiceUpdatedV2
+          '["0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc",
+          "0x6bb38c26db65749ab6e472080a3d20a2f35776494e72016d1e339593f21c59bc"]'
+          
+          [env: ETH_RPC_JWT_SECRET=]
+
+      --rpc-headers <RPC_HEADERS>
+          Specify custom headers for RPC requests
+          
+          [env: ETH_RPC_HEADERS=]
+
+      --curl
+          Print the equivalent curl command instead of making the RPC request
+
+  -e, --etherscan-api-key <KEY>
+          The Etherscan (or equivalent) API key
+          
+          [env: ETHERSCAN_API_KEY=]
+
+  -c, --chain <CHAIN>
+          The chain name or EIP-155 chain ID
+          
+          [env: CHAIN=]
+
+Wallet options - raw:
+  -f, --from <ADDRESS>
+          The sender account
+          
+          [env: ETH_FROM=]
+
+  -i, --interactive
+          Open an interactive prompt to enter your private key
+
+      --private-key <RAW_PRIVATE_KEY>
+          Use the provided private key
+
+      --mnemonic <MNEMONIC>
+          Use the mnemonic phrase of mnemonic file at the specified path
+
+      --mnemonic-passphrase <PASSPHRASE>
+          Use a BIP39 passphrase for the mnemonic
+
+      --mnemonic-derivation-path <PATH>
+          The wallet derivation path.
+          
+          Works with both --mnemonic-path and hardware wallets.
+
+      --mnemonic-index <INDEX>
+          Use the private key from the given mnemonic index.
+          
+          Used with --mnemonic-path.
+          
+          [default: 0]
+
+Wallet options - keystore:
+      --keystore <PATH>
+          Use the keystore in the given folder or file
+          
+          [env: ETH_KEYSTORE=]
+
+      --account <ACCOUNT_NAME>
+          Use a keystore from the default keystores folder
+          (~/.foundry/keystores) by its filename
+          
+          [env: ETH_KEYSTORE_ACCOUNT=]
+
+      --password <PASSWORD>
+          The keystore password.
+          
+          Used with --keystore.
+
+      --password-file <PASSWORD_FILE>
+          The keystore password file path.
+          
+          Used with --keystore.
+          
+          [env: ETH_PASSWORD=]
+
+Wallet options - hardware wallet:
+  -l, --ledger
+          Use a Ledger hardware wallet
+
+  -t, --trezor
+          Use a Trezor hardware wallet
+
+Wallet options - Tempo:
+      --tempo.access-key <PRIVATE_KEY>
+          Tempo access key private key.
+          
+          When set, the transaction is signed with this access key on behalf of
+          `--tempo.root-account`.
+          
+          [env: TEMPO_ACCESS_KEY=]
+
+      --tempo.root-account <ADDRESS>
+          Tempo root account address (the `from` address for keychain
+          transactions).
+          
+          Required when `--tempo.access-key` is set.
+          
+          [env: TEMPO_ROOT_ACCOUNT=]
+
+Wallet options - browser wallet:
+      --browser
+          Use a browser wallet
+
+      --browser-port <PORT>
+          Port for the browser wallet server
+          
+          [default: 9545]
+
+      --browser-disable-open
+          Whether to open the browser for wallet connection
+
+Transaction options:
+      --gas-limit <GAS_LIMIT>
+          Gas limit for the transaction
+          
+          [env: ETH_GAS_LIMIT=]
+
+      --gas-price <GAS_PRICE>
+          Gas price for legacy transactions, or max fee per gas for EIP1559
+          transactions
+          
+          [env: ETH_GAS_PRICE=]
+
+      --priority-gas-price <PRIORITY_GAS_PRICE>
+          Max priority fee per gas for EIP1559 transactions
+          
+          [env: ETH_PRIORITY_GAS_PRICE=]
+
+      --nonce <NONCE>
+          Nonce for the transaction
+
+Tempo:
+      --tempo.session <SESSION_ID>
+          Use a live Tempo wallet session for signing.
+          
+          When set, Foundry resolves the authorization witness from
+          `$TEMPO_HOME/wallet/store.json` and signs with that Accounts access
+          key on behalf of its root account.
+
+      --tempo.fee-token <FEE_TOKEN>
+          Fee token address, numeric TIP-20 token id, or known symbol for Tempo
+          transactions.
+          
+          When set, builds a Tempo (type 0x76) transaction that pays gas fees in
+          the specified token. Known symbols are PathUSD, AlphaUSD, BetaUSD, and
+          ThetaUSD.
+          
+          If this is not set, the fee token is chosen according to network
+          rules. See the Tempo docs for more information.
+
+      --tempo.expires <SECONDS>
+          Opt into TIP-1009 expiring-nonce mode with a validity window.
+          
+          Convenience flag that combines `--tempo.expiring-nonce` with a
+          relative `--tempo.valid-before`. Sets nonce_key = U256::MAX, nonce =
+          0, and valid_before = now + seconds.
+          
+          Maximum value is 30 seconds. The transaction must be mined before the
+          deadline or it becomes permanently invalid, giving safe retry
+          semantics: retries produce a fresh tx hash and the old tx can never
+          land late.
+
+      --tempo.nonce-key <NONCE_KEY>
+          Nonce key for Tempo parallelizable nonces.
+          
+          When set, builds a Tempo (type 0x76) transaction with the specified
+          nonce key, allowing multiple transactions with the same nonce but
+          different keys to be executed in parallel. If not set, the protocol
+          nonce key (0) will be used.
+          
+          For more information see
+          [https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#parallelizable-nonces).
+
+      --tempo.lane <NAME>
+          Named nonce lane for Tempo parallelizable nonces.
+          
+          Resolves a friendly lane name (e.g. `deploy`, `payments`) to a
+          `nonce_key` via a shared lanes file (default: `tempo.lanes.toml` at
+          the project root). The lanes file is a TOML map of `name = <U256>`
+          entries, e.g.:
+          
+          ```toml deploy   = 1 ops      = 2 payments = 3 ```
+          
+          Mutually exclusive with `--tempo.nonce-key`.
+
+      --tempo.lanes-file <PATH>
+          Path to the Tempo lanes file used by `--tempo.lane`.
+          
+          Defaults to `tempo.lanes.toml` at the project root.
+
+      --tempo.sponsor <ADDRESS>
+          Sponsor (fee payer) address for Tempo sponsored transactions
+
+      --tempo.sponsor-signer <SIGNER>
+          Sign Tempo sponsor digests in-band with the given signer URI.
+          
+          Supported forms include `env://VAR`, `keystore://PATH`,
+          `account://NAME`, `ledger://`, `trezor://`, `aws://`, `gcp://`,
+          `turnkey://`, and `private-key://KEY`.
+
+      --tempo.sponsor-sig <SPONSOR_SIG>
+          Sponsor (fee payer) signature for Tempo sponsored transactions.
+          
+          The sponsor signs the `fee_payer_signature_hash` to commit to paying
+          gas fees on behalf of the sender. Provide as a hex-encoded signature.
+
+      --sponsor-url <URL>
+          Remote sponsor (fee payer) service URL for Cast transaction commands.
+          
+          When set, the user-signed transaction is forwarded to this URL via
+          `eth_signRawTransaction`. The service adds its fee payer signature and
+          returns the fully-sponsored transaction, which is then submitted via
+          the regular RPC. No local sponsor key is required.
+          
+          This option is supported by `cast send` and `cast erc20`. Forge
+          commands currently support local sponsorship through `--tempo.sponsor`
+          and `--tempo.sponsor-signer` instead.
+          
+          Example: `cast send 0x... --sponsor-url
+          https://sponsor.moderato.tempo.xyz`
+          
+          [env: TEMPO_SPONSOR_URL=]
+
+      --tempo.print-sponsor-hash
+          Print the sponsor signature hash and exit.
+          
+          Computes the `fee_payer_signature_hash` for the transaction so that a
+          sponsor knows what hash to sign. The transaction is not sent.
+
+      --tempo.key-id <KEY_ID>
+          Access key ID for Tempo Keychain signature transactions.
+          
+          Used during gas estimation to override the key_id that would normally
+          be recovered from the signature.
+
+      --tempo.expiring-nonce
+          Enable expiring nonce mode for Tempo transactions.
+          
+          Sets nonce to 0 and nonce_key to U256::MAX, enabling time-bounded
+          transaction validity via `--tempo.valid-before` and
+          `--tempo.valid-after`.
+
+      --tempo.valid-before <VALID_BEFORE>
+          Upper bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid before this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+      --tempo.valid-after <VALID_AFTER>
+          Lower bound timestamp for Tempo expiring nonce transactions.
+          
+          The transaction is only valid after this unix timestamp. Requires
+          `--tempo.expiring-nonce`.
+
+Display options:
+      --color <COLOR>
+          The color of the log messages
+
+          Possible values:
+          - auto:   Intelligently guess whether to use color output (default)
+          - always: Force color output
+          - never:  Force disable color output
+
+      --json
+          Format log messages as JSON
+
+      --md
+          Format log messages as Markdown
+
+  -q, --quiet
+          Do not print log messages
+
+  -v, --verbosity...
+          Verbosity level of the log messages.
+          
+          Pass multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+          
+          Depending on the context the verbosity levels have different meanings.
+          
+          For example, the verbosity levels of the EVM are:
+          - 2 (-vv): Print logs for all tests.
+          - 3 (-vvv): Print execution traces for failing tests.
+          - 4 (-vvvv): Print execution traces for all tests, and setup traces
+          for failing tests.
+          - 5 (-vvvvv): Print execution and setup traces for all tests,
+          including storage changes and
+            backtraces with line numbers.
+```
+
+:::


### PR DESCRIPTION
Document `cast erc20 permit` from https://github.com/foundry-rs/foundry/pull/16672 with a token-approval guide covering sign-only output, relayer calldata, owner broadcasting, domain discovery and overrides, nonce consumption, and deadline semantics. Link the guide from the Cast navigation and vault deposit workflow to explain the difference between underlying-asset and vault-share permits.

Include the permit CLI reference generated from the feature binary and the corresponding command navigation entry. Merge after the Foundry implementation is available.

AI assistance: Codex helped write the documentation and PR description and generate the CLI reference.
