### PR TITLE
feat(lint): render example diagnostics during import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,9 +178,17 @@ sidebar. Commit the generated output and `scripts/lint-docs-manifest.json` toget
 hand-edit them. The manifest pins the Foundry revision so the Book builds without fetching
 Foundry. The weekly update imports the revision matching its installed Forge binary.
 
+The importer replaces standalone `{{produces}}` markers after Solidity code blocks with
+diagnostics from `forge lint --json --only-lint <id>`. Marked blocks must be complete source
+files: they are linted as `src/Example.sol` in isolated temporary projects, never executed.
+The import fails if the example is invalid or does not emit the documented lint. Unmarked
+fragments are copied without running Forge. Install the matching Forge binary or pass
+`--forge /path/to/forge`; no Forge installation is needed for offline checks or Book builds.
+
 `--check` validates the committed output offline. Add `--foundry /path/to/foundry` to check
 against that source checkout. Run `vp exec vocs build` and inspect the rendered Markdown
-under `dist/public/assets/md/forge/linting/`. Verify changed Solidity examples in Foundry.
+under `dist/public/assets/md/forge/linting/`. Foundry's existing lint tests cover lint behavior;
+the Book owns documentation validation and diagnostic generation at sync time.
 
 #### Auto-Generated CLI Output
 

--- a/scripts/import-lint-docs.test.ts
+++ b/scripts/import-lint-docs.test.ts
@@ -13,6 +13,7 @@ import {
   renderPage,
   shiftHeadings,
 } from "./import-lint-docs.ts";
+import { diagnosticOutput, renderExamples } from "./lint-examples.ts";
 
 let temporary: string;
 let root: string;
@@ -104,6 +105,107 @@ beforeEach(() => {
 afterEach(() => rmSync(temporary, { recursive: true, force: true }));
 
 describe("lint import", () => {
+  const diagnostic = (
+    id = "example",
+    rendered = "warning[example]: explanation\n  --> src/Example.sol:1:1\n",
+  ) => JSON.stringify({ level: "warning", code: { code: id }, rendered });
+
+  test("replaces produces with the expected lint's actual rendered output", () => {
+    const source = canonical().replace("\nUse instead:", "\n{{produces}}\n\nUse instead:");
+    const seen: string[] = [];
+    const page = renderExamples(source, "example", (code, id) => {
+      seen.push(code, id);
+      return [diagnostic("other", "unrelated"), diagnostic()].join("\n");
+    });
+    expect(seen).toEqual(["bad();\n", "example"]);
+    expect(page).toContain(
+      "```text\nwarning[example]: explanation\n  --> src/Example.sol:1:1\n```",
+    );
+    expect(page).not.toContain("unrelated");
+    expect(page).not.toContain("{{produces}}");
+    expect(page).toContain("Use instead:\n\n```solidity\ngood();");
+  });
+
+  test("preserves markers inside code and does not execute unmarked fragments", () => {
+    const source = canonical().replace("bad();", "// {{produces}}\n{{produces}}");
+    expect(
+      renderExamples(source, "example", () => {
+        throw new Error("must not run");
+      }),
+    ).toBe(source);
+  });
+
+  test("supports longer and tilde fences and encloses backticks in diagnostics", () => {
+    for (const fence of ["````", "~~~"]) {
+      const source = `${fence}solidity\ncontract C {}\n${fence}\n\n{{produces}}`;
+      expect(
+        renderExamples(source, "example", (code) => {
+          expect(code).toBe("contract C {}\n");
+          return diagnostic("example", "source contains ```\n");
+        }),
+      ).toContain("````text\nsource contains ```\n````");
+    }
+  });
+
+  test("rejects markers without an immediately preceding Solidity block", () => {
+    for (const source of [
+      "{{produces}}",
+      "```text\ncode\n```\n{{produces}}",
+      "```solidity\ncode\n```\nExplanation\n{{produces}}",
+      "```solidity\ncode\n```\n{{produces}}\n{{produces}}",
+    ])
+      expect(() => renderExamples(source, "example", () => diagnostic())).toThrow(
+        "must immediately follow",
+      );
+  });
+
+  test("requires a rendered diagnostic for the documented lint", () => {
+    for (const output of ["", diagnostic("other"), diagnostic("example", "")])
+      expect(() => diagnosticOutput(output, "example")).toThrow("did not produce");
+    expect(() => diagnosticOutput("not JSON", "example")).toThrow();
+    expect(() =>
+      diagnosticOutput(
+        `${diagnostic()}\n${JSON.stringify({ level: "error", message: "invalid source" })}`,
+        "example",
+      ),
+    ).toThrow("invalid documentation example: invalid source");
+  });
+
+  test("keeps multiple diagnostics in emission order, including note severity", () => {
+    expect(
+      diagnosticOutput(
+        [
+          diagnostic("example", "first\n"),
+          JSON.stringify({ level: "note", code: { code: "example" }, rendered: "second\n" }),
+        ].join("\n"),
+        "example",
+      ),
+    ).toBe("first\n\nsecond");
+  });
+
+  test("offline validation rejects unresolved produces without running Forge", () => {
+    run();
+    put(root, pagePath, read(pagePath).replace("\nUse instead:", "\n{{produces}}\n\nUse instead:"));
+    expect(() => checkImportedDocs(root)).toThrow("unresolved {{produces}}");
+  });
+
+  test("failed example generation leaves all imported files untouched", () => {
+    run();
+    const original = read(pagePath);
+    const manifest = read("scripts/lint-docs-manifest.json");
+    put(
+      foundry,
+      "crates/lint/docs/example.md",
+      canonical().replace("\nUse instead:", "\n{{produces}}\n\nUse instead:"),
+    );
+    commit();
+    expect(() => run("--forge", join(temporary, "missing-forge"))).toThrow(
+      "cannot lint documentation example",
+    );
+    expect(read(pagePath)).toBe(original);
+    expect(read("scripts/lint-docs-manifest.json")).toBe(manifest);
+  });
+
   test("imports source content, metadata, navigation and exact revision, then is idempotent", () => {
     run();
     expect(canonicalBody(read(pagePath))).toBe(canonical().trim());

--- a/scripts/import-lint-docs.ts
+++ b/scripts/import-lint-docs.ts
@@ -4,6 +4,7 @@ import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { pathToFileURL } from "node:url";
+import { renderExamples, runExample } from "./lint-examples.ts";
 
 export const groups = {
   High: "High severity",
@@ -189,7 +190,7 @@ function region(
 }
 
 // Build every replacement before writing, so invalid input cannot partially update the book.
-export function planImport(root: string, foundry: string): Map<string, string> {
+export function planImport(root: string, foundry: string, forge = "forge"): Map<string, string> {
   const commit = git(foundry, "rev-parse", "HEAD");
   if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error("expected a full Foundry commit SHA");
   if (git(foundry, "status", "--porcelain", "--", "crates/lint"))
@@ -203,7 +204,8 @@ export function planImport(root: string, foundry: string): Map<string, string> {
     navigation: {},
   };
   for (const lint of lints) {
-    const page = renderPage(lint);
+    const body = renderExamples(lint.body, lint.id, (source, id) => runExample(source, id, forge));
+    const page = renderPage({ ...lint, body });
     files.set(`${pagesPath}/${lint.id}.mdx`, page);
     manifest.pages[lint.id] = hash(page);
   }
@@ -287,6 +289,9 @@ export function checkImportedDocs(root: string): void {
   }
   for (const file of readdirSync(join(root, pagesPath)).filter((file) => file.endsWith(".mdx"))) {
     const page = read(root, `${pagesPath}/${file}`);
+    renderExamples(canonicalBody(page), file.slice(0, -4), () => {
+      throw new Error(`${file}: unresolved {{produces}}; regenerate the lint import`);
+    });
     validateLintDoc(canonicalBody(page), file.slice(0, -4));
     if (
       !hasOwn(manifest.pages, file.slice(0, -4)) &&
@@ -312,13 +317,14 @@ export function main(
     args: args.filter((arg) => arg !== "--"),
     options: {
       foundry: { type: "string" },
+      forge: { type: "string" },
       check: { type: "boolean" },
       help: { type: "boolean" },
     },
   });
   if (values.help) {
     console.log(
-      "Usage: vp run import:lints -- --foundry <checkout> [--check]\n       vp run import:lints -- --check\n\nImport committed Foundry lint pages and navigation. --check never writes files;\nwithout --foundry it checks the committed import manifest offline.",
+      "Usage: vp run import:lints -- --foundry <checkout> [--forge <binary>] [--check]\n       vp run import:lints -- --check\n\nImport committed Foundry lint pages and navigation. Use a Forge binary matching the source.\n--check never writes files; without --foundry it checks the committed import manifest offline.",
     );
     return;
   }
@@ -328,7 +334,7 @@ export function main(
     console.log("Imported lint documentation matches the committed manifest.");
     return;
   }
-  const files = planImport(root, resolve(values.foundry));
+  const files = planImport(root, resolve(values.foundry), values.forge);
   const changed = [...files].filter(([path, text]) => {
     try {
       return read(root, path) !== text;

--- a/scripts/lint-docs-manifest.json
+++ b/scripts/lint-docs-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "source": {
     "repository": "foundry-rs/foundry",
-    "commit": "913a2970f28d626c895b07b01d50fc91db93626e",
+    "commit": "07c3b806313d8a83c482a6de3d1e4d0032cd2939",
     "path": "crates/lint/docs"
   },
   "pages": {
@@ -20,7 +20,7 @@
     "calls-loop": "a0e1bad08e194574a862e8dd2802e5efc822fd8c9ff7738d01c0f4f8313629bc",
     "controlled-delegatecall": "5d17b9fdff51e5299a6a1fa8536bc51d30bc80c32b6bf866624845d3c93b215a",
     "costly-loop": "e4088a9c09ebd0a676bb1d2060fbfbbe63eea8ac47c8271d6352d90f16db30b9",
-    "could-be-constant": "e2bbcfe7101f9a56888b08e024ec68155b1fd41eadc2c58def487eba06675307",
+    "could-be-constant": "be14ab82b6983b40c50cc38be25284b8a22a8ee6908a5573a3473ce5797484b0",
     "could-be-immutable": "3758a14ec66a549a7dbd1e5e6386101fb604a67727fbfdc462495fffaaec30e2",
     "custom-errors": "a7c8652d046c7212f075591901ccf65127646c8cdc228afa9c45363f364f2c25",
     "cyclomatic-complexity": "faa8470190745d4e406c42104a8bbf9361f044f472578fc6957c5808b464a452",
@@ -40,14 +40,14 @@
     "inconsistent-type-names": "f4575f849175bffd3a42f35098d782bfae78c629d849636c554843ba1ddd6924",
     "incorrect-erc20-interface": "d696a4922839139e338bb4d7be4d5c78dd8d454916e915198365030dc38fe9ea",
     "incorrect-erc721-interface": "7b9645279e17d5b16d30176b35d09f2b7bd412cf7dcf504b0432f525b952f12e",
-    "incorrect-exp": "09fb57712b8aa1809b2f00d091a3ce0f7ff66fa1e4cc62e879b9ab1c6bc6c94c",
+    "incorrect-exp": "b97216ceb2fb30def0ec7fbecb895e5e95b3afff7499bf11e48db8a7503872fa",
     "incorrect-modifier": "5a2e1acb1f59b8e7921de837736c41567d72cceeaa7def930049038cfc082aff",
     "incorrect-shift": "da23bf5a27a4d7f5c3e66a28242b5f5cf6e73a737cf9c00309ac4ee911f50f81",
     "incorrect-strict-equality": "0c79123282f86fbb62259115d1741638b3ac9f72381a676627abf313fb024a6c",
     "incorrect-using-for": "d9669e972d7fc69bd6bc7fd48b1346c449e39d862269280c247a6ee38fcec496",
     "inline-assembly": "685dacbab25a1ce919ddb064d33fa198dad15be2b6b8f054d3ca21c956058e29",
     "interface-file-naming": "63173b1202d2a2b2e01ce57f32c26899b197628d4c65c09772ebd0f6d8d3ff8d",
-    "interface-naming": "c310ad3a13454640f0215ce5d0706b3b575527a1ce6cc9481f288819e58c6340",
+    "interface-naming": "02ed8e2ce229e5d0a1f532bbf2fb5314d378e9072709c514ac1f2cb0694c10c1",
     "internal-function-used-once": "b95e0e73fbd91f6b0e2b967f8d0e0013040c18b25b446b81849a7eb64aae051a",
     "literal-instead-of-constant": "e3307933ab664802af5f260580a19e2b579565c1f60aedad62f86d15515a2872",
     "locked-ether": "bfb3b93dda019b5db43480f755952821d54e5f6d4c106915ea4bd82881b485ba",
@@ -61,7 +61,7 @@
     "mixed-case-variable": "d1ecd76d7a13a364fda349497059c0d7d14f0a6ea54bc001ead52bdb7e4784d6",
     "modifier-used-only-once": "578aa3ba68f8a94e2d6feaf616a85cbbf76beb2ceed388d5a60a10588c72c669",
     "msg-value-loop": "3b4fe1d59ab7a522a611f8e1c3efa64d06e44ad93a5c7d0110b90526a885b635",
-    "multi-contract-file": "f78f54598b26d60bbaf62004c6ccf0a8d437f7d24e80730c0cf56c03836c32a4",
+    "multi-contract-file": "4f6e2570e1cd4cb3e92c49edf73c0ee35db7cd44c8264b1f44c48bcf8a535aa5",
     "named-struct-fields": "7b01b01b09ad5550832f14bc591b63f84e122dc1a8964b29bfc0ed7c78908fd1",
     "non-reentrant-not-first": "b13f6310ad1f6ef8b1ac1fa031a00c0bc5bbae515102963e53ef1562998f1247",
     "pascal-case-struct": "7034fc96ee2d655930315cb6b897c2b235d535fbc9fb97dcdf054e1f68b2cf14",
@@ -92,16 +92,16 @@
     "unsafe-oz-erc721-mint": "60b4bb4f73cb29cee85d35a2a451c086b43354babbef519d62f607ce6c5fb660",
     "unsafe-typecast": "8971505bdf79fc9df826c6410a594d1318e6d31f44eaae8c32ae50dac1ebb20f",
     "unused-error": "426915d68002b0245040f794521e22bdda056054e814e3c369b646b202d3adfc",
-    "unused-import": "a6eb3a5954418be203f473834c3ef4717e05c43b534c026bd611e8ff45349138",
+    "unused-import": "d2c6afb1e4f87897f6564f30f5bcd9dbb1bafd86e52a4d3e448f81d4a24bad80",
     "unused-return": "24c2207c5174dc7685da4031dd2823100c739782745084d2c8639703b0a085c2",
     "unused-state-variables": "798fe8bc47e5e79ab9c3bd1eca979862dd9093eecd706c4268db5ec801c7b89c",
-    "unwrapped-modifier-logic": "0a50b16765e4480a87d0945dfcb9b2503f8a7a77bde412c965d00b35adf9aee0",
+    "unwrapped-modifier-logic": "3ea0c3eaa384cb718c7edaab425badf769d35bc30fc7d944c381c60ea712f76b",
     "var-read-using-this": "700eb04fce0843008db184eef675202170b4d2c31bb5ab978ba44ec487f3ff44",
     "weak-prng": "734a50fbf32dae86cda45304551676a97a493f5845098824746708ec78c043c4",
     "write-after-write": "14707732c38124cc28a2eec5b315291358f8e8977f31c52c2f2c865c09771570"
   },
   "navigation": {
     "sidebar/forge.ts": "e76b67a80e3e2a48531c9ff900feb7a6b6a5d2f619e83713e4210b0abbbf83b8",
-    "src/pages/forge/linting.mdx": "3057b4e13d82aae7279d311057c0f7b62e43fa15f6273f48eb3f01860dc80cda"
+    "src/pages/forge/linting.mdx": "833b580bd7538e774c91ae873a06403d6643c6bd81c7b8d0f25eea5eda6b1863"
   }
 }

--- a/scripts/lint-examples.ts
+++ b/scripts/lint-examples.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type Diagnostic = {
+  level?: string;
+  code?: { code?: string } | null;
+  rendered?: string;
+  message?: string;
+};
+
+// Each example is a complete source file. Linting parses it; it never executes Solidity.
+export function runExample(source: string, id: string, forge = "forge"): string {
+  const root = mkdtempSync(join(tmpdir(), "book-lint-example-"));
+  try {
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "foundry.toml"), '[profile.default]\nsrc = "src"\n');
+    writeFileSync(join(root, "src/Example.sol"), source);
+    return execFileSync(
+      forge,
+      ["lint", "src/Example.sol", "--root", root, "--json", "--only-lint", id],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FOUNDRY_CONFIG: join(root, "foundry.toml"),
+          FOUNDRY_PROFILE: "default",
+        },
+        timeout: 60_000,
+        maxBuffer: 4 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+      .split(`${root}/`)
+      .join("");
+  } catch (error) {
+    throw new Error(
+      `${id}: cannot lint documentation example: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+export function diagnosticOutput(output: string, id: string): string {
+  const diagnostics: Diagnostic[] = output
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line));
+  const errors = diagnostics.filter((diagnostic) => diagnostic.level === "error");
+  if (errors.length)
+    throw new Error(
+      `${id}: invalid documentation example: ${errors.map((error) => error.message).join("; ")}`,
+    );
+  const matching = diagnostics.filter((diagnostic) => diagnostic.code?.code === id);
+  if (!matching.length || matching.some((diagnostic) => !diagnostic.rendered?.trim()))
+    throw new Error(`${id}: documentation example did not produce a rendered ${id} diagnostic`);
+  return matching.map((diagnostic) => diagnostic.rendered!.trimEnd()).join("\n\n");
+}
+
+// Markers are prose, not source comments. Only an immediately preceding Solidity fence applies.
+export function renderExamples(
+  body: string,
+  id: string,
+  run: (source: string, id: string) => string = runExample,
+): string {
+  const output: string[] = [];
+  let fence: { char: string; length: number; solidity: boolean; lines: string[] } | undefined;
+  let source: string | undefined;
+  for (const line of body.split("\n")) {
+    const marker = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (fence) {
+      if (
+        marker &&
+        marker[1][0] === fence.char &&
+        marker[1].length >= fence.length &&
+        !marker[2].trim()
+      ) {
+        source = fence.solidity ? `${fence.lines.join("\n")}\n` : undefined;
+        fence = undefined;
+      } else fence.lines.push(line);
+    } else if (marker) {
+      source = undefined;
+      fence = {
+        char: marker[1][0],
+        length: marker[1].length,
+        solidity: marker[2].trim() === "solidity",
+        lines: [],
+      };
+    } else if (line.trim() === "{{produces}}") {
+      if (source === undefined)
+        throw new Error(`${id}: {{produces}} must immediately follow a Solidity code block`);
+      const rendered = diagnosticOutput(run(source, id), id);
+      // Diagnostics can quote source containing backticks. Keep those inside the output fence.
+      const delimiter = "`".repeat(
+        Math.max(3, ...[...rendered.matchAll(/`+/g)].map((match) => match[0].length + 1)),
+      );
+      output.push(`${delimiter}text\n${rendered}\n${delimiter}`);
+      source = undefined;
+      continue;
+    } else if (line.trim()) source = undefined;
+    output.push(line);
+  }
+  return output.join("\n");
+}

--- a/src/pages/forge/linting.mdx
+++ b/src/pages/forge/linting.mdx
@@ -237,7 +237,7 @@ navigation on the right to browse by severity.
 - [`mixed-case-function`](/forge/linting/mixed-case-function) — Reports functions whose names contain embedded underscores, start with an uppercase letter, or otherwise deviate from `mixedCase`. Leading and trailing underscores are preserved, and single-character names are not checked. Test functions starting with `test`, `invariant_`, or `statefulFuzz`, configured uppercase patterns (for example, `ERC20`), and external constant-style getters are exempted.
 - [`mixed-case-variable`](/forge/linting/mixed-case-variable) — Reports mutable variable identifiers that contain embedded underscores, start with an uppercase letter, or otherwise deviate from `mixedCase`. Leading and trailing underscores are preserved, and single-character names are not checked.
 - [`modifier-used-only-once`](/forge/linting/modifier-used-only-once) — Reports modifiers used by exactly one function or constructor across the compiled sources. Virtual modifiers, overrides, and unused modifiers are excluded.
-- [`multi-contract-file`](/forge/linting/multi-contract-file) — Reports each top-level `contract`, `interface`, or `library` definition (after the first) in a file that contains more than one such declaration.
+- [`multi-contract-file`](/forge/linting/multi-contract-file) — Reports every non-exempt top-level `contract`, `interface`, or `library` definition in a file that contains more than one non-exempt declaration.
 - [`named-struct-fields`](/forge/linting/named-struct-fields) — Reports `Struct(a, b, c)` style struct construction; suggests `Struct({ field1: a, field2: b, field3: c })` instead.
 - [`pascal-case-struct`](/forge/linting/pascal-case-struct) — Reports `struct` identifiers longer than one character that do not match the `PascalCase` convention. Single-character names are not checked.
 - [`pragma-inconsistent`](/forge/linting/pragma-inconsistent) — Reports inconsistent `pragma solidity ...;` requirements across source files, such as different exact versions or mixed caret, tilde, and range constraints.
@@ -249,7 +249,7 @@ navigation on the right to browse by severity.
 - [`unaliased-plain-import`](/forge/linting/unaliased-plain-import) — Reports plain imports of the form `import "path";`. Suggests using either named imports (`import { A, B } from "path"`) or an aliased import (`import "path" as X`).
 - [`unsafe-cheatcode`](/forge/linting/unsafe-cheatcode) — Reports calls to `ffi`, `readFile`, `readLine`, `writeFile`, `writeLine`, `removeFile`, `closeFile`, `setEnv`, or `deriveKey`. Unrelated methods with these names may also be flagged.
 - [`unused-error`](/forge/linting/unused-error) — Reports custom error declarations that are never used by a revert, `require`, or selector reference anywhere in the compiled sources.
-- [`unused-import`](/forge/linting/unused-import) — Reports `import "..."`, `import "..." as X`, and `import { A, B } from "..."` statements where one or more imported names are never used. This includes unused namespace imports (`import * as X`).
+- [`unused-import`](/forge/linting/unused-import) — Reports unused names in named imports (`import { A, B } from "..."`) and unused namespace aliases (`import "..." as X` or `import * as X from "..."`). Plain imports without an alias are not checked.
 
 #### Gas optimization
 
@@ -266,6 +266,6 @@ navigation on the right to browse by severity.
 
 #### Code size
 
-- [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Reports modifiers containing logic beyond a placeholder, simple `require` or `assert` checks, or a single library call. Assembly blocks are excluded from suggested extraction.
+- [`unwrapped-modifier-logic`](/forge/linting/unwrapped-modifier-logic) — Reports modifier logic that can be extracted into a helper, including `require` and `assert` checks. A single ordinary function or library call on either side of `_` is left inline. Assembly blocks are excluded from suggested extraction.
 
 {/* END GENERATED LINTS */}

--- a/src/pages/forge/linting/could-be-constant.mdx
+++ b/src/pages/forge/linting/could-be-constant.mdx
@@ -29,6 +29,26 @@ contract C {
 }
 ```
 
+```text
+note[could-be-constant]: state variable has a constant initializer and is never written
+  ╭▸ src/Example.sol:2:13
+  │
+2 │     uint256 LIMIT = 100;
+  │             ━━━━━
+  │
+  ├ help: consider declaring it `constant`
+  ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable has a constant initializer and is never written
+  ╭▸ src/Example.sol:3:13
+  │
+3 │     bytes32 SALT = keccak256("foundry");
+  │             ━━━━
+  │
+  ├ help: consider declaring it `constant`
+  ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+```
+
 Use instead:
 
 ```solidity

--- a/src/pages/forge/linting/incorrect-exp.mdx
+++ b/src/pages/forge/linting/incorrect-exp.mdx
@@ -27,6 +27,17 @@ which can corrupt amounts, decimals, or limits.
 uint256 constant WAD = 10 ^ 18; // evaluates to 24, not 1e18
 ```
 
+```text
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation
+  ╭▸ src/Example.sol:1:24
+  │
+1 │ uint256 constant WAD = 10 ^ 18; // evaluates to 24, not 1e18
+  │                        ━━━━━━━
+  │
+  ├ help: use `**` for exponentiation
+  ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+```
+
 Use instead:
 
 ```solidity

--- a/src/pages/forge/linting/interface-naming.mdx
+++ b/src/pages/forge/linting/interface-naming.mdx
@@ -29,6 +29,16 @@ when renaming would disrupt downstream imports or conflict with that convention.
 interface ERC20 { /* ... */ }
 ```
 
+```text
+note[interface-naming]: interface name is missing the `I` prefix
+  ╭▸ src/Example.sol:1:11
+  │
+1 │ interface ERC20 { /* ... */ }
+  │           ━━━━━
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/interface-naming
+```
+
 Use instead:
 
 ```solidity

--- a/src/pages/forge/linting/multi-contract-file.mdx
+++ b/src/pages/forge/linting/multi-contract-file.mdx
@@ -11,8 +11,8 @@ description: "Multiple contracts in one file"
 
 ### What it does
 
-Reports each top-level `contract`, `interface`, or `library` definition (after the first) in a
-file that contains more than one such declaration.
+Reports every non-exempt top-level `contract`, `interface`, or `library` definition in a
+file that contains more than one non-exempt declaration.
 
 ### Why restrict this?
 

--- a/src/pages/forge/linting/unused-import.mdx
+++ b/src/pages/forge/linting/unused-import.mdx
@@ -11,8 +11,9 @@ description: "Unused import"
 
 ### What it does
 
-Reports `import "..."`, `import "..." as X`, and `import { A, B } from "..."` statements where one
-or more imported names are never used. This includes unused namespace imports (`import * as X`).
+Reports unused names in named imports (`import { A, B } from "..."`) and unused namespace
+aliases (`import "..." as X` or `import * as X from "..."`). Plain imports without an alias
+are not checked.
 
 ### Why is this bad?
 

--- a/src/pages/forge/linting/unwrapped-modifier-logic.mdx
+++ b/src/pages/forge/linting/unwrapped-modifier-logic.mdx
@@ -11,8 +11,9 @@ description: "Unwrapped modifier logic"
 
 ### What it does
 
-Reports modifiers containing logic beyond a placeholder, simple `require` or `assert`
-checks, or a single library call. Assembly blocks are excluded from suggested extraction.
+Reports modifier logic that can be extracted into a helper, including `require` and `assert`
+checks. A single ordinary function or library call on either side of `_` is left inline.
+Assembly blocks are excluded from suggested extraction.
 
 ### Why is this bad?
 


### PR DESCRIPTION
## Summary

Render standalone `{{produces}}` markers while importing Foundry lint documentation. The importer lints the preceding self-contained Solidity block in an isolated temporary project and inserts the expected lint's actual rendered diagnostics, including spans and help. Invalid examples, missing diagnostics and failed Forge invocations stop the import before any files are written.

Documentation validation and output generation live only in the Book importer. Ordinary Book builds and manifest checks remain offline; Foundry keeps its existing lint behavior tests. The existing weekly/manual sync already installs Forge and checks out the matching source, so no workflow or second validation suite is needed.

Companion to https://github.com/foundry-rs/foundry/pull/16754. Imports its corrected descriptions for `unwrapped-modifier-logic`, `multi-contract-file` and `unused-import`, plus generated diagnostics for `incorrect-exp`, `could-be-constant` and `interface-naming`. Other fragments remain unmarked until they are self-contained; this does not claim to execute every example. Merge the importer before the source markers reach the nightly sync.

## Verification

- 28 unit tests passed (25 importer tests and 3 benchmark-fetch tests).
- Formatting and lint checks passed for all changed scripts.
- Built Forge from the exact imported commit, `07c3b806313d8a83c482a6de3d1e4d0032cd2939`; all three triggering examples emitted their expected diagnostics and their corrected versions were clean.
- Re-import check reported zero changed files; offline manifest validation passed.
- Production Vocs build passed; rendered Markdown contains the diagnostic output and no unresolved markers.
- Chromium confirmed all three pages visibly render diagnostics, source locations and help, with no unresolved markers or uncaught page errors.
- Standalone `tsc --noEmit` still reports existing library-target and generated `SidebarItem` errors; no errors in the new example runner.

Implemented with AI assistance (Centaur).

Prompted by: @DaniPopes
