### PR TITLE
docs: add slot number cheatcodes

### DIFF
--- a/sidebar/cmd-reference.ts
+++ b/sidebar/cmd-reference.ts
@@ -8,10 +8,12 @@ export const cmdReference: SidebarItem[] = [
     items: [
       { text: "warp", link: "/reference/cheatcodes/warp" },
       { text: "roll", link: "/reference/cheatcodes/roll" },
+      { text: "rollSlot", link: "/reference/cheatcodes/roll-slot" },
       { text: "setBlockhash", link: "/reference/cheatcodes/set-blockhash" },
       { text: "fee", link: "/reference/cheatcodes/fee" },
       { text: "getBlockTimestamp", link: "/reference/cheatcodes/get-block-timestamp" },
       { text: "getBlockNumber", link: "/reference/cheatcodes/get-block-number" },
+      { text: "getSlotNumber", link: "/reference/cheatcodes/get-slot-number" },
       { text: "difficulty", link: "/reference/cheatcodes/difficulty" },
       { text: "prevrandao", link: "/reference/cheatcodes/prevrandao" },
       { text: "chainId", link: "/reference/cheatcodes/chain-id" },

--- a/src/pages/reference/cheatcodes/get-block-number.mdx
+++ b/src/pages/reference/cheatcodes/get-block-number.mdx
@@ -43,3 +43,4 @@ You only need to use this cheatcode when compiling with `--via-ir`. Without IR c
 
 - [`roll`](/reference/cheatcodes/roll) - Sets `block.number`
 - [`getBlockTimestamp`](/reference/cheatcodes/get-block-timestamp) - Gets the current block timestamp (avoids IR optimization issues)
+- [`getSlotNumber`](/reference/cheatcodes/get-slot-number) - Gets the block slot number

--- a/src/pages/reference/cheatcodes/get-slot-number.mdx
+++ b/src/pages/reference/cheatcodes/get-slot-number.mdx
@@ -1,0 +1,51 @@
+---
+description: Gets the current block.slotnum.
+---
+
+## `getSlotNumber`
+
+### Signature
+
+```solidity
+function getSlotNumber() external view returns (uint64 slotNumber);
+```
+
+### Description
+
+Gets the current `block.slotnum`.
+
+Use this after `vm.rollSlot` to read the updated slot number. The Solidity compiler assumes `block.slotnum` is constant during a transaction and may optimize repeated reads away, especially with `--via-ir`. The cheatcode reads the current EVM value on every call.
+
+Requires the Amsterdam EVM hardfork or later and reverts on earlier versions. Slot numbers are unsigned 64-bit values, as defined by [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843).
+
+### Returns
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `slotNumber` | `uint64` | The current block slot number |
+
+Solidity exposes `block.slotnum` starting with version 0.8.37.
+
+### Examples
+
+With `evm_version = "amsterdam"` configured:
+
+```solidity [test/SlotNumber.t.sol]
+function testSlotNumber() public {
+    uint256 number = vm.getBlockNumber();
+    uint256 timestamp = vm.getBlockTimestamp();
+
+    vm.rollSlot(100);
+    assertEq(vm.getSlotNumber(), 100);
+    vm.rollSlot(101);
+    assertEq(vm.getSlotNumber(), 101);
+
+    assertEq(vm.getBlockNumber(), number);
+    assertEq(vm.getBlockTimestamp(), timestamp);
+}
+```
+
+### Related Cheatcodes
+
+- [`rollSlot`](/reference/cheatcodes/roll-slot) - Sets the slot number
+- [`getBlockNumber`](/reference/cheatcodes/get-block-number) - Gets the block number

--- a/src/pages/reference/cheatcodes/roll-slot.mdx
+++ b/src/pages/reference/cheatcodes/roll-slot.mdx
@@ -1,0 +1,52 @@
+---
+description: Sets block.slotnum to the specified value.
+---
+
+## `rollSlot`
+
+### Signature
+
+```solidity
+function rollSlot(uint64 newSlotNumber) external;
+```
+
+### Description
+
+Sets `block.slotnum` to the specified value.
+
+The slot number is independent of the block number and timestamp. Calling `rollSlot` does not change either value. You can move the slot number forwards or backwards, including to zero. Use [`vm.getSlotNumber()`](/reference/cheatcodes/get-slot-number) to read it after an update, because the compiler may optimize repeated `block.slotnum` reads away.
+
+Requires the Amsterdam EVM hardfork or later and reverts on earlier versions. Slot numbers are unsigned 64-bit values, as defined by [EIP-7843](https://eips.ethereum.org/EIPS/eip-7843).
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `newSlotNumber` | `uint64` | The new slot number, from 0 to 2^64 − 1 |
+
+Solidity exposes `block.slotnum` starting with version 0.8.37.
+
+### Examples
+
+With `evm_version = "amsterdam"` configured:
+
+```solidity [test/SlotNumber.t.sol]
+function testSlotNumber() public {
+    uint256 number = vm.getBlockNumber();
+    uint256 timestamp = vm.getBlockTimestamp();
+
+    vm.rollSlot(100);
+    assertEq(vm.getSlotNumber(), 100);
+    vm.rollSlot(101);
+    assertEq(vm.getSlotNumber(), 101);
+
+    assertEq(vm.getBlockNumber(), number);
+    assertEq(vm.getBlockTimestamp(), timestamp);
+}
+```
+
+### Related Cheatcodes
+
+- [`getSlotNumber`](/reference/cheatcodes/get-slot-number) - Gets the current slot number
+- [`roll`](/reference/cheatcodes/roll) - Sets the block number
+- [`warp`](/reference/cheatcodes/warp) - Sets the timestamp

--- a/src/pages/reference/cheatcodes/roll.mdx
+++ b/src/pages/reference/cheatcodes/roll.mdx
@@ -40,3 +40,4 @@ When using `--via-ir` compilation, direct access to `block.number` may be optimi
 - [`getBlockNumber`](/reference/cheatcodes/get-block-number) - Gets the current block number (avoids IR optimization issues)
 - [`rollFork`](/reference/cheatcodes/roll-fork) - Rolls the fork to a specific block
 - [`warp`](/reference/cheatcodes/warp) - Sets `block.timestamp`
+- [`rollSlot`](/reference/cheatcodes/roll-slot) - Sets the block slot number


### PR DESCRIPTION
Documents `vm.getSlotNumber()` and `vm.rollSlot(uint64)`, including Amsterdam availability, the uint64 range, compiler optimization behavior, and independence from block number and timestamp. Adds navigation and links from the existing block-number cheatcodes. Solidity calls the underlying variable `block.slotnum`, available starting in 0.8.37.

Depends on https://github.com/foundry-rs/foundry/pull/16784 and the bindings in https://github.com/foundry-rs/forge-std/pull/911.

AI assistance: Codex helped write and verify the documentation.
