### PR TITLE
test: add production browser smoke tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,43 +70,6 @@ jobs:
       - name: Build Vocs
         run: vp exec vocs build
 
-      - name: Upload Vocs build
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: vocs-build
-          path: dist/
-          if-no-files-found: error
-          retention-days: 1
-
-  e2e:
-    name: browser smoke tests
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
-        with:
-          cache: true
-          node-version: "24"
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
-
-      - name: Download Vocs build
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: vocs-build
-          path: dist/
-
       - name: Install Chromium
         run: vp exec playwright install --with-deps chromium
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
   build:
     name: vocs build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -68,3 +69,19 @@ jobs:
 
       - name: Build Vocs
         run: vp exec vocs build
+
+      - name: Install Chromium
+        run: vp exec playwright install --with-deps chromium
+
+      - name: Browser smoke tests
+        run: vp run test:e2e
+
+      - name: Upload browser test results
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: browser-test-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,43 @@ jobs:
       - name: Build Vocs
         run: vp exec vocs build
 
+      - name: Upload Vocs build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: vocs-build
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e:
+    name: browser smoke tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@1b32467adbe183473499fd9d5d372c3ed9641754 # v1.18.0
+        with:
+          cache: true
+          node-version: "24"
+          run-install: false
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Download Vocs build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: vocs-build
+          path: dist/
+
       - name: Install Chromium
         run: vp exec playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /docs/snippets/projects/**/out/
 
 /node_modules
+/playwright-report/
+/test-results/
 /dist
 /docs/dist
 /.vocs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ The book follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/c
 ### Browser smoke tests
 
 CI runs Chromium against the production Vocs build on pull requests and pushes
-to `master`. The smoke tests check rendered content, search hydration, navigation,
+to `master`. The separate `browser smoke tests` job downloads the build job's
+`vocs-build` artifact. The smoke tests check rendered content, search hydration, navigation,
 direct page loads, and reloads, and fail on console errors or uncaught exceptions.
 Only externally hosted sponsor SVGs are stubbed; application code and local assets
 are served from the real build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ The book follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/c
 ### Browser smoke tests
 
 CI runs Chromium against the production Vocs build on pull requests and pushes
-to `master`. The separate `browser smoke tests` job downloads the build job's
-`vocs-build` artifact. The smoke tests check rendered content, search hydration, navigation,
+to `master`. The smoke tests check rendered content, search hydration, navigation,
 direct page loads, and reloads, and fail on console errors or uncaught exceptions.
 Only externally hosted sponsor SVGs are stubbed; application code and local assets
 are served from the real build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,26 @@ For this particular book, it is OK to assume some familiarity with Solidity and 
 
 The book follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
 
+### Browser smoke tests
+
+CI runs Chromium against the production Vocs build on pull requests and pushes
+to `master`. The smoke tests check rendered content, search hydration, navigation,
+direct page loads, and reloads, and fail on console errors or uncaught exceptions.
+Only externally hosted sponsor SVGs are stubbed; application code and local assets
+are served from the real build.
+
+To run them locally after installing dependencies:
+
+```bash
+vp exec playwright install chromium
+vp exec vocs build
+vp run test:e2e
+```
+
+Failed runs retain screenshots, traces, and an HTML report in `test-results/` and
+`playwright-report/`; CI uploads these as the `browser-test-results` artifact.
+Open the report with `vp exec playwright show-report`.
+
 ### Ways to contribute
 
 #### Issues

--- a/e2e/navigation.e2e.ts
+++ b/e2e/navigation.e2e.ts
@@ -1,0 +1,80 @@
+import { expect, test as base, type Page } from "@playwright/test";
+
+const test = base.extend<{ browserErrors: void }>({
+  browserErrors: [
+    async ({ page }, use, testInfo) => {
+      const errors: string[] = [];
+      // Decorative sponsor logos are external; avoid depending on their host.
+      await page.route(
+        "https://raw.githubusercontent.com/wevm/.github/main/content/sponsors/*.svg",
+        (route) =>
+          route.fulfill({
+            contentType: "image/svg+xml",
+            body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
+          }),
+      );
+      // Register before the first navigation to catch hydration failures too.
+      page.on("pageerror", (error) => errors.push(error.stack ?? error.message));
+      page.on("console", (message) => {
+        if (message.type() === "error") errors.push(message.text());
+      });
+      await use();
+      if (errors.length) {
+        await testInfo.attach("browser-errors", {
+          body: errors.join("\n\n"),
+          contentType: "text/plain",
+        });
+      }
+      expect(errors, "No uncaught exceptions or console errors").toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+async function expectHydrated(page: Page) {
+  // A working interactive control proves hydration completed before clicking links.
+  await page.getByRole("button", { name: /Search/ }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).toBeHidden();
+}
+
+test("homepage hydrates and navigates to documentation", async ({ page }) => {
+  const response = await page.goto("/");
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole("img", { name: "Foundry", exact: true })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Get Started", exact: true })).toBeVisible();
+
+  await expectHydrated(page);
+
+  // A full document reload must not masquerade as working client-side routing.
+  const document = await page.locator("html").elementHandle();
+  await page.getByRole("link", { name: "Get Started", exact: true }).click();
+  await expect(page).toHaveURL(/\/introduction\/getting-started$/);
+  await expect(page.getByRole("heading", { name: /^Getting Started\b/, level: 2 })).toBeVisible();
+  await expect(page.getByRole("table").first()).toContainText("forge");
+  expect(await document!.evaluate((element) => element.isConnected)).toBe(true);
+
+  await page.getByRole("link", { name: "installing Foundry", exact: true }).click();
+  await expect(page).toHaveURL(/\/introduction\/installation$/);
+  await expect(page.getByRole("heading", { name: /^Installation\b/, level: 2 })).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/introduction\/getting-started$/);
+  await expect(page.getByRole("heading", { name: /^Getting Started\b/, level: 2 })).toBeVisible();
+});
+
+test("documentation renders on direct entry and reload", async ({ page }) => {
+  const response = await page.goto("/forge");
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole("heading", { name: /^Forge\b/, level: 2 })).toBeVisible();
+  await expectHydrated(page);
+  await page.getByRole("link", { name: /Build and test Compile contracts/ }).click();
+  await expect(page).toHaveURL(/\/forge\/testing$/);
+  await expect(page.getByRole("heading", { name: /^Testing\b/, level: 2 })).toBeVisible();
+  const reload = await page.reload();
+  expect(reload?.ok()).toBe(true);
+  await expect(page.getByRole("heading", { name: /^Testing\b/, level: 2 })).toBeVisible();
+  await expect(page.locator("pre").first()).toBeVisible();
+  await expectHydrated(page);
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vp run fetch-benchmarks && vp run fetch-changelog && vp exec vocs build",
-    "check": "vp check .github package.json pnpm-workspace.yaml scripts sidebar src/components tsconfig.json vite.config.ts vocs.config.ts",
+    "check": "vp check .github e2e package.json playwright.config.ts pnpm-workspace.yaml scripts sidebar src/components tsconfig.json vite.config.ts vocs.config.ts",
     "check:anvil-rpc": "vp exec tsx scripts/check-anvil-rpc-coverage.ts",
     "check:cheatcodes": "vp exec tsx scripts/check-cheatcode-coverage.ts",
     "check:commands": "vp exec tsx scripts/check-narrative-commands.ts",
@@ -13,7 +13,8 @@
     "fetch-benchmarks": "vp exec tsx scripts/fetch-benchmarks.ts",
     "fetch-changelog": "vp exec tsx scripts/fetch-changelog.ts",
     "preview": "vp exec vocs preview",
-    "test": "vp test --run"
+    "test": "vp test --run",
+    "test:e2e": "vp exec playwright test"
   },
   "dependencies": {
     "react": "^19.2.5",
@@ -23,6 +24,7 @@
     "waku": "1.0.0-beta.6"
   },
   "devDependencies": {
+    "@playwright/test": "1.63.0",
     "@types/node": "^26.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Keep browser tests out of the unit runner's *.test / *.spec discovery.
+  testMatch: "**/*.e2e.ts",
+  forbidOnly: !!process.env.CI,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // Exercise the production bundle built by CI, including client hydration.
+    command: "vp exec vocs preview --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: false,
+    timeout: 60_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@26.4.1)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.110.3(esbuild@0.27.7)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(terser@5.51.2)(tsx@4.21.0)(typescript@7.0.2)(yaml@2.9.0)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.63.0
+        version: 1.63.0
       '@types/node':
         specifier: ^26.0.0
         version: 26.4.1
@@ -813,6 +816,11 @@ packages:
 
   '@phosphor-icons/core@2.1.1':
     resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
+
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3638,6 +3646,16 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -5130,6 +5148,10 @@ snapshots:
   '@oxlint/plugins@1.79.0': {}
 
   '@phosphor-icons/core@2.1.1': {}
+
+  '@playwright/test@1.63.0':
+    dependencies:
+      playwright: 1.63.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8036,6 +8058,12 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.1
       pathe: 2.0.3
+
+  playwright-core@1.63.0: {}
+
+  playwright@1.63.0:
+    dependencies:
+      playwright-core: 1.63.0
 
   pngjs@7.0.0: {}
 


### PR DESCRIPTION
Build-only CI passed the Waku upgrade in [#2067](https://github.com/foundry-rs/book/pull/2067) even though Vocs crashed during browser hydration. Add two Chromium smoke tests against the production Vocs preview to catch this before merging.

The existing build job installs Chromium and runs the tests after building. Coverage includes the homepage banner and CTA, opening search, client-side navigation to Getting Started and Installation, back navigation, and direct entry/reload of Forge documentation. Every test fails on uncaught exceptions or console errors; only external sponsor SVGs are stubbed. Failure screenshots, traces, browser errors, and the HTML report are uploaded for debugging.

Validation: production Vocs build passed; both browser tests passed; formatting/lint, targeted TypeScript checks, and all 3 unit tests passed; `git diff --check` passed. The current tree is identical to the version that passed [GitHub CI](https://github.com/foundry-rs/book/actions/runs/34154501408), including the browser smoke test step.

Regression proof: in a separate worktree, changing only Waku to `1.0.0-rc.0` still built successfully, but both new browser tests failed and captured `TypeError: Cannot read properties of undefined (reading 'on')`. The committed dependency remains `1.0.0-beta.6`.

AI disclosure: Centaur authored the tests, CI configuration, documentation, and this PR description, and ran validation.

Prompted by: @DaniPopes
