### PR TITLE
docs(config): document symbolic defaults

### DIFF
--- a/sidebar/sidebar.ts
+++ b/sidebar/sidebar.ts
@@ -125,6 +125,10 @@ export const sidebar: Sidebar = {
         { text: "Testing", link: "/config/reference/testing" },
         { text: "Tracing", link: "/config/reference/tracing" },
         { text: "Advanced Testing", link: "/config/reference/advanced-testing" },
+        {
+          text: "Symbolic Testing",
+          link: "/config/reference/advanced-testing#symbolic-testing",
+        },
         { text: "Build, Runtime, and RPC", link: "/config/reference/build-and-runtime" },
         { text: "Tool-specific Configuration", link: "/config/reference/tooling" },
         { text: "In-line Test Config", link: "/config/reference/inline-test-config" },

--- a/src/pages/config/reference/README.mdx
+++ b/src/pages/config/reference/README.mdx
@@ -6,6 +6,7 @@
 - [Testing](/config/reference/testing.mdx)
 - [Tracing](/config/reference/tracing.mdx)
 - [Advanced Testing](/config/reference/advanced-testing.mdx)
+- [Symbolic Testing](/config/reference/advanced-testing.mdx#symbolic-testing)
 - [Build, Runtime, and RPC](/config/reference/build-and-runtime.mdx)
 - [Tool-specific Configuration](/config/reference/tooling.mdx)
 - [In-line test configuration](/config/reference/inline-test-config.mdx)

--- a/src/pages/config/reference/advanced-testing.mdx
+++ b/src/pages/config/reference/advanced-testing.mdx
@@ -42,6 +42,7 @@ Define symbolic settings under `[profile.<name>.symbolic]`.
 | `use_fuzz_corpus` | `false` | Imports fuzz corpus seeds for symbolic exploration. |
 | `corpus_seed_limit` | `32` | Limits imported corpus seeds. |
 | `use_fuzz_frontiers` | `false` | Uses fuzz branch frontiers for targeted exploration. |
+| `check_invariant_frontiers` | `false` | Checks imported invariant frontiers for property failures before branch-target seeding. |
 | `frontier_limit` | `256` | Limits imported branch frontiers. |
 | `frontier_ids` | `[]` | Filters imported frontier artifact IDs. |
 | `frontier_pcs` | `[]` | Filters frontier program counters. |
@@ -68,6 +69,23 @@ Define symbolic settings under `[profile.<name>.symbolic]`.
 | `symbolic_call_targets` | `false` | Expands symbolic targets over known deployed contracts. |
 | `dump_smt` | `false` | Writes SMT-LIB queries before solving. |
 | `storage_layout` | `solidity` | Selects `solidity`, `generic`, or `zero_init` storage modelling. |
+
+#### Invariant frontier property checks
+
+`check_invariant_frontiers` is a boolean that defaults to `false`. It is also
+available as `FOUNDRY_SYMBOLIC_CHECK_INVARIANT_FRONTIERS` and applies when
+`use_fuzz_frontiers` imports an invariant frontier artifact. For each selected
+frontier, Forge replays the concrete sequence prefix, symbolically executes the
+target call, and checks the configured invariant functions from the resulting
+state before separately attempting to flip the retained branch. Only candidates
+that reproduce the failure during concrete replay are persisted. An incomplete
+symbolic search is not a proof that the invariant holds.
+
+```toml
+[profile.default.symbolic]
+use_fuzz_frontiers = true
+check_invariant_frontiers = true
+```
 
 ### Coverage
 

--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -771,10 +771,136 @@ show_edge_coverage = false
 # =============================================================================
 
 [symbolic]
+# Whether symbolic tests are enabled
+# Default: false
+enabled = false
+
+# Whether fuzz tests should be symbolically concretized into fuzz corpus seeds
+# Default: false
+seed_corpus = false
+
+# Whether fuzz corpus seeds should guide symbolic fuzz-test exploration
+# Default: false
+use_fuzz_corpus = false
+
+# Maximum number of fuzz corpus seeds to import for one symbolic run
+# Default: 32
+corpus_seed_limit = 32
+
+# Whether fuzz branch frontiers should guide targeted symbolic fuzz-test seeding
+# Default: false
+use_fuzz_frontiers = false
+
 # Whether imported invariant frontiers are checked for property failures before
 # branch-target seeding
 # Default: false
 check_invariant_frontiers = false
+
+# Maximum number of fuzz branch frontiers to try for one symbolic run
+# Default: 256
+frontier_limit = 256
+
+# Fuzz branch frontier artifact IDs to import
+# Default: []
+frontier_ids = []
+
+# Fuzz branch frontier comparison program counters to import
+# Default: []
+frontier_pcs = []
+
+# Fuzz branch frontier calldata selectors to import
+# Default: []
+frontier_selectors = []
+
+# Solver executable to invoke
+# Default: "z3"
+solver = "z3"
+
+# Exact solver command to invoke, overriding solver
+# Default: None
+# solver_command = "z3 -in -smt2"
+
+# Solver names or commands to race in parallel
+# Default: []
+solver_portfolio = []
+
+# SMT solver timeout in seconds
+# Default: 30
+timeout = 30
+
+# Halmos-compatible loop bound
+# Default: None
+# loop = 2
+
+# Halmos-compatible execution depth alias, overriding max_depth
+# Default: None
+# depth = 10000
+
+# Halmos-compatible path width alias, overriding max_paths
+# Default: None
+# width = 1024
+
+# Maximum number of opcodes to execute along a path
+# Default: 10000
+max_depth = 10000
+
+# Maximum number of symbolic paths to explore
+# Default: 1024
+max_paths = 1024
+
+# Maximum number of calls in a bounded symbolic invariant sequence
+# Default: 10
+invariant_depth = 10
+
+# Pending symbolic path exploration order
+# Options: "bfs", "dfs"
+# Default: "bfs"
+exploration_order = "bfs"
+
+# Maximum number of solver queries
+# Default: 10000
+max_solver_queries = 10000
+
+# Default bounded length for dynamic ABI inputs
+# Default: 2
+default_dynamic_length = 2
+
+# Maximum permitted bounded length for a dynamic ABI input
+# Default: 256
+max_dynamic_length = 256
+
+# Per-dynamic-leaf bounded lengths, applied in ABI traversal order
+# Default: []
+array_lengths = []
+
+# Per-symbolic-input bounded lengths keyed by ABI argument name
+# Default: {}
+dynamic_lengths = {}
+
+# Default bounded lengths for dynamic ABI arrays
+# Default: []
+default_array_lengths = []
+
+# Default bounded lengths for ABI bytes and string values
+# Default: []
+default_bytes_lengths = []
+
+# Maximum symbolic calldata size in bytes
+# Default: 4096
+max_calldata_bytes = 4096
+
+# Whether symbolic call targets may include known deployed contracts
+# Default: false
+symbolic_call_targets = false
+
+# Whether to dump SMT-LIB queries before invoking the solver
+# Default: false
+dump_smt = false
+
+# Storage modelling mode for symbolic reads
+# Options: "solidity", "generic", "zero_init"
+# Default: "solidity"
+storage_layout = "solidity"
 
 # =============================================================================
 # FORMATTER CONFIGURATION

--- a/src/pages/config/reference/default-config.mdx
+++ b/src/pages/config/reference/default-config.mdx
@@ -767,6 +767,16 @@ corpus_min_size = 0
 show_edge_coverage = false
 
 # =============================================================================
+# SYMBOLIC TESTING CONFIGURATION
+# =============================================================================
+
+[symbolic]
+# Whether imported invariant frontiers are checked for property failures before
+# branch-target seeding
+# Default: false
+check_invariant_frontiers = false
+
+# =============================================================================
 # FORMATTER CONFIGURATION
 # =============================================================================
 


### PR DESCRIPTION
Documents `symbolic.check_invariant_frontiers`, introduced by foundry-rs/foundry#16643, including its default, environment variable, dependency on imported invariant frontiers, concrete replay behavior, and an example configuration. It also populates the default configuration's `[symbolic]` block from Foundry's complete `SymbolicConfig` defaults instead of displaying only the new key.

AI assistance: Codex assisted with this documentation under Gustavo Figueiredo's direction.
