### PR TITLE
docs: clarify EIP-8037 gas accounting

### DIFF
--- a/sidebar/forge.ts
+++ b/sidebar/forge.ts
@@ -10,7 +10,7 @@ export const forgeDocs: SidebarItem[] = [
   { text: "Scripting", link: "/forge/scripting" },
   { text: "Debugging", link: "/forge/debugging" },
   { text: "Gas Tracking", link: "/forge/gas-tracking" },
-  { text: "Gas Accounting", link: "/forge/gas-accounting" },
+  { text: "Gas Accounting (EIP-8037)", link: "/forge/gas-accounting" },
   { text: "Formatting", link: "/forge/formatting" },
   { text: "Linting", link: "/forge/linting" },
 ];

--- a/sidebar/forge.ts
+++ b/sidebar/forge.ts
@@ -10,6 +10,7 @@ export const forgeDocs: SidebarItem[] = [
   { text: "Scripting", link: "/forge/scripting" },
   { text: "Debugging", link: "/forge/debugging" },
   { text: "Gas Tracking", link: "/forge/gas-tracking" },
+  { text: "Gas Accounting", link: "/forge/gas-accounting" },
   { text: "Formatting", link: "/forge/formatting" },
   { text: "Linting", link: "/forge/linting" },
 ];

--- a/src/pages/forge/gas-accounting.mdx
+++ b/src/pages/forge/gas-accounting.mdx
@@ -1,0 +1,92 @@
+---
+description: Understand execution gas, state gas, refunds, receipts, and gas limits with EIP-8037.
+---
+
+## Gas accounting
+
+Use a gas **measurement** to understand an execution, a transaction **receipt** to find the charged gas, and a gas **estimate** to choose the limit for a new transaction. These numbers answer different questions, even when they happen to be equal.
+
+[EIP-8037: State Creation Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-8037) separates gas into two dimensions. This page explains that model and how Foundry exposes it. The EIP and its [tracing API proposal](https://github.com/ethereum/execution-apis/pull/852) are evolving; select tools and a node that implement the rules of the network and block you are testing.
+
+### Execution gas and state gas
+
+| Term | What it pays for | What it excludes |
+| --- | --- | --- |
+| **Regular gas / execution gas** | The same dimension under two names: computation, memory expansion, state access, existing-state updates, and transaction intrinsic costs. | State creation charges assigned to the EIP-8037 state dimension; blob gas. |
+| **State gas** | State creation, such as a new storage slot, a new account, or deployed code. Reported net usage already deducts charges undone by state refills or rollback. | The accompanying regular execution costs; blob gas. |
+| **Combined transaction gas limit** (`tx.gas`) | The single gas budget you supply for intrinsic costs and both execution and state gas. | Blob gas, which is accounted for separately. |
+| **Receipt gas used** (`gasUsed`) | The transaction's combined charged gas after ordinary refunds and the applicable calldata floor. | Unused gas, blob gas, and separate network-specific fees. |
+
+A state-changing opcode can incur **both** regular and state gas. State gas does not mean “all gas spent by storage opcodes.” Before EIP-8037, those operations still cost gas, but their costs use the ordinary single-dimensional schedule.
+
+### How the reservoir works
+
+You still supply **one transaction gas limit**. After subtracting intrinsic gas, the EVM allocates a regular gas allowance, subject to the protocol's regular gas cap. Any excess becomes the **state gas reservoir**.
+
+| Charge or operation | Effect |
+| --- | --- |
+| Regular execution charge | Deducts from regular gas only; cannot use the reservoir. |
+| State creation charge | Uses the reservoir first; if it runs out, the remainder draws from regular gas. |
+| State refill | Returns a state charge when the associated creation is undone. It restores the appropriate pools under EIP-8037's refill rules. |
+| Child call | Receives the state reservoir in full. The 63/64 forwarding rule applies to regular gas only. |
+| `GAS` / Solidity `gasleft()` | Reports regular gas only, excluding the reservoir. |
+
+An empty reservoir does **not** mean state gas is disabled: state charges can still be paid from regular gas. Conversely, a large reservoir cannot fund ordinary execution after regular gas runs out.
+
+A nested call's Solidity `{gas: amount}` argument controls its regular gas allowance. It does not impose a combined execution-plus-state budget because the reservoir is passed separately. A `gasleft()` delta can miss state charges paid by the reservoir or include state charges spilling into regular gas. State refills can even make a later `gasleft()` value larger, so unsigned subtraction can revert.
+
+See the EIP's [transaction accounting](https://eips.ethereum.org/EIPS/eip-8037#transaction-level-gas-accounting-reservoir-model) and [call-frame rules](https://eips.ethereum.org/EIPS/eip-8037#gas-accounting-for-halts-and-reverts).
+
+### Two meanings of “refund”
+
+**Ordinary gas refunds** accumulate in the EVM refund counter and are settled at the transaction boundary. [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) caps the applied refund at one fifth of gas spent; the [EIP-7623 calldata floor](https://eips.ethereum.org/EIPS/eip-7623) can further limit the reduction in charged gas. A refund does not replenish gas available to execute instructions.
+
+**State gas refills** reverse state creation charges during execution, for example when a slot that was zero at transaction start is set and then cleared. They can replenish gas available during execution and are already deducted from net state gas. They are not the ordinary capped refund counter. A reverted or exceptionally halted frame reports zero net state gas, even if it temporarily needed state gas before failing; its regular execution still costs gas.
+
+A successful nested frame can have a **negative state gas delta** when it clears state created by an earlier frame in the same transaction. This is why `Vm.Gas.gasStateUsed` is signed. Transaction-level state gas is nonnegative. Use signed arithmetic for frame deltas and avoid subtracting state refills twice.
+
+### Which value should you use?
+
+| Your question | Value or API | Important boundary |
+| --- | --- | --- |
+| How much regular gas did the last call or creation use? | `vm.lastFrameGas().gasTotalUsed` | Excludes EIP-8037 state gas; includes nested execution. Isolation adds transaction intrinsic gas and the regular calldata floor. |
+| How much net state gas did that frame use? | `vm.lastFrameGas().gasStateUsed` | Already net of state refills; can be negative. Zero without EIP-8037 or after frame rollback. |
+| What is the net sum of those frame components? | `int256(uint256(g.gasTotalUsed)) + int256(g.gasStateUsed)` | A signed measurement, not a sufficient gas limit or necessarily receipt gas. |
+| What ordinary refund did that frame accumulate? | `vm.lastFrameGas().gasRefunded` | Frame counter without isolation; finalized refund for an isolated transaction. Excludes state refills. |
+| How much total gas was charged for a mined transaction? | `eth_getTransactionReceipt` → `gasUsed`; `cast receipt <TX_HASH> gasUsed` | Includes both dimensions after refund/floor processing. **Do not add state gas again.** |
+| What was the transaction's execution/state breakdown? | `debug_traceTransaction` with `stateGasTracer`, if the node supports it | Returns `gasUsed`, `executionGasUsed`, `stateGasUsed`, and `gasRefund`. The dimension fields use block-accounting rules; receipt gas is `gasUsed`. |
+| How much gas should I supply for another transaction? | `eth_estimateGas`; `cast estimate`; Alloy `Provider::estimate_gas` | Use the target network, input, sender, value, and state. Estimates require a node implementing its fork rules. |
+| What gas fee did I pay? | Receipt `gasUsed × effectiveGasPrice` | Covers regular and state gas. Add blob or network-specific fee components separately when applicable. |
+
+See [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) for every field, [Cast receipt](/reference/cast/receipt), [Cast estimate](/reference/cast/estimate), and [Alloy's gas trace types](https://docs.rs/alloy-rpc-types-trace/latest/alloy_rpc_types_trace/geth/state_gas/index.html).
+
+### Why used gas is not required gas
+
+Your transaction budget must fund both regular and state gas **when they are charged**, before later refills or refunds. Regular execution must also fit its separate protocol cap. A transaction that allocates state and later undoes it can report little net state gas while requiring enough gas for the temporary allocation. Call forwarding and minimum gas checks can require additional headroom as well.
+
+For example, if a frame reports 30,000 regular gas and 100,000 net state gas, their sum is 130,000 measured gas units. It is not proof that a transaction with a 130,000 gas limit will succeed: the frame can exclude intrinsic or caller-side costs, and it does not report peak temporary state consumption. Subtracting its ordinary refund makes an estimate even less reliable.
+
+For an already executed transaction, read the receipt directly. In the EIP-8037 model, transaction gas before the ordinary refund includes both dimensions and intrinsic costs. The applied ordinary refund is capped, then the calldata floor determines the final charged amount. This settlement cannot generally be reconstructed from `lastFrameGas`, because a child frame is not the whole transaction.
+
+### Transaction gas versus block gas
+
+A transaction receipt counts the **combined** charged gas. Under EIP-8037, the block header instead records the **larger** of the accumulated execution and state dimensions. Therefore the block header's `gasUsed` need not equal the sum of receipt `gasUsed` values or the last receipt's `cumulativeGasUsed`.
+
+[EIP-7778](https://eips.ethereum.org/EIPS/eip-7778) additionally keeps ordinary refunds out of block gas accounting. With EIP-8037 and EIP-7778, trace `executionGasUsed` is before ordinary refunds and includes the execution-dimension calldata floor; `stateGasUsed` remains net of state refills. When no floor binds, their sum minus the transaction refund equals charged receipt gas. If a floor binds, use receipt `gasUsed` directly rather than assuming that equality.
+
+Do not sum a parent frame and all its children to get a transaction total: parent measurements already include nested execution. Opcode state deltas also need not sum to transaction state gas, because some charges and rollbacks occur outside opcode steps.
+
+### Which networks are affected?
+
+| Execution environment | Behavior |
+| --- | --- |
+| Foundry's Ethereum EVM with `evm_version = "amsterdam"` or a later supported fork | Uses EIP-8037 regular/state gas accounting. This is a local execution setting, not evidence of activation on a live chain. |
+| Ethereum forks before Amsterdam, or another network that has not activated EIP-8037 | No separate state gas dimension: `Vm.Gas.gasStateUsed` is zero. State creation still costs ordinary gas and is included in `gasTotalUsed`. |
+| A custom network or an L2 | Follows its own hardfork and gas schedule. EVM compatibility alone does not establish EIP-8037 support, pricing, activation dates, or fee equivalence. |
+| RPC tracing on any network | Depends on both the block's rules and the node's tracer support. Optional state fields may be absent; an unsupported `stateGasTracer` can return an RPC error. An absent field means “not reported,” not measured zero. |
+
+When compiling with Solidity 0.8.36, Amsterdam is experimental and also requires `--experimental` (or `experimental = true` in `foundry.toml`).
+
+Pin the [EVM version](/config/reference/solidity-compiler#evm_version), fork block, optimizer settings, and isolation mode when comparing measurements. Use a Foundry version supporting the selected fork and a current forge-std `Vm.Gas` interface containing `gasStateUsed`. For a live network, consult that network's activation schedule rather than assuming Amsterdam rules from a chain name or from Alloy's ability to decode the fields.
+
+RPC field names can also depend on the node/proposal revision. Current Alloy types use `executionGasUsed`; older revisions may call that dimension `regularGasUsed`. Confirm the response schema when choosing your client version.

--- a/src/pages/forge/gas-accounting.mdx
+++ b/src/pages/forge/gas-accounting.mdx
@@ -8,43 +8,6 @@ Use a gas **measurement** to understand an execution, a transaction **receipt** 
 
 [EIP-8037: State Creation Gas Cost Increase](https://eips.ethereum.org/EIPS/eip-8037) separates gas into two dimensions. This page explains that model and how Foundry exposes it. The EIP and its [tracing API proposal](https://github.com/ethereum/execution-apis/pull/852) are evolving; select tools and a node that implement the rules of the network and block you are testing.
 
-### Execution gas and state gas
-
-| Term | What it pays for | What it excludes |
-| --- | --- | --- |
-| **Regular gas / execution gas** | The same dimension under two names: computation, memory expansion, state access, existing-state updates, and transaction intrinsic costs. | State creation charges assigned to the EIP-8037 state dimension; blob gas. |
-| **State gas** | State creation, such as a new storage slot, a new account, or deployed code. Reported net usage already deducts charges undone by state refills or rollback. | The accompanying regular execution costs; blob gas. |
-| **Combined transaction gas limit** (`tx.gas`) | The single gas budget you supply for intrinsic costs and both execution and state gas. | Blob gas, which is accounted for separately. |
-| **Receipt gas used** (`gasUsed`) | The transaction's combined charged gas after ordinary refunds and the applicable calldata floor. | Unused gas, blob gas, and separate network-specific fees. |
-
-A state-changing opcode can incur **both** regular and state gas. State gas does not mean “all gas spent by storage opcodes.” Before EIP-8037, those operations still cost gas, but their costs use the ordinary single-dimensional schedule.
-
-### How the reservoir works
-
-You still supply **one transaction gas limit**. After subtracting intrinsic gas, the EVM allocates a regular gas allowance, subject to the protocol's regular gas cap. Any excess becomes the **state gas reservoir**.
-
-| Charge or operation | Effect |
-| --- | --- |
-| Regular execution charge | Deducts from regular gas only; cannot use the reservoir. |
-| State creation charge | Uses the reservoir first; if it runs out, the remainder draws from regular gas. |
-| State refill | Returns a state charge when the associated creation is undone. It restores the appropriate pools under EIP-8037's refill rules. |
-| Child call | Receives the state reservoir in full. The 63/64 forwarding rule applies to regular gas only. |
-| `GAS` / Solidity `gasleft()` | Reports regular gas only, excluding the reservoir. |
-
-An empty reservoir does **not** mean state gas is disabled: state charges can still be paid from regular gas. Conversely, a large reservoir cannot fund ordinary execution after regular gas runs out.
-
-A nested call's Solidity `{gas: amount}` argument controls its regular gas allowance. It does not impose a combined execution-plus-state budget because the reservoir is passed separately. A `gasleft()` delta can miss state charges paid by the reservoir or include state charges spilling into regular gas. State refills can even make a later `gasleft()` value larger, so unsigned subtraction can revert.
-
-See the EIP's [transaction accounting](https://eips.ethereum.org/EIPS/eip-8037#transaction-level-gas-accounting-reservoir-model) and [call-frame rules](https://eips.ethereum.org/EIPS/eip-8037#gas-accounting-for-halts-and-reverts).
-
-### Two meanings of “refund”
-
-**Ordinary gas refunds** accumulate in the EVM refund counter and are settled at the transaction boundary. [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) caps the applied refund at one fifth of gas spent; the [EIP-7623 calldata floor](https://eips.ethereum.org/EIPS/eip-7623) can further limit the reduction in charged gas. A refund does not replenish gas available to execute instructions.
-
-**State gas refills** reverse state creation charges during execution, for example when a slot that was zero at transaction start is set and then cleared. They can replenish gas available during execution and are already deducted from net state gas. They are not the ordinary capped refund counter. A reverted or exceptionally halted frame reports zero net state gas, even if it temporarily needed state gas before failing; its regular execution still costs gas.
-
-A successful nested frame can have a **negative state gas delta** when it clears state created by an earlier frame in the same transaction. This is why `Vm.Gas.gasStateUsed` is signed. Transaction-level state gas is nonnegative. Use signed arithmetic for frame deltas and avoid subtracting state refills twice.
-
 ### Which value should you use?
 
 | Your question | Value or API | Important boundary |
@@ -54,11 +17,36 @@ A successful nested frame can have a **negative state gas delta** when it clears
 | What is the net sum of those frame components? | `int256(uint256(g.gasTotalUsed)) + int256(g.gasStateUsed)` | A signed measurement, not a sufficient gas limit or necessarily receipt gas. |
 | What ordinary refund did that frame accumulate? | `vm.lastFrameGas().gasRefunded` | Frame counter without isolation; finalized refund for an isolated transaction. Excludes state refills. |
 | How much total gas was charged for a mined transaction? | `eth_getTransactionReceipt` → `gasUsed`; `cast receipt <TX_HASH> gasUsed` | Includes both dimensions after refund/floor processing. **Do not add state gas again.** |
-| What was the transaction's execution/state breakdown? | `debug_traceTransaction` with `stateGasTracer`, if the node supports it | Returns `gasUsed`, `executionGasUsed`, `stateGasUsed`, and `gasRefund`. The dimension fields use block-accounting rules; receipt gas is `gasUsed`. |
+| What was the transaction's execution/state breakdown? | `debug_traceTransaction` with `stateGasTracer`, if the node supports it | Returns `gasUsed`, `executionGasUsed` (the proposal’s `regularGasUsed`), `stateGasUsed`, and `gasRefund`. The dimension fields use block-accounting rules; receipt gas is `gasUsed`. |
 | How much gas should I supply for another transaction? | `eth_estimateGas`; `cast estimate`; Alloy `Provider::estimate_gas` | Use the target network, input, sender, value, and state. Estimates require a node implementing its fork rules. |
 | What gas fee did I pay? | Receipt `gasUsed × effectiveGasPrice` | Covers regular and state gas. Add blob or network-specific fee components separately when applicable. |
 
 See [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) for every field, [Cast receipt](/reference/cast/receipt), [Cast estimate](/reference/cast/estimate), and [Alloy's gas trace types](https://docs.rs/alloy-rpc-types-trace/latest/alloy_rpc_types_trace/geth/state_gas/index.html).
+
+### Execution gas and state gas
+
+| Term | What it pays for | What it excludes |
+| --- | --- | --- |
+| **Regular gas** (the EIP’s *execution gas*) | Computation, memory expansion, state access, existing-state updates, and transaction intrinsic costs. | State creation charges assigned to the EIP-8037 state dimension; blob gas. |
+| **State gas** | State creation, such as a new storage slot, a new account, or deployed code. Reported net usage already deducts charges undone by state refills or rollback. | The accompanying regular execution costs; blob gas. |
+| **Combined transaction gas limit** (`tx.gas`) | The single gas budget you supply for intrinsic costs and both execution and state gas. | Blob gas, which is accounted for separately. |
+| **Receipt gas used** (`gasUsed`) | The transaction's combined charged gas after ordinary refunds and the applicable calldata floor. | Unused gas, blob gas, and separate network-specific fees. |
+
+A state-changing opcode can incur **both** regular and state gas. State gas does not mean “all gas spent by storage opcodes.” Before EIP-8037, those operations still cost gas, but their costs use the ordinary single-dimensional schedule.
+
+### How the reservoir works
+
+You still supply **one transaction gas limit**. After intrinsic gas, the EVM gives the transaction a regular gas allowance, capped by the protocol, and puts any excess into a **state gas reservoir**. Regular execution spends regular gas only. State creation spends the reservoir first and spills into regular gas once it is empty. State **refills** reverse creation charges and restore the gas pools according to EIP-8037's refill rules. Child calls receive the reservoir in full; their `{gas: amount}` allowance and the 63/64 rule apply to regular gas only.
+
+`gasleft()` reports regular gas only. Its delta can miss state gas paid from the reservoir or include state charges spilling into regular gas. A refill can make a later `gasleft()` **larger**, causing checked subtraction to revert. An empty reservoir does not disable state charges, and a large reservoir cannot fund regular execution. See the EIP's [reservoir model](https://eips.ethereum.org/EIPS/eip-8037#transaction-level-gas-accounting-reservoir-model) and [call-frame rules](https://eips.ethereum.org/EIPS/eip-8037#gas-accounting-for-halts-and-reverts) for the full mechanics.
+
+### Two meanings of “refund”
+
+**Ordinary gas refunds** accumulate in the EVM refund counter and are settled at the transaction boundary. [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) caps the applied refund at one fifth of gas spent; the [EIP-7623 calldata floor](https://eips.ethereum.org/EIPS/eip-7623) can further limit the reduction in charged gas. A refund does not replenish gas available to execute instructions.
+
+**State gas refills** reverse state creation charges during execution, for example when a slot that was zero at transaction start is set and then cleared. They can replenish gas available during execution and are already deducted from net state gas. They are not the ordinary capped refund counter. A reverted or exceptionally halted frame reports zero net state gas, even if it temporarily needed state gas before failing; its regular execution still costs gas.
+
+A successful nested frame can have a **negative state gas delta** when it clears state created by an earlier frame in the same transaction. This is why `Vm.Gas.gasStateUsed` is signed. Transaction-level state gas is nonnegative. Use signed arithmetic for frame deltas and avoid subtracting state refills twice.
 
 ### Why used gas is not required gas
 
@@ -70,11 +58,9 @@ For an already executed transaction, read the receipt directly. In the EIP-8037 
 
 ### Transaction gas versus block gas
 
-A transaction receipt counts the **combined** charged gas. Under EIP-8037, the block header instead records the **larger** of the accumulated execution and state dimensions. Therefore the block header's `gasUsed` need not equal the sum of receipt `gasUsed` values or the last receipt's `cumulativeGasUsed`.
+Receipt `gasUsed` is the transaction's combined charge. Under EIP-8037, the block header uses the **larger** accumulated gas dimension instead. With [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), block accounting counts regular gas before ordinary refunds, while state gas remains net of state refills. See [Alloy's gas accounting documentation](https://docs.rs/alloy-rpc-types-trace/latest/alloy_rpc_types_trace/geth/state_gas/index.html) for the fields and calldata-floor rules.
 
-[EIP-7778](https://eips.ethereum.org/EIPS/eip-7778) additionally keeps ordinary refunds out of block gas accounting. With EIP-8037 and EIP-7778, trace `executionGasUsed` is before ordinary refunds and includes the execution-dimension calldata floor; `stateGasUsed` remains net of state refills. When no floor binds, their sum minus the transaction refund equals charged receipt gas. If a floor binds, use receipt `gasUsed` directly rather than assuming that equality.
-
-Do not sum a parent frame and all its children to get a transaction total: parent measurements already include nested execution. Opcode state deltas also need not sum to transaction state gas, because some charges and rollbacks occur outside opcode steps.
+Do not sum parent and child frames to reconstruct a transaction total: parent measurements already include nested execution. Some state charges and rollbacks also occur outside opcode steps.
 
 ### Which networks are affected?
 
@@ -89,4 +75,4 @@ When compiling with Solidity 0.8.36, Amsterdam is experimental and also requires
 
 Pin the [EVM version](/config/reference/solidity-compiler#evm_version), fork block, optimizer settings, and isolation mode when comparing measurements. Use a Foundry version supporting the selected fork and a current forge-std `Vm.Gas` interface containing `gasStateUsed`. For a live network, consult that network's activation schedule rather than assuming Amsterdam rules from a chain name or from Alloy's ability to decode the fields.
 
-RPC field names can also depend on the node/proposal revision. Current Alloy types use `executionGasUsed`; older revisions may call that dimension `regularGasUsed`. Confirm the response schema when choosing your client version.
+RPC field names differ between implementations. The [execution-apis proposal](https://github.com/ethereum/execution-apis/pull/852) names the execution dimension `regularGasUsed`; Alloy and reth serialize `executionGasUsed`. Check what your node returns and whether your Alloy version accepts both names when decoding.

--- a/src/pages/forge/gas-tracking.mdx
+++ b/src/pages/forge/gas-tracking.mdx
@@ -6,7 +6,7 @@ description: Track and compare gas usage with Forge snapshots and reports.
 
 Forge tracks gas usage to help optimize contracts and catch regressions.
 
-For EIP-8037, distinguish regular (execution) gas, state gas, and charged receipt gas. A scalar gas report or snapshot is not a transaction gas-limit estimate. See [gas accounting](/forge/gas-accounting) for what each value includes and [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) for separate frame measurements.
+Under EIP-8037 (Amsterdam), gas has two dimensions: regular gas and state gas. See [gas accounting](/forge/gas-accounting) for how reports, snapshots, and [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) relate to them.
 
 ### Gas reports
 

--- a/src/pages/forge/gas-tracking.mdx
+++ b/src/pages/forge/gas-tracking.mdx
@@ -6,6 +6,8 @@ description: Track and compare gas usage with Forge snapshots and reports.
 
 Forge tracks gas usage to help optimize contracts and catch regressions.
 
+For EIP-8037, distinguish regular (execution) gas, state gas, and charged receipt gas. A scalar gas report or snapshot is not a transaction gas-limit estimate. See [gas accounting](/forge/gas-accounting) for what each value includes and [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) for separate frame measurements.
+
 ### Gas reports
 
 Generate a gas report for all tests:

--- a/src/pages/reference/cheatcodes/gas-snapshots.mdx
+++ b/src/pages/reference/cheatcodes/gas-snapshots.mdx
@@ -32,6 +32,14 @@ These cheatcodes allow you to capture gas usage in your tests. Snapshots are wri
 | `snapshotGasLastFrame` | Record gas usage of the last external call or contract creation |
 | `snapshotGasLastCall` | Deprecated call-only variant; use `snapshotGasLastFrame` |
 
+### EIP-8037 gas accounting
+
+A scalar snapshot is not a guaranteed total of regular and state gas. `snapshotGasLastFrame` and the deprecated `snapshotGasLastCall` use gas consumed from the regular counter: that can include state gas spilled into regular gas, but excludes state gas paid from the reservoir. For isolated frames with zero net state gas, they use the isolated transaction's receipt gas instead. They therefore need not equal `lastFrameGas().gasTotalUsed`.
+
+Section snapshots (`startSnapshotGas` / `stopSnapshotGas`) also measure regular gas-counter consumption and do not capture state gas paid from the reservoir. Use [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) to inspect regular and signed net state gas separately. Use receipt `gasUsed` for a mined transaction's total charged gas, and `eth_estimateGas` to estimate a sufficient transaction limit.
+
+Without EIP-8037, state creation costs use the ordinary gas schedule and there is no separate state reservoir to exclude. See [gas accounting](/forge/gas-accounting) and [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) for refunds, state refills, isolation, and network support.
+
 ### Configuration
 
 To enforce gas snapshot comparisons:

--- a/src/pages/reference/cheatcodes/gas-snapshots.mdx
+++ b/src/pages/reference/cheatcodes/gas-snapshots.mdx
@@ -34,7 +34,16 @@ These cheatcodes allow you to capture gas usage in your tests. Snapshots are wri
 
 ### EIP-8037 gas accounting
 
-A scalar snapshot is not a guaranteed total of regular and state gas. `snapshotGasLastFrame` and the deprecated `snapshotGasLastCall` use gas consumed from the regular counter: that can include state gas spilled into regular gas, but excludes state gas paid from the reservoir. For isolated frames with zero net state gas, they use the isolated transaction's receipt gas instead. They therefore need not equal `lastFrameGas().gasTotalUsed`.
+`snapshotGasLastFrame` and the deprecated `snapshotGasLastCall` record one gas number. Without isolation, they measure consumption of the regular gas counter, including state charges spilled into that counter and excluding charges paid from the reservoir.
+
+For an **isolated transaction**, the current snapshot value depends on its net state gas:
+
+| Net state gas in the isolated frame | Snapshot value |
+| --- | --- |
+| Positive (state created and retained) | Regular counter consumption before the ordinary refund, including any state spillover but excluding reservoir-funded state gas. |
+| Zero (no net state creation) | Receipt gas after ordinary refund and calldata-floor processing. |
+
+These are different accounting bases; keep the same workload and isolation mode when comparing snapshots. Use [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) for the separate components.
 
 Section snapshots (`startSnapshotGas` / `stopSnapshotGas`) also measure regular gas-counter consumption and do not capture state gas paid from the reservoir. Use [`lastFrameGas`](/reference/cheatcodes/last-frame-gas) to inspect regular and signed net state gas separately. Use receipt `gasUsed` for a mined transaction's total charged gas, and `eth_estimateGas` to estimate a sufficient transaction limit.
 

--- a/src/pages/reference/cheatcodes/last-frame-gas.mdx
+++ b/src/pages/reference/cheatcodes/last-frame-gas.mdx
@@ -24,7 +24,17 @@ function lastCallGas() external view returns (Gas memory gas);
 
 `lastFrameGas` returns gas measurements for the most recently completed external call or contract creation. The values are recorded from the callee's perspective, so they describe the child execution frame rather than all overhead paid by its caller.
 
-`lastCallGas` provides the same measurements but only records calls, not `CREATE` or `CREATE2`. It is deprecated; use `lastFrameGas` for new tests.
+### Is this just a rename of `lastCallGas`?
+
+No. Both return the same `Gas` struct and use the same gas accounting for a given call, but **`lastFrameGas` also records contract creation** (`CREATE` and `CREATE2`). `lastCallGas` only records calls and is deprecated; use `lastFrameGas` for new tests.
+
+| Most recently completed operation | `lastFrameGas()` | `lastCallGas()` |
+| --- | --- | --- |
+| An external call | Gas for that call | The same gas measurements for that call |
+| Contract creation whose constructor makes no external calls | Gas for the creation frame | Gas for the earlier call, or reverts if no call has been recorded |
+| Contract creation whose constructor makes external calls | Gas for the completed creation frame, including nested execution | Gas for the most recently completed call within the constructor |
+
+For example, after `target.setValue(42)` followed by `new GasTarget()` with no external calls in its constructor, `lastFrameGas()` describes the creation while `lastCallGas()` still describes `setValue`. Replacing `lastCallGas` with `lastFrameGas` therefore changes what you measure if a creation completes between the call you intended to measure and the measurement.
 
 Reading either value does not replace the recorded frame because cheatcode calls are excluded from this measurement.
 

--- a/src/pages/reference/cheatcodes/last-frame-gas.mdx
+++ b/src/pages/reference/cheatcodes/last-frame-gas.mdx
@@ -13,6 +13,7 @@ struct Gas {
     uint64 gasMemoryUsed;
     int64 gasRefunded;
     uint64 gasRemaining;
+    int64 gasStateUsed;
 }
 
 function lastFrameGas() external view returns (Gas memory gas);
@@ -31,11 +32,36 @@ Reading either value does not replace the recorded frame because cheatcode calls
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `gasLimit` | `uint64` | Gas limit available to the frame |
-| `gasTotalUsed` | `uint64` | Total gas spent by the frame |
-| `gasMemoryUsed` | `uint64` | Deprecated field that currently returns `0` |
-| `gasRefunded` | `int64` | Gas refund accumulated by the frame |
-| `gasRemaining` | `uint64` | Gas remaining when the frame completed |
+| `gasLimit` | `uint64` | Regular gas limit of the frame. Excludes the EIP-8037 state gas reservoir; it is not the transaction's combined limit or the minimum required to succeed. |
+| `gasTotalUsed` | `uint64` | Regular (execution) gas used, including nested execution, before subtracting `gasRefunded`. **Excludes EIP-8037 state gas.** With isolation, includes intrinsic gas and the regular-gas calldata floor. Without EIP-8037, state creation costs use the ordinary gas schedule and are included here. |
+| `gasMemoryUsed` | `uint64` | Deprecated; always `0`. Memory expansion costs are included in `gasTotalUsed`. |
+| `gasRefunded` | `int64` | Ordinary gas refund counter for the frame, which can be negative in a nested frame. Without isolation, this is before the transaction-wide refund cap and calldata floor. With isolation, this is the isolated transaction's final refund reported by the EVM. **Excludes state gas refills**, which are already reflected in `gasStateUsed`. Refunds do not provide gas to continue executing. |
+| `gasRemaining` | `uint64` | Regular gas remaining at completion. **Excludes the state gas reservoir.** State charges can draw from regular gas and state refills can restore it, so `gasLimit - gasRemaining` need not equal `gasTotalUsed`. |
+| `gasStateUsed` | `int64` | Net EIP-8037 state creation gas, including nested execution, **excluding regular gas** and already subtracting state refills. Zero without EIP-8037 and for reverted or halted frames. Can be negative when a successful nested frame undoes state creation charged by an earlier frame in the same transaction. Do not subtract `gasRefunded` from this value. |
+
+### Regular gas, state gas, and total gas
+
+[Regular gas and execution gas mean the same dimension](/forge/gas-accounting): computation, memory, access costs, and transaction intrinsic costs. [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) adds a separate **state gas** dimension for state creation, such as new storage slots, accounts, and deployed code. Reading or updating existing state still costs regular gas.
+
+When EIP-8037 is active, `gasTotalUsed` excludes state gas regardless of whether the state charge was paid from the reservoir or spilled into regular gas. An exceptional halt consumes the remaining regular allowance after state rollback; those consumed units are reported as regular gas and `gasStateUsed` is zero.
+
+For the net sum of the measured components, widen both fields to signed integers before adding them. This preserves negative nested-frame state deltas:
+
+```solidity [test/LastFrameGas.t.sol]
+// [!include ~/snippets/projects/cheatcodes/test/LastFrameGas.t.sol:components]
+```
+
+That sum is **not a gas-limit estimate**. You may need gas temporarily before a state refill, and the caller pays additional overhead. Call forwarding rules and the regular gas cap also constrain execution. A negative state delta is valid accounting, not a negative gas limit.
+
+Use the transaction receipt's `gasUsed` for the total charged by a mined transaction. It already includes regular and state gas, refunds, and the calldata floor. Do not add state gas again. Use `eth_estimateGas` on a node supporting the target network's rules to estimate the transaction gas limit. See [which gas value to use](/forge/gas-accounting#which-value-should-you-use).
+
+### Isolation and network support
+
+With isolation enabled, a top-level external call or creation in a test runs as a separate transaction. Its measurement includes transaction intrinsic gas, and `gasTotalUsed` uses the transaction's regular block-accounting contribution, including its calldata floor. The refund field is finalized for that isolated transaction. Without isolation, these are frame-local measurements: intrinsic gas and the caller's call setup are outside the frame, and the ordinary refund counter has not been finalized. Nested frames remain frame-local even within an isolated transaction.
+
+Do not reconstruct a receipt by blindly subtracting `gasRefunded` from the sum: frame scope, final refund handling, the calldata floor, and state charges incurred outside the child frame can differ. In particular, the isolated creation frame need not include an account-creation charge already paid by its caller.
+
+EIP-8037 behavior depends on the selected EVM/network rules. In Foundry's Ethereum EVM, it is enabled for `amsterdam` and later EVM versions. This does not mean every live Ethereum-compatible network has activated it. On an earlier fork or a network without EIP-8037, `gasStateUsed` is zero and state creation is still charged through the ordinary gas schedule in `gasTotalUsed`. See [network support](/forge/gas-accounting#which-networks-are-affected).
 
 ### Examples
 

--- a/src/pages/reference/cheatcodes/last-frame-gas.mdx
+++ b/src/pages/reference/cheatcodes/last-frame-gas.mdx
@@ -24,9 +24,9 @@ function lastCallGas() external view returns (Gas memory gas);
 
 `lastFrameGas` returns gas measurements for the most recently completed external call or contract creation. The values are recorded from the callee's perspective, so they describe the child execution frame rather than all overhead paid by its caller.
 
-### Is this just a rename of `lastCallGas`?
+### Comparison with `lastCallGas`
 
-No. Both return the same `Gas` struct and use the same gas accounting for a given call, but **`lastFrameGas` also records contract creation** (`CREATE` and `CREATE2`). `lastCallGas` only records calls and is deprecated; use `lastFrameGas` for new tests.
+`lastFrameGas` extends `lastCallGas` with **contract creation** (`CREATE` and `CREATE2`); it is more than a rename. Both return the same `Gas` struct and use the same gas accounting for a given call. `lastCallGas` only records calls and is deprecated; use `lastFrameGas` for new tests.
 
 | Most recently completed operation | `lastFrameGas()` | `lastCallGas()` |
 | --- | --- | --- |
@@ -55,10 +55,19 @@ Reading either value does not replace the recorded frame because cheatcode calls
 
 When EIP-8037 is active, `gasTotalUsed` excludes state gas regardless of whether the state charge was paid from the reservoir or spilled into regular gas. An exceptional halt consumes the remaining regular allowance after state rollback; those consumed units are reported as regular gas and `gasStateUsed` is zero.
 
-For the net sum of the measured components, widen both fields to signed integers before adding them. This preserves negative nested-frame state deltas:
+For the net sum of the measured components, widen both fields to signed integers before adding them. The example below disables isolation so both calls share one transaction: the second call undoes the first call's state creation and reports a negative state delta. With isolation enabled, the calls are separate transactions and clearing the slot reports zero state gas instead.
 
-```solidity [test/LastFrameGas.t.sol]
-// [!include ~/snippets/projects/cheatcodes/test/LastFrameGas.t.sol:components]
+Use Solidity 0.8.36, `evm_version = "amsterdam"`, and `experimental = true` for this example. The [complete example project](https://github.com/foundry-rs/book/tree/master/src/snippets/projects/gas-accounting) includes these settings. From that directory, install a current forge-std containing `gasStateUsed` and run:
+
+```bash
+$ forge install foundry-rs/forge-std --no-git
+$ forge test --match-contract StateGasTest -vv
+```
+
+The function's inline configuration disables isolation only for this test:
+
+```solidity [test/StateGas.t.sol]
+// [!include ~/snippets/projects/gas-accounting/test/StateGas.t.sol:components]
 ```
 
 That sum is **not a gas-limit estimate**. You may need gas temporarily before a state refill, and the caller pays additional overhead. Call forwarding rules and the regular gas cap also constrain execution. A negative state delta is valid accounting, not a negative gas limit.

--- a/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
+++ b/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
@@ -27,6 +27,24 @@ contract LastFrameGasTest is Test {
     }
     // [!endregion call]
 
+    // [!region components]
+    function testMeasureGasComponents() public {
+        GasTarget target = new GasTarget();
+        target.setValue(42);
+        Vm.Gas memory gas = vm.lastFrameGas();
+
+        uint256 regularGasUsed = uint256(gas.gasTotalUsed);
+        int256 netStateGasUsed = int256(gas.gasStateUsed);
+        int256 netMeasuredGas = int256(regularGasUsed) + netStateGasUsed;
+
+        // These are measured components, not a transaction gas-limit estimate.
+        emit log_named_uint("Regular gas (excludes state gas)", regularGasUsed);
+        emit log_named_int("State gas (after state refills)", netStateGasUsed);
+        emit log_named_int("Net sum of measured components", netMeasuredGas);
+        emit log_named_int("Ordinary refund (excludes state refills)", int256(gas.gasRefunded));
+    }
+    // [!endregion components]
+
     // [!region create]
     function testMeasureContractCreationFrame() public {
         new GasTarget();

--- a/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
+++ b/src/snippets/projects/cheatcodes/test/LastFrameGas.t.sol
@@ -27,24 +27,6 @@ contract LastFrameGasTest is Test {
     }
     // [!endregion call]
 
-    // [!region components]
-    function testMeasureGasComponents() public {
-        GasTarget target = new GasTarget();
-        target.setValue(42);
-        Vm.Gas memory gas = vm.lastFrameGas();
-
-        uint256 regularGasUsed = uint256(gas.gasTotalUsed);
-        int256 netStateGasUsed = int256(gas.gasStateUsed);
-        int256 netMeasuredGas = int256(regularGasUsed) + netStateGasUsed;
-
-        // These are measured components, not a transaction gas-limit estimate.
-        emit log_named_uint("Regular gas (excludes state gas)", regularGasUsed);
-        emit log_named_int("State gas (after state refills)", netStateGasUsed);
-        emit log_named_int("Net sum of measured components", netMeasuredGas);
-        emit log_named_int("Ordinary refund (excludes state refills)", int256(gas.gasRefunded));
-    }
-    // [!endregion components]
-
     // [!region create]
     function testMeasureContractCreationFrame() public {
         new GasTarget();

--- a/src/snippets/projects/gas-accounting/.gitignore
+++ b/src/snippets/projects/gas-accounting/.gitignore
@@ -1,0 +1,3 @@
+lib/
+out/
+cache/

--- a/src/snippets/projects/gas-accounting/foundry.toml
+++ b/src/snippets/projects/gas-accounting/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+solc = "0.8.36"
+evm_version = "amsterdam"
+experimental = true
+isolate = true

--- a/src/snippets/projects/gas-accounting/test/StateGas.t.sol
+++ b/src/snippets/projects/gas-accounting/test/StateGas.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract StateGasTarget {
+    uint256 public value;
+
+    function setValue(uint256 newValue) external {
+        value = newValue;
+    }
+}
+
+contract StateGasTest is Test {
+    // [!region components]
+    /// forge-config: default.isolate = false
+    function testNestedFrameCanRefillStateGas() public {
+        StateGasTarget target = new StateGasTarget();
+        target.setValue(42); // Creates a slot that was zero at transaction start.
+        assertGt(vm.lastFrameGas().gasStateUsed, 0);
+
+        target.setValue(0); // Clears it again: this frame refills state gas.
+        Vm.Gas memory gas = vm.lastFrameGas();
+        assertLt(gas.gasStateUsed, 0);
+
+        // Widen before adding: this is a signed measurement, not a gas-limit estimate.
+        int256 netMeasuredGas = int256(uint256(gas.gasTotalUsed)) + int256(gas.gasStateUsed);
+        emit log_named_int("Net sum of measured components", netMeasuredGas);
+    }
+    // [!endregion components]
+}


### PR DESCRIPTION
Add a gas-accounting guide explaining regular/execution gas, state gas, the reservoir, ordinary refunds versus state refills, and the distinction between frame measurements, charged receipt gas, block accounting, and required gas limits. Complete the `lastFrameGas` reference with `gasStateUsed` and explicit field boundaries, add an asserted negative-state-delta example in a standalone Amsterdam project, and clarify snapshot limitations, isolation, network activation, and RPC support.

Companion API documentation updates are in foundry-rs/foundry#16772, foundry-rs/forge-std#910, and alloy-rs/alloy#4195.

AI assistance: Codex authored the documentation, Solidity example, and PR description.
