### PR TITLE
docs(forge): explain block environment captures

### DIFF
--- a/sidebar/forge.ts
+++ b/sidebar/forge.ts
@@ -45,6 +45,8 @@ export const lintingSidebar: SidebarItem[] = [
   ]),
   ruleGroup("Medium severity", [
     "assert-state-change",
+    "block-number-across-roll",
+    "block-timestamp-across-warp",
     "boolean-cst",
     "dangerous-unary-operator",
     "divide-before-multiply",

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -175,6 +175,8 @@ navigation on the right to browse by severity.
 #### Medium severity
 
 - [`assert-state-change`](/forge/linting/assert-state-change) — Flags expressions inside `assert()` that modify contract state.
+- [`block-number-across-roll`](/forge/linting/block-number-across-roll) — Flags raw block-number values used across `vm.roll` or raw reads on both sides of a roll; use `vm.getBlockNumber()` for reliable captures.
+- [`block-timestamp-across-warp`](/forge/linting/block-timestamp-across-warp) — Flags raw timestamp values used across `vm.warp` or raw reads on both sides of a warp; use `vm.getBlockTimestamp()` for reliable captures.
 - [`boolean-cst`](/forge/linting/boolean-cst) — Flags expressions where a boolean constant (`true`/`false`) is used as a control-flow condition or operand of a boolean operator, which usually indicates dead code or a leftover debug toggle.
 - [`dangerous-unary-operator`](/forge/linting/dangerous-unary-operator) — Flags assignments whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment rather than the compound assignment it resembles.
 - [`divide-before-multiply`](/forge/linting/divide-before-multiply) — Flags arithmetic expressions where division is performed before multiplication, which can cause unintended precision loss in integer arithmetic.

--- a/src/pages/forge/linting/block-number-across-roll.mdx
+++ b/src/pages/forge/linting/block-number-across-roll.mdx
@@ -1,0 +1,69 @@
+---
+description: Detect block.number captures that can cross vm.roll and use getBlockNumber for reliable test values
+---
+
+## Block number captures across roll
+
+**Severity**: `Med`
+**ID**: `block-number-across-roll`
+
+### What it does
+
+Warns when a value derived from `block.number` can be used after `vm.roll`, or when raw
+block-number reads occur on both sides of a roll in the same call frame. The diagnostic points
+to the original raw read.
+
+### Why is this bad?
+
+The EVM block number is constant during a normal transaction. Compilers can therefore reuse,
+move, or defer `block.number` reads across calls. Foundry's `vm.roll` changes that environment
+inside a test, so a Solidity local is not a guarantee that the earlier number was captured.
+This can happen with optimized solc via IR as well as other compiler optimizations.
+
+Use [`vm.getBlockNumber()`](/reference/cheatcodes/get-block-number) for test values that need to observe a particular point in time.
+Its call result is materialized. Keep normal compiler optimizations enabled.
+
+### Example
+
+#### Bad
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:number-bad]
+```
+
+#### Good
+
+Capture through the getter instead:
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:number-good]
+```
+
+For before/after comparisons, use the getter on both sides of the mutation.
+
+### Scope and controls
+
+The rule runs in `forge lint` and the normal build lint stage, including configured test and
+script directories. It uses source analysis and does not depend on the selected optimizer
+settings. It does not modify compiler output or automatically insert cheatcodes into source.
+Production reads without a recognized roll stay quiet.
+
+The analysis follows scalar local aliases, arithmetic, tuples, internal helper arguments and
+returns, inherited helpers, and modifier bodies. It recognizes the constant cheatcode address
+and the resolved `roll(uint256)` signature, even when the receiver is not named `vm`.
+Unrelated methods named `roll` and changes to the timestamp do not trigger this rule.
+External call results are treated as materialized values from a separate call frame.
+
+This is a bounded warning, not a complete execution analysis: it visits up to 16,384 nodes,
+retains at most 32 paths at statement boundaries, follows at most eight function frames, and
+visits at most two loop iterations. It does not prove relationships between runtime conditions
+or analyze recursive/indirect calls, low-level cheatcode calls, assembly, or heap/storage aliases.
+Internal call outcomes and conditional expressions can be joined conservatively. Absence of a
+warning does not establish that every test capture is safe.
+
+Existing severity filters, `exclude_lints`, and inline suppressions apply. Suppress at the raw
+capture when its behavior is intentional:
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:number-suppression]
+```

--- a/src/pages/forge/linting/block-number-across-roll.mdx
+++ b/src/pages/forge/linting/block-number-across-roll.mdx
@@ -58,8 +58,11 @@ This is a bounded warning, not a complete execution analysis: it visits up to 16
 retains at most 32 paths at statement boundaries, follows at most eight function frames, and
 visits at most two loop iterations. It does not prove relationships between runtime conditions
 or analyze recursive/indirect calls, low-level cheatcode calls, assembly, or heap/storage aliases.
-Internal call outcomes and conditional expressions can be joined conservatively. Absence of a
-warning does not establish that every test capture is safe.
+Known unsigned and boolean locals prune exhausted loops and constant branches. Internal-call
+state effects can be joined conservatively, but differing return values and conditional-expression
+values are discarded to avoid combining mutually exclusive outcomes. This can miss captures
+returned by branching helpers. Absence of a warning does not establish that every test capture
+is safe.
 
 Existing severity filters, `exclude_lints`, and inline suppressions apply. Suppress at the raw
 capture when its behavior is intentional:

--- a/src/pages/forge/linting/block-timestamp-across-warp.mdx
+++ b/src/pages/forge/linting/block-timestamp-across-warp.mdx
@@ -1,0 +1,72 @@
+---
+description: Detect block.timestamp captures that can cross vm.warp and use getBlockTimestamp for reliable test values
+---
+
+## Timestamp captures across warp
+
+**Severity**: `Med`
+**ID**: `block-timestamp-across-warp`
+
+### What it does
+
+Warns when a value derived from `block.timestamp` can be used after `vm.warp`, or when raw
+timestamp reads occur on both sides of a warp in the same call frame. The diagnostic points
+to the original raw read.
+
+### Why is this bad?
+
+The EVM timestamp is constant during a normal transaction. Compilers can therefore reuse,
+move, or defer `block.timestamp` reads across calls. Foundry's `vm.warp` changes that environment
+inside a test, so a Solidity local is not a guarantee that the earlier timestamp was captured.
+This can happen with optimized solc via IR as well as other compiler optimizations.
+
+Use [`vm.getBlockTimestamp()`](/reference/cheatcodes/get-block-timestamp) for test values that need to observe a particular point in time.
+Its call result is materialized. Keep normal compiler optimizations enabled.
+
+### Example
+
+#### Bad
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:timestamp-bad]
+```
+
+#### Good
+
+Capture through the getter instead:
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:timestamp-good]
+```
+
+For before/after comparisons, use the getter on both sides of the mutation.
+
+### Scope and controls
+
+The rule runs in `forge lint` and the normal build lint stage, including configured test and
+script directories. It uses source analysis and does not depend on the selected optimizer
+settings. It does not modify compiler output or automatically insert cheatcodes into source.
+Production reads without a recognized warp stay quiet.
+
+The analysis follows scalar local aliases, arithmetic, tuples, internal helper arguments and
+returns, inherited helpers, and modifier bodies. It recognizes the constant cheatcode address
+and the resolved `warp(uint256)` signature, even when the receiver is not named `vm`.
+Unrelated methods named `warp` and changes to the block number do not trigger this rule.
+External call results are treated as materialized values from a separate call frame.
+
+This is a bounded warning, not a complete execution analysis: it visits up to 16,384 nodes,
+retains at most 32 paths at statement boundaries, follows at most eight function frames, and
+visits at most two loop iterations. It does not prove relationships between runtime conditions
+or analyze recursive/indirect calls, low-level cheatcode calls, assembly, or heap/storage aliases.
+Internal call outcomes and conditional expressions can be joined conservatively. Absence of a
+warning does not establish that every test capture is safe.
+
+Existing severity filters, `exclude_lints`, and inline suppressions apply. Suppress at the raw
+capture when its behavior is intentional:
+
+```solidity
+// [!include ~/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol:timestamp-suppression]
+```
+
+This is separate from [`block-timestamp`](/forge/linting/block-timestamp), which warns about validator-influenced comparisons in
+production code. This rule addresses compiler materialization in Foundry tests and scripts.

--- a/src/pages/forge/linting/block-timestamp-across-warp.mdx
+++ b/src/pages/forge/linting/block-timestamp-across-warp.mdx
@@ -58,8 +58,11 @@ This is a bounded warning, not a complete execution analysis: it visits up to 16
 retains at most 32 paths at statement boundaries, follows at most eight function frames, and
 visits at most two loop iterations. It does not prove relationships between runtime conditions
 or analyze recursive/indirect calls, low-level cheatcode calls, assembly, or heap/storage aliases.
-Internal call outcomes and conditional expressions can be joined conservatively. Absence of a
-warning does not establish that every test capture is safe.
+Known unsigned and boolean locals prune exhausted loops and constant branches. Internal-call
+state effects can be joined conservatively, but differing return values and conditional-expression
+values are discarded to avoid combining mutually exclusive outcomes. This can miss captures
+returned by branching helpers. Absence of a warning does not establish that every test capture
+is safe.
 
 Existing severity filters, `exclude_lints`, and inline suppressions apply. Suppress at the raw
 capture when its behavior is intentional:

--- a/src/snippets/projects/lint-block-environment/foundry.toml
+++ b/src/snippets/projects/lint-block-environment/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+solc = "0.8.30"
+optimizer = true
+optimizer_runs = 200
+via_ir = true

--- a/src/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol
+++ b/src/snippets/projects/lint-block-environment/test/BlockEnvironment.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+interface VmBlockEnvironment {
+    function roll(uint256 blockNumber) external;
+    function warp(uint256 timestamp) external;
+    function getBlockNumber() external view returns (uint256);
+    function getBlockTimestamp() external view returns (uint256);
+}
+
+contract BlockEnvironmentTest {
+    VmBlockEnvironment private constant vm =
+        VmBlockEnvironment(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function exampleRawNumber() public {
+        // [!region number-bad]
+        vm.roll(100);
+        uint256 saved = block.number; // Warning: this capture can cross the next roll.
+        vm.roll(200);
+        vm.roll(saved);
+        // [!endregion number-bad]
+    }
+
+    function testNumberGetterCapture() public {
+        // [!region number-good]
+        vm.roll(100);
+        uint256 saved = vm.getBlockNumber();
+        vm.roll(200);
+        vm.roll(saved); // Restores 100.
+        // [!endregion number-good]
+        require(vm.getBlockNumber() == 100, "original block number was not restored");
+    }
+
+    function exampleSuppressedNumber() public {
+        vm.roll(100);
+        // [!region number-suppression]
+        // forge-lint: disable-next-line(block-number-across-roll)
+        uint256 saved = block.number;
+        // [!endregion number-suppression]
+        vm.roll(200);
+        vm.roll(saved);
+    }
+
+    function exampleRawTimestamp() public {
+        // [!region timestamp-bad]
+        vm.warp(100);
+        uint256 saved = block.timestamp; // Warning: this capture can cross the next warp.
+        vm.warp(200);
+        vm.warp(saved);
+        // [!endregion timestamp-bad]
+    }
+
+    function testTimestampGetterCapture() public {
+        // [!region timestamp-good]
+        vm.warp(100);
+        uint256 saved = vm.getBlockTimestamp();
+        vm.warp(200);
+        vm.warp(saved); // Restores 100.
+        // [!endregion timestamp-good]
+        require(vm.getBlockTimestamp() == 100, "original timestamp was not restored");
+    }
+
+    function exampleSuppressedTimestamp() public {
+        vm.warp(100);
+        // [!region timestamp-suppression]
+        // forge-lint: disable-next-line(block-timestamp-across-warp)
+        uint256 saved = block.timestamp;
+        // [!endregion timestamp-suppression]
+        vm.warp(200);
+        vm.warp(saved);
+    }
+}


### PR DESCRIPTION
Document `block-number-across-roll` and `block-timestamp-across-warp`, the medium-severity lints added by foundry-rs/foundry#16727. Explain when raw block reads can cross `vm.roll` or `vm.warp`, recommend the corresponding getters, and cover the analysis limits and suppression controls. Add both rules to the lint navigation and include runnable examples with optimizer and via-IR settings enabled.

These pages must be merged and deployed before the Foundry PR can pass its mandatory public-documentation check. The new lint rules are introduced by that companion PR; the getters already exist.
