### PR TITLE
feat(perf): restore bounded intraline highlighting

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -62,8 +62,13 @@ both files remain downloadable with bounded previews; the failed content pair st
 failed for the page session, with no automatic retries on revisits or visibility changes.
 Theme and split/unified changes reuse the computed diff. Syntax highlighting
 uses the library's worker pool (one worker, retained across file/compiler switches);
-intraline decorations are disabled because Shiki's decoration splitting becomes
-quadratic on generated files. Syntax colors and added/deleted line colors remain.
+intraline word decorations are enabled only when both sides together contain at most
+2,000 lines, 200 changed lines, and 32,768 characters. Lines longer than 256 characters
+skip word matching. Large diffs retain syntax colors and added/deleted line colors
+without intraline decorations, whose Shiki processing becomes quadratic on generated
+files. These are whole-diff limits: Pierre does not expose per-block decoration budgets.
+Changing between decorated and undecorated diffs clears the library's highlighting
+caches through `setRenderOptions`; the worker and our computed-diff cache are retained.
 `@pierre/diffs` 1.4.1 includes the large-hunk stack-overflow fix upstream;
 no dependency patch is needed. Its edit-session APIs are not used by this read-only viewer.
 `CodeView` owns the scroll container and virtualizes visible lines. File cache keys

--- a/perf/e2e/diffs.e2e.ts
+++ b/perf/e2e/diffs.e2e.ts
@@ -14,6 +14,7 @@ test('computes diff in a worker and reuses it for presentation changes', async (
   await expect(page.locator('.solar-diff')).toHaveCSS('overflow', 'auto')
   // A plain-text placeholder is not proof that worker highlighting succeeded.
   await expect(page.locator('diffs-container').locator('code span[style]').first()).toBeVisible()
+  await expect(page.locator('diffs-container').locator('[data-diff-span]').first()).toBeVisible()
   expect(workers).toBe(1)
   await page.getByRole('button', { name: 'Unified', exact: true }).click()
   await page.getByRole('button', { name: /Switch to .* theme/ }).click()
@@ -72,6 +73,7 @@ test('highlights a large repetitive assembly diff without expensive intraline de
   const code = page.locator('diffs-container').locator('code')
   // Include cold worker/grammar startup within the five-second rendering budget.
   await expect(code.locator('span[style]').first()).toBeVisible({ timeout: 5000 })
+  await expect(code.locator('[data-diff-span]')).toHaveCount(0)
   await expect(page.locator('diffs-container').locator('code[data-additions]')).toContainText(
     '0x11',
   )
@@ -80,6 +82,23 @@ test('highlights a large repetitive assembly diff without expensive intraline de
   )
   await page.locator('.solar-diff').press('End')
   await expect(code.first()).toContainText('40000')
+  // Changing policy must not leave the pool highlighting the next file incorrectly.
+  await page.getByRole('button', { name: 'optimized.yul', exact: true }).click()
+  await expect(code.locator('[data-diff-span]').first()).toBeVisible()
+  await page.getByRole('button', { name: 'runtime.disasm', exact: true }).click()
+  await expect(code.locator('span[style]').first()).toBeVisible({ timeout: 5000 })
+  await expect(code.locator('[data-diff-span]')).toHaveCount(0)
+})
+
+test('skips within-line matching for long lines in an otherwise small diff', async ({ page }) => {
+  await page.route('**/api/data/runs/**/1.json', (route) => {
+    const head = route.request().url().includes('9d8c7b6a5e4f32100123456789abcdef01234567')
+    return route.fulfill({ json: `PUSH32 ${'a'.repeat(256)}${head ? '1' : '0'}\n` })
+  })
+  await page.goto(url)
+  const code = page.locator('diffs-container').locator('code')
+  await expect(code.locator('span[style]').first()).toBeVisible()
+  await expect(code.locator('[data-diff-span]')).toHaveCount(0)
 })
 
 test('leaving a pending diff cannot replace the newly selected file', async ({ page }) => {

--- a/perf/src/ArtifactDiff.tsx
+++ b/perf/src/ArtifactDiff.tsx
@@ -1,6 +1,7 @@
-import { CodeView, WorkerPoolContextProvider } from '@pierre/diffs/react'
+import { CodeView, WorkerPoolContextProvider, useWorkerPool } from '@pierre/diffs/react'
 import type { FileContents, FileDiffMetadata } from '@pierre/diffs'
 import { computeDiff } from './computeDiff'
+import { intralineOptions } from './intralineOptions'
 import HighlightWorker from '@pierre/diffs/worker/worker.js?worker'
 import { useEffect, useState } from 'react'
 import { Info } from 'lucide-react'
@@ -26,8 +27,7 @@ export default function ArtifactDiff(props: Props) {
   return (
     <WorkerPoolContextProvider
       poolOptions={poolOptions}
-      // Intraline decorations make Shiki quadratic on large generated artifacts.
-      // Keep syntax highlighting and line-level additions/deletions.
+      // Start safely; computed diffs opt into bounded intraline highlighting.
       highlighterOptions={{ lineDiffType: 'none' }}
     >
       <ArtifactDiffContents
@@ -153,6 +153,7 @@ function ComputedDiff({
   style: Props['style']
   onStyleChange: Props['onStyleChange']
 }) {
+  const pool = useWorkerPool()
   const [diff, setDiff] = useState<FileDiffMetadata | null>(null)
   const [error, setError] = useState('')
   useEffect(() => {
@@ -160,16 +161,23 @@ function ComputedDiff({
     const { signal } = controller
     setDiff(null)
     setError('')
-    computeDiff(before, after, signal).then(
-      (value) => {
-        if (!signal.aborted) setDiff(value)
-      },
-      (error: Error) => {
-        if (!signal.aborted) setError(error.message)
-      },
-    )
+    computeDiff(before, after, signal)
+      .then(async (value) => {
+        if (signal.aborted) return value
+        // Pool options, not CodeView options, control worker highlighting.
+        await pool?.setRenderOptions(intralineOptions(value))
+        return value
+      })
+      .then(
+        (value) => {
+          if (!signal.aborted) setDiff(value)
+        },
+        (error: Error) => {
+          if (!signal.aborted) setError(error.message)
+        },
+      )
     return () => controller.abort()
-  }, [before, after])
+  }, [before, after, pool])
   if (error)
     return (
       <section className="large-artifact">
@@ -206,7 +214,12 @@ function ComputedDiff({
         className="solar-diff"
         style={{ height: '75vh', overflow: 'auto' }}
         items={[{ id: before.name, type: 'diff', fileDiff: diff }]}
-        options={{ diffStyle: style, overflow: 'scroll', themeType: theme }}
+        options={{
+          ...intralineOptions(diff),
+          diffStyle: style,
+          overflow: 'scroll',
+          themeType: theme,
+        }}
       />
     </div>
   )

--- a/perf/src/intralineOptions.ts
+++ b/perf/src/intralineOptions.ts
@@ -1,0 +1,14 @@
+import type { FileDiffMetadata, LineDiffTypes } from '@pierre/diffs'
+
+// Shiki applies decorations across the full file, even with a virtualized view.
+// Bound both the file and changed-line counts; a line-length limit alone is not enough.
+export function intralineOptions(diff: FileDiffMetadata) {
+  const lines = diff.additionLines.length + diff.deletionLines.length
+  const changed = diff.hunks.reduce((sum, hunk) => sum + hunk.additionLines + hunk.deletionLines, 0)
+  const bounded =
+    lines <= 2000 &&
+    changed <= 200 &&
+    [...diff.additionLines, ...diff.deletionLines].reduce((sum, line) => sum + line.length, 0) <=
+      32_768
+  return { lineDiffType: (bounded ? 'word-alt' : 'none') as LineDiffTypes, maxLineDiffLength: 256 }
+}

--- a/perf/tests/intralineOptions.test.ts
+++ b/perf/tests/intralineOptions.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import { processFile } from '@pierre/diffs'
+import { patiencePatch } from '../src/patiencePatch'
+import { intralineOptions } from '../src/intralineOptions'
+
+function options(before: string, after: string) {
+  return intralineOptions(
+    processFile(patiencePatch(before, after), {
+      oldFile: { name: 'test.asm', contents: before },
+      newFile: { name: 'test.asm', contents: after },
+      throwOnError: true,
+    })!,
+  )
+}
+
+test('enables bounded word matching for small diffs', () => {
+  expect(options('PUSH1 0x00\n', 'PUSH1 0x11\n')).toEqual({
+    lineDiffType: 'word-alt',
+    maxLineDiffLength: 256,
+  })
+})
+
+test('disables decorations for many changed lines', () => {
+  expect(options('ADD\n'.repeat(101), 'SUB\n'.repeat(101)).lineDiffType).toBe('none')
+})
+
+test('bounds whole-file decoration work even with few changes', () => {
+  const context = 'ADD\n'.repeat(1000)
+  expect(options(`${context}PUSH1 0x00\n`, `${context}PUSH1 0x11\n`).lineDiffType).toBe('none')
+})
+
+test('bounds character volume as well as line counts', () => {
+  expect(options('a'.repeat(20_000), 'b'.repeat(20_000)).lineDiffType).toBe('none')
+})


### PR DESCRIPTION
## Why

Disabling intraline decorations fixed pathological highlighting costs on large generated artifacts, but also removed useful changed-operand markings from small diffs.

## What

Restore Pierre's native word-level decorations when both sides together stay within 2,000 lines, 200 changed lines, and 32,768 characters. Individual lines over 256 characters skip word matching. Large diffs such as LibString keep syntax highlighting and line-level changes without intraline decorations.

This is a whole-diff policy, not per-block selection. Switching policies uses Pierre's public `setRenderOptions`, which clears its highlighting caches while retaining the worker and our computed-diff cache. No dependency patches or algorithm changes.

Local Chrome measurements with the production API: LibString rendered in 0.9–1.2 seconds; same-mode revisits took about 15 ms without new fetches. All 138 unit tests and 11 browser tests passed, including small/large mode switches and long-line limits. Operand markings were manually verified in Chrome; that capture was not saved as an uploadable screenshot. Production deployment remains unverified.

Implemented with AI assistance.
