### PR TITLE
feat(perf): improve diff navigation and pin benchmark sources

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -92,15 +92,30 @@ using Pierre's virtualized line positions. Changing the file, benchmark, or
 compiler clears the selection. Line numbers refer to the displayed artifact
 (including pretty-printed JSON).
 
-Benchmark source links load lazily from `/api/data/sources/<commit>.json`. The API
-reads literal source paths from `benches/runtime/cases.py` at that exact Solar
-commit (without executing Python), preserving historical archive locations.
-Checked-in sources and compressed inputs get Solar permalinks; known archives
-also link to their pinned upstream entrypoints and Lil Web3's Solmate dependencies.
-The archive provenance map lives in `src/sources.ts`; new upstream archives need
-verified provenance there. Unsupported catalog expressions display unavailable
-metadata, never a generic repository link. Catalogs are cached per commit in the
-browser, server, and CDN for an hour and require no database queries or GitHub token.
+Benchmark sources come from Solar's `source_links` result field (Solar PR #1449),
+validated during import and stored once per benchmark in `run_snapshots.source_links`.
+The existing run response includes these links; expanding a benchmark makes no
+source request. The browser never fetches or parses Solar's Python catalog.
+Historical results without source links are enriched by the importer from the
+catalog at their exact Solar commit, without executing Python. The old archive
+provenance map lives in `src/server/legacySources.ts`; new producer-supplied links
+need no dashboard mapping changes. Failed catalog reads do not block metrics
+publication and can be retried through the backend source backfill.
+
+Before deploying this change, apply the additive `source_links` column from
+`schema/snapshots.sql` using `pnpm run db:schema` with a schema-admin account.
+The read account needs SELECT on this column; a table-level SELECT grant already
+covers it. No new credentials are needed for the application itself.
+Then run `pnpm run db:backfill-sources` with write credentials to enrich all existing
+snapshots, including pinned revisions. It skips complete snapshots, preserves
+their original revision and `published_at` (so latest-run selection cannot change),
+and never downloads artifact bodies or modifies metrics/manifests. Failures stop
+the CLI with the unresolved commits reported; rerunning resumes unfinished rows.
+Alternatively, authenticated `POST /api/worker/backfill-sources` processes up to
+10 snapshots per call using the deployed worker's credentials and `CRON_SECRET`.
+Repeat until `scanned` is zero; resolve any `failed` commits before repeating.
+This maintenance endpoint does not run automatically on the import cron.
+Roll back by restoring the old deployment; the additive column can remain.
 
 Legacy artifact URLs remain supported through snapshot manifests and content hashes.
 Writers now populate only snapshots and blobs. Before retiring `runs`,

--- a/perf/README.md
+++ b/perf/README.md
@@ -85,6 +85,13 @@ DOM updates still run on the main thread. This follows the
 but do not eliminate computation time. The separate computation worker is necessary
 because `MultiFileDiff` calculates its Myers diff synchronously even with a highlighting pool.
 
+Click a line number to highlight it; Shift-click or drag across the gutter to
+select a range. Side-aware URL fragments (`#L12`, `#R12-R20`) preserve the
+selection. Opening a link reveals its collapsed context and scrolls to the line
+using Pierre's virtualized line positions. Changing the file, benchmark, or
+compiler clears the selection. Line numbers refer to the displayed artifact
+(including pretty-printed JSON).
+
 Benchmark source links load lazily from `/api/data/sources/<commit>.json`. The API
 reads literal source paths from `benches/runtime/cases.py` at that exact Solar
 commit (without executing Python), preserving historical archive locations.

--- a/perf/README.md
+++ b/perf/README.md
@@ -84,6 +84,17 @@ DOM updates still run on the main thread. This follows the
 [Diffs performance guidance](https://diffs.com/docs); workers keep the UI responsive,
 but do not eliminate computation time. The separate computation worker is necessary
 because `MultiFileDiff` calculates its Myers diff synchronously even with a highlighting pool.
+
+Benchmark source links load lazily from `/api/data/sources/<commit>.json`. The API
+reads literal source paths from `benches/runtime/cases.py` at that exact Solar
+commit (without executing Python), preserving historical archive locations.
+Checked-in sources and compressed inputs get Solar permalinks; known archives
+also link to their pinned upstream entrypoints and Lil Web3's Solmate dependencies.
+The archive provenance map lives in `src/sources.ts`; new upstream archives need
+verified provenance there. Unsupported catalog expressions display unavailable
+metadata, never a generic repository link. Catalogs are cached per commit in the
+browser, server, and CDN for an hour and require no database queries or GitHub token.
+
 Legacy artifact URLs remain supported through snapshot manifests and content hashes.
 Writers now populate only snapshots and blobs. Before retiring `runs`,
 `benchmark_results`, and `artifact_files`, rerun the additive backfill, verify

--- a/perf/README.md
+++ b/perf/README.md
@@ -71,7 +71,12 @@ Changing between decorated and undecorated diffs clears the library's highlighti
 caches through `setRenderOptions`; the worker and our computed-diff cache are retained.
 `@pierre/diffs` 1.4.1 includes the large-hunk stack-overflow fix upstream;
 no dependency patch is needed. Its edit-session APIs are not used by this read-only viewer.
-`CodeView` owns the scroll container and virtualizes visible lines. File cache keys
+`FileDiff`/`File` use Pierre's `Virtualizer` with `setup(document)` through
+`VirtualizerContext`: the browser page scrolls normally while only visible lines
+are rendered. The file toolbar and side labels stick during scrolling. The file
+tree can be collapsed or resized with a pointer or the separator's arrow keys;
+its visibility and width reset on reload. Narrow screens stack the tree above the
+diff and omit the resize handle. File cache keys
 include a SHA-256 of the actual formatted text, path, and language, preventing
 same-name artifacts from sharing highlighting. Completed diffs reuse the existing
 bounded cache (16 MiB, one hour); cancelled computations are not retained.

--- a/perf/e2e/diffs.e2e.ts
+++ b/perf/e2e/diffs.e2e.ts
@@ -3,6 +3,39 @@ import { expect, test } from '@playwright/test'
 const url =
   '/perf/solar/?base=8c7b6a5e4f32100123456789abcdef0123456789&head=9d8c7b6a5e4f32100123456789abcdef01234567&view=files&benchmark=demo::factorial&file=runtime.disasm'
 
+test('file tree resizes, collapses and resets on reload', async ({ page }) => {
+  await page.goto(url)
+  const sidebar = page.locator('#artifact-sidebar')
+  const handle = page.getByRole('separator', { name: 'Resize file tree' })
+  await expect(handle).toHaveAttribute('aria-valuenow', '270')
+  // Short files fill the viewport without an extra blank scrolling region.
+  expect(await page.evaluate(() => document.documentElement.scrollHeight)).toBe(
+    await page.evaluate(() => innerHeight),
+  )
+  const box = (await handle.boundingBox())!
+  await page.mouse.move(box.x + box.width / 2, box.y + 40)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width / 2 + 80, box.y + 40)
+  await page.mouse.up()
+  await expect(handle).toHaveAttribute('aria-valuenow', '350')
+  await handle.press('ArrowLeft')
+  await expect(handle).toHaveAttribute('aria-valuenow', '330')
+  await page.getByRole('button', { name: 'Hide file tree' }).click()
+  await expect(sidebar).toBeHidden()
+  await page.getByRole('button', { name: 'Show file tree' }).click()
+  await expect(sidebar).toBeVisible()
+  await expect(handle).toHaveAttribute('aria-valuenow', '330')
+  await page.getByRole('button', { name: 'Hide file tree' }).click()
+  await page.reload()
+  await expect(sidebar).toBeVisible()
+  await expect(handle).toHaveAttribute('aria-valuenow', '270')
+  await page.setViewportSize({ width: 390, height: 844 })
+  await expect(handle).toBeHidden()
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390)
+  await page.getByRole('button', { name: 'Hide file tree' }).click()
+  await expect(sidebar).toBeHidden()
+})
+
 test('computes diff in a worker and reuses it for presentation changes', async ({ page }) => {
   let workers = 0
   page.on('worker', (worker) => {
@@ -11,7 +44,7 @@ test('computes diff in a worker and reuses it for presentation changes', async (
   await page.goto(url)
   await expect(page.getByRole('button', { name: 'Unified', exact: true })).toBeVisible()
   await expect(page.locator('diffs-container').locator('pre')).toBeVisible()
-  await expect(page.locator('.solar-diff')).toHaveCSS('overflow', 'auto')
+  await expect(page.locator('.file-diff')).toHaveCSS('overflow', 'visible')
   // A plain-text placeholder is not proof that worker highlighting succeeded.
   await expect(page.locator('diffs-container').locator('code span[style]').first()).toBeVisible()
   await expect(page.locator('diffs-container').locator('[data-diff-span]').first()).toBeVisible()
@@ -54,9 +87,15 @@ test('virtualizes long files and renders their last lines on scroll', async ({ p
   const code = page.locator('diffs-container').locator('code')
   await expect(code).toContainText('0x0000')
   await expect(code).not.toContainText('0x07cf')
-  await page.locator('.solar-diff').press('End')
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
   await expect(code).toContainText('0x07cf')
   await expect(code).not.toContainText('0x0000')
+  expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(1000)
+  expect((await page.locator('.viewer-toolbar').boundingBox())!.y).toBe(0)
+  expect((await page.locator('.diff-sides').boundingBox())!.y).toBe(48)
+  await page.getByRole('button', { name: 'abi.json', exact: true }).click()
+  await expect(page.locator('.viewer-filename')).toHaveText('abi.json')
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
 })
 
 test('highlights a large repetitive assembly diff without expensive intraline decorations', async ({
@@ -80,7 +119,7 @@ test('highlights a large repetitive assembly diff without expensive intraline de
   await expect(page.locator('diffs-container').locator('code[data-deletions]')).toContainText(
     '0x00',
   )
-  await page.locator('.solar-diff').press('End')
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
   await expect(code.first()).toContainText('40000')
   // Changing policy must not leave the pool highlighting the next file incorrectly.
   await page.getByRole('button', { name: 'optimized.yul', exact: true }).click()

--- a/perf/e2e/lines.e2e.ts
+++ b/perf/e2e/lines.e2e.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+const url =
+  '/perf/solar/?base=8c7b6a5e4f32100123456789abcdef0123456789&head=9d8c7b6a5e4f32100123456789abcdef01234567&view=files&benchmark=demo::factorial&file=runtime.disasm'
+
+test('gutter clicks and Shift-click ranges update sharable side-aware anchors', async ({
+  page,
+}) => {
+  await page.goto(url)
+  const right = page.locator('diffs-container code[data-additions]')
+  const left = page.locator('diffs-container code[data-deletions]')
+  await right.locator('[data-column-number="2"]').click()
+  await expect(page).toHaveURL(/#R2$/)
+  await expect(right.locator('[data-column-number="2"]')).toHaveAttribute('data-selected-line')
+  await right.locator('[data-column-number="4"]').click({ modifiers: ['Shift'] })
+  await expect(page).toHaveURL(/#R2-R4$/)
+  await page.reload()
+  await expect(right.locator('[data-column-number="3"]')).toHaveAttribute('data-selected-line')
+  await left.locator('[data-column-number="2"]').click()
+  await expect(page).toHaveURL(/#L2$/)
+  await page.getByRole('button', { name: 'Unified', exact: true }).click()
+  await expect(
+    page.locator('diffs-container [data-column-number="2"][data-selected-line]').first(),
+  ).toBeVisible()
+  await page.getByRole('combobox', { name: 'Right', exact: true }).selectOption('head:solx')
+  await expect(page).not.toHaveURL(/#/)
+  await expect(page.locator('diffs-container [data-selected-line]')).toHaveCount(0)
+})
+
+for (const identical of [false, true]) {
+  test(`deep links reveal virtualized ${identical ? 'identical' : 'collapsed diff'} lines`, async ({
+    page,
+  }) => {
+    await page.route('**/api/data/runs/**/1.json', (route) => {
+      const head = route.request().url().includes('9d8c7b6a5e4f32100123456789abcdef01234567')
+      return route.fulfill({
+        json: Array.from(
+          { length: 2000 },
+          (_, i) => `PUSH2 ${i === 1000 && head && !identical ? 'changed' : i}`,
+        ).join('\n'),
+      })
+    })
+    await page.goto(`${url}#R1800-R1802`)
+    const line = page
+      .locator('diffs-container [data-column-number="1800"][data-selected-line]')
+      .last()
+    await expect(line).toBeVisible()
+    await expect.poll(async () => (await line.boundingBox())?.y).toBeGreaterThanOrEqual(80)
+    expect((await line.boundingBox())!.y).toBeLessThan(200)
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(1000)
+    await page.getByRole('button', { name: 'abi.json', exact: true }).click()
+    await expect(page).not.toHaveURL(/#/)
+    await expect(page.locator('diffs-container [data-selected-line]')).toHaveCount(0)
+  })
+}

--- a/perf/e2e/sources.e2e.ts
+++ b/perf/e2e/sources.e2e.ts
@@ -1,19 +1,21 @@
 import { expect, test } from '@playwright/test'
 
-test('loads pinned sources only when expanded and reuses the commit catalog', async ({ page }) => {
+test('shows imported source links without a separate source request', async ({ page }) => {
   let requests = 0
   const source =
     'https://github.com/paradigmxyz/solar/blob/9d8c7b6a5e4f32100123456789abcdef01234567/testdata/Factorial.sol'
-  await page.route('**/api/data/sources/*.json', (route) => {
-    requests++
-    return route.fulfill({
-      json: {
-        'demo::factorial': [{ label: 'Factorial.sol', url: source }],
-        'demo::fibonacci': [
-          { label: 'Fibonacci.sol', url: source.replace('Factorial', 'Fibonacci') },
-        ],
-      },
-    })
+  page.on('request', (request) => {
+    if (request.url().includes('/api/data/sources/')) requests++
+  })
+  await page.route('**/api/data/runs.json?*', async (route) => {
+    const response = await route.fetch()
+    const data = await response.json()
+    for (const run of data.runs)
+      for (const result of run.results) {
+        const name = result.test_id === 'demo::factorial' ? 'Factorial' : 'Fibonacci'
+        result.source_links = [{ label: `${name}.sol`, url: source.replace('Factorial', name) }]
+      }
+    await route.fulfill({ json: data })
   })
   await page.goto(
     '/perf/solar/?base=8c7b6a5e4f32100123456789abcdef0123456789&head=9d8c7b6a5e4f32100123456789abcdef01234567',
@@ -27,6 +29,6 @@ test('loads pinned sources only when expanded and reuses the commit catalog', as
   )
   await page.getByRole('button', { name: /demo::fibonacci/ }).click()
   await expect(page.getByRole('link', { name: 'Fibonacci.sol ↗', exact: true })).toBeVisible()
-  expect(requests).toBe(1)
+  expect(requests).toBe(0)
   await expect(page.getByRole('link', { name: 'Solar repository' })).toHaveCount(0)
 })

--- a/perf/e2e/sources.e2e.ts
+++ b/perf/e2e/sources.e2e.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+
+test('loads pinned sources only when expanded and reuses the commit catalog', async ({ page }) => {
+  let requests = 0
+  const source =
+    'https://github.com/paradigmxyz/solar/blob/9d8c7b6a5e4f32100123456789abcdef01234567/testdata/Factorial.sol'
+  await page.route('**/api/data/sources/*.json', (route) => {
+    requests++
+    return route.fulfill({
+      json: {
+        'demo::factorial': [{ label: 'Factorial.sol', url: source }],
+        'demo::fibonacci': [
+          { label: 'Fibonacci.sol', url: source.replace('Factorial', 'Fibonacci') },
+        ],
+      },
+    })
+  })
+  await page.goto(
+    '/perf/solar/?base=8c7b6a5e4f32100123456789abcdef0123456789&head=9d8c7b6a5e4f32100123456789abcdef01234567',
+  )
+  await expect(page.getByRole('button', { name: /demo::factorial/ })).toBeVisible()
+  expect(requests).toBe(0)
+  await page.getByRole('button', { name: /demo::factorial/ }).click()
+  await expect(page.getByRole('link', { name: 'Factorial.sol ↗', exact: true })).toHaveAttribute(
+    'href',
+    source,
+  )
+  await page.getByRole('button', { name: /demo::fibonacci/ }).click()
+  await expect(page.getByRole('link', { name: 'Fibonacci.sol ↗', exact: true })).toBeVisible()
+  expect(requests).toBe(1)
+  await expect(page.getByRole('link', { name: 'Solar repository' })).toHaveCount(0)
+})

--- a/perf/package.json
+++ b/perf/package.json
@@ -9,6 +9,7 @@
     "check": "vp check",
     "dev": "vp dev",
     "db:backfill": "node scripts/ingest-github-runs.mjs",
+    "db:backfill-sources": "node scripts/backfill-sources.mjs",
     "db:schema": "node scripts/apply-schema.mjs",
     "db:verify": "node scripts/verify-clickhouse.mjs",
     "format": "vp fmt",

--- a/perf/schema/snapshots.sql
+++ b/perf/schema/snapshots.sql
@@ -1,5 +1,6 @@
--- Immutable publication rows: all measurements and manifest entries become
+-- Immutable artifact publications: all measurements and manifest entries become
 -- visible together. No import-time partitions or cross-table latest-row joins.
+-- source_links is additive provenance and may be backfilled on existing revisions.
 CREATE TABLE IF NOT EXISTS run_snapshots (
   commit FixedString(40),
   revision FixedString(64),
@@ -19,10 +20,14 @@ CREATE TABLE IF NOT EXISTS run_snapshots (
   artifacts Array(Tuple(
     test_id String, path String, compiler String, bytes UInt64,
     content_sha256 String, legacy_storage_path String)),
+  source_links Map(String, Array(Tuple(label String, url String))) DEFAULT map(),
   published_at DateTime64(3, 'UTC') DEFAULT now64(3)
 ) ENGINE = ReplacingMergeTree
 ORDER BY (commit, revision)
 SETTINGS index_granularity = 1, index_granularity_bytes = 1048576;
+
+ALTER TABLE run_snapshots ADD COLUMN IF NOT EXISTS
+  source_links Map(String, Array(Tuple(label String, url String))) DEFAULT map();
 
 CREATE TABLE IF NOT EXISTS artifact_blobs (
   content_sha256 FixedString(64),

--- a/perf/scripts/backfill-sources.mjs
+++ b/perf/scripts/backfill-sources.mjs
@@ -1,0 +1,15 @@
+import { backfillSources } from '../src/server/backfillSources.ts'
+import { clickHouseConfig } from '../src/server/clickhouse.ts'
+
+const config = clickHouseConfig(process.env, 'write')
+if (!config) throw new Error('ClickHouse write credentials are not configured')
+let total = 0
+while (true) {
+  const result = await backfillSources(config, 100)
+  total += result.updated
+  console.log(JSON.stringify({ ...result, total }))
+  // Stop on unresolved metadata rather than repeatedly scanning the same rows.
+  if (result.failed.length)
+    throw new Error('Some snapshots need source provenance; see failures above')
+  if (!result.scanned) break
+}

--- a/perf/scripts/ingest-run.mjs
+++ b/perf/scripts/ingest-run.mjs
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path'
 
 import { insert } from './lib/clickhouse.mjs'
 import { normalizeResults } from '../src/server/normalizeResults.ts'
+import { enrichSources } from '../src/server/benchmarkSources.ts'
 import { publication, publicationBlobs } from '../src/server/publication.ts'
 import {
   artifactMetadata,
@@ -127,6 +128,9 @@ const results = normalizeResults(document, {
   commit: run.commit,
 })
 const artifacts = await normalizeArtifacts(resolve(options.artifacts), { ...run, results })
+await enrichSources(run.commit, results).catch((error) =>
+  console.warn('Could not enrich historical benchmark sources', error.message),
+)
 await insert('artifact_blobs', publicationBlobs(artifacts))
 await insert('run_snapshots', [publication({ ...run, run_attempt: attempt }, results, artifacts)])
 console.log(`Ingested ${run.commit.slice(0, 8)} from workflow run ${run.workflow_run_id}`)

--- a/perf/src/ArtifactDiff.tsx
+++ b/perf/src/ArtifactDiff.tsx
@@ -9,6 +9,7 @@ import { Virtualizer } from '@pierre/diffs'
 import type { FileContents, FileDiffMetadata } from '@pierre/diffs'
 import { computeDiff } from './computeDiff'
 import { intralineOptions } from './intralineOptions'
+import { useLineSelection } from './lineSelection'
 import HighlightWorker from '@pierre/diffs/worker/worker.js?worker'
 import { useEffect, useState } from 'react'
 import { Info } from 'lucide-react'
@@ -119,11 +120,7 @@ function ArtifactDiffContents({ before, after, path, language, theme, style }: P
               ? `Published only by ${before.label}.`
               : 'Contents are identical.'}
         </p>
-        <File
-          className="solar-diff"
-          file={oldFile ?? newFile!}
-          options={{ overflow: 'scroll', themeType: theme, disableFileHeader: true }}
-        />
+        <SelectedFile file={oldFile ?? newFile!} theme={theme} side={newFile ? 'R' : 'L'} />
       </>
     )
   }
@@ -135,6 +132,23 @@ function ArtifactDiffContents({ before, after, path, language, theme, style }: P
       afterLabel={after.label}
       theme={theme}
       style={style}
+    />
+  )
+}
+
+function SelectedFile({ file, theme, side }: { file: FileContents; theme: Theme; side: string }) {
+  const selection = useLineSelection(file.name, undefined, side)
+  return (
+    <File
+      className="solar-diff"
+      file={file}
+      selectedLines={selection.selectedLines}
+      options={{
+        ...selection.options,
+        overflow: 'scroll',
+        themeType: theme,
+        disableFileHeader: true,
+      }}
     />
   )
 }
@@ -156,6 +170,7 @@ function ComputedDiff({
 }) {
   const pool = useWorkerPool()
   const [diff, setDiff] = useState<FileDiffMetadata | null>(null)
+  const selection = useLineSelection(after.name, diff ?? undefined)
   const [error, setError] = useState('')
   useEffect(() => {
     const controller = new AbortController()
@@ -199,7 +214,9 @@ function ComputedDiff({
     <FileDiff
       className="solar-diff"
       fileDiff={diff}
+      selectedLines={selection.selectedLines}
       options={{
+        ...selection.options,
         ...intralineOptions(diff),
         disableFileHeader: true,
         diffStyle: style,

--- a/perf/src/ArtifactDiff.tsx
+++ b/perf/src/ArtifactDiff.tsx
@@ -1,4 +1,11 @@
-import { CodeView, WorkerPoolContextProvider, useWorkerPool } from '@pierre/diffs/react'
+import {
+  File,
+  FileDiff,
+  VirtualizerContext,
+  WorkerPoolContextProvider,
+  useWorkerPool,
+} from '@pierre/diffs/react'
+import { Virtualizer } from '@pierre/diffs'
 import type { FileContents, FileDiffMetadata } from '@pierre/diffs'
 import { computeDiff } from './computeDiff'
 import { intralineOptions } from './intralineOptions'
@@ -15,7 +22,6 @@ interface Props {
   language: string
   theme: Theme
   style: 'split' | 'unified'
-  onStyleChange: (style: 'split' | 'unified') => void
 }
 
 const poolOptions = {
@@ -24,29 +30,28 @@ const poolOptions = {
 }
 
 export default function ArtifactDiff(props: Props) {
+  const [virtualizer] = useState(() => new Virtualizer())
+  useEffect(() => {
+    virtualizer.setup(document)
+    return () => virtualizer.cleanUp()
+  }, [virtualizer])
   return (
-    <WorkerPoolContextProvider
-      poolOptions={poolOptions}
-      // Start safely; computed diffs opt into bounded intraline highlighting.
-      highlighterOptions={{ lineDiffType: 'none' }}
-    >
-      <ArtifactDiffContents
-        key={JSON.stringify([props.before, props.after, props.path, props.language])}
-        {...props}
-      />
-    </WorkerPoolContextProvider>
+    <VirtualizerContext.Provider value={virtualizer}>
+      <WorkerPoolContextProvider
+        poolOptions={poolOptions}
+        // Start safely; computed diffs opt into bounded intraline highlighting.
+        highlighterOptions={{ lineDiffType: 'none' }}
+      >
+        <ArtifactDiffContents
+          key={JSON.stringify([props.before, props.after, props.path, props.language])}
+          {...props}
+        />
+      </WorkerPoolContextProvider>
+    </VirtualizerContext.Provider>
   )
 }
 
-function ArtifactDiffContents({
-  before,
-  after,
-  path,
-  language,
-  theme,
-  style,
-  onStyleChange,
-}: Props) {
+function ArtifactDiffContents({ before, after, path, language, theme, style }: Props) {
   const [contents, setContents] = useState<[FileContents | null, FileContents | null] | null>(null)
   const [error, setError] = useState('')
   useEffect(() => {
@@ -114,11 +119,10 @@ function ArtifactDiffContents({
               ? `Published only by ${before.label}.`
               : 'Contents are identical.'}
         </p>
-        <CodeView
+        <File
           className="solar-diff"
-          style={{ height: '75vh', overflow: 'auto' }}
-          items={[{ id: path, type: 'file', file: oldFile ?? newFile! }]}
-          options={{ overflow: 'scroll', themeType: theme }}
+          file={oldFile ?? newFile!}
+          options={{ overflow: 'scroll', themeType: theme, disableFileHeader: true }}
         />
       </>
     )
@@ -131,7 +135,6 @@ function ArtifactDiffContents({
       afterLabel={after.label}
       theme={theme}
       style={style}
-      onStyleChange={onStyleChange}
     />
   )
 }
@@ -143,7 +146,6 @@ function ComputedDiff({
   afterLabel,
   theme,
   style,
-  onStyleChange,
 }: {
   before: FileContents
   after: FileContents
@@ -151,7 +153,6 @@ function ComputedDiff({
   afterLabel: string
   theme: Theme
   style: Props['style']
-  onStyleChange: Props['onStyleChange']
 }) {
   const pool = useWorkerPool()
   const [diff, setDiff] = useState<FileDiffMetadata | null>(null)
@@ -164,7 +165,7 @@ function ComputedDiff({
     computeDiff(before, after, signal)
       .then(async (value) => {
         if (signal.aborted) return value
-        // Pool options, not CodeView options, control worker highlighting.
+        // Pool options, not FileDiff options, control worker highlighting.
         await pool?.setRenderOptions(intralineOptions(value))
         return value
       })
@@ -195,33 +196,17 @@ function ComputedDiff({
       </p>
     )
   return (
-    <div className="artifact-diff">
-      <div className="diff-tools">
-        <button
-          className={style === 'split' ? 'active' : ''}
-          onClick={() => onStyleChange('split')}
-        >
-          Split
-        </button>
-        <button
-          className={style === 'unified' ? 'active' : ''}
-          onClick={() => onStyleChange('unified')}
-        >
-          Unified
-        </button>
-      </div>
-      <CodeView
-        className="solar-diff"
-        style={{ height: '75vh', overflow: 'auto' }}
-        items={[{ id: before.name, type: 'diff', fileDiff: diff }]}
-        options={{
-          ...intralineOptions(diff),
-          diffStyle: style,
-          overflow: 'scroll',
-          themeType: theme,
-        }}
-      />
-    </div>
+    <FileDiff
+      className="solar-diff"
+      fileDiff={diff}
+      options={{
+        ...intralineOptions(diff),
+        disableFileHeader: true,
+        diffStyle: style,
+        overflow: 'scroll',
+        themeType: theme,
+      }}
+    />
   )
 }
 
@@ -248,7 +233,7 @@ function LargeArtifact({
           Download {path}
         </a>
       )}
-      <pre style={{ overflow: 'auto', maxHeight: '50vh' }}>{contents.slice(0, 20_000)}</pre>
+      <pre style={{ overflowX: 'auto' }}>{contents.slice(0, 20_000)}</pre>
     </section>
   )
 }

--- a/perf/src/BenchmarkSources.tsx
+++ b/perf/src/BenchmarkSources.tsx
@@ -1,31 +1,6 @@
-import { useEffect, useState } from 'react'
-import { responseCache } from './cache'
-import type { SourceLink } from './sources'
+import type { SourceLink } from './types'
 
-const catalogs = responseCache<Record<string, SourceLink[]>>(3_600_000, 2 * 1024 * 1024)
-
-export function BenchmarkSources({ benchmark, commit }: { benchmark: string; commit: string }) {
-  const [links, setLinks] = useState<SourceLink[] | null>(null)
-  useEffect(() => {
-    let cancelled = false
-    setLinks(null)
-    catalogs(commit, async () => {
-      const response = await fetch(`/api/data/sources/${commit}.json`)
-      if (!response.ok) throw new Error('Source metadata unavailable')
-      return response.json()
-    }).then(
-      (catalog) => {
-        if (!cancelled) setLinks(Object.hasOwn(catalog, benchmark) ? catalog[benchmark] : [])
-      },
-      () => {
-        if (!cancelled) setLinks([])
-      },
-    )
-    return () => {
-      cancelled = true
-    }
-  }, [benchmark, commit])
-  if (links === null) return <span>Loading sources…</span>
+export function BenchmarkSources({ links = [] }: { links?: SourceLink[] }) {
   if (!links.length) return <span>Source metadata unavailable.</span>
   return links.map((link) => (
     <a key={link.url} href={link.url}>

--- a/perf/src/BenchmarkSources.tsx
+++ b/perf/src/BenchmarkSources.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { responseCache } from './cache'
+import type { SourceLink } from './sources'
+
+const catalogs = responseCache<Record<string, SourceLink[]>>(3_600_000, 2 * 1024 * 1024)
+
+export function BenchmarkSources({ benchmark, commit }: { benchmark: string; commit: string }) {
+  const [links, setLinks] = useState<SourceLink[] | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    setLinks(null)
+    catalogs(commit, async () => {
+      const response = await fetch(`/api/data/sources/${commit}.json`)
+      if (!response.ok) throw new Error('Source metadata unavailable')
+      return response.json()
+    }).then(
+      (catalog) => {
+        if (!cancelled) setLinks(Object.hasOwn(catalog, benchmark) ? catalog[benchmark] : [])
+      },
+      () => {
+        if (!cancelled) setLinks([])
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [benchmark, commit])
+  if (links === null) return <span>Loading sources…</span>
+  if (!links.length) return <span>Source metadata unavailable.</span>
+  return links.map((link) => (
+    <a key={link.url} href={link.url}>
+      {link.label} ↗
+    </a>
+  ))
+}

--- a/perf/src/Compare.tsx
+++ b/perf/src/Compare.tsx
@@ -248,7 +248,7 @@ export function Compare({ base, head }: Props) {
                     <a href={fileViewerHref(runs[0], runs[1], after.test_id, metrics[metric].key)}>
                       Artifacts diff viewer →
                     </a>
-                    <BenchmarkSources benchmark={after.test_id} commit={headResult ? head : base} />
+                    <BenchmarkSources links={after.source_links} />
                   </aside>
                 </section>
               )}

--- a/perf/src/Compare.tsx
+++ b/perf/src/Compare.tsx
@@ -3,7 +3,7 @@ import { BenchmarkHistory } from './BenchmarkHistory'
 import { changeClass, formatChange } from './change'
 import { formatRawValue, formatValue } from './formatValue'
 import { loadHistory, loadRun } from './data'
-import { benchmarkSource } from './sources'
+import { BenchmarkSources } from './BenchmarkSources'
 import type { RunDocument, Theme } from './types'
 import { benchmarkMetric as value } from './benchmarkMetric'
 import { replaceUrl } from './navigation'
@@ -186,7 +186,6 @@ export function Compare({ base, head }: Props) {
         {rows.map(({ before, headResult, result: after }) => {
           const selected = expanded === after.test_id
           const headValue = value(headResult, metrics[metric].key)
-          const source = benchmarkSource(after.test_id, head)
           return (
             <div key={after.test_id} className="benchmark-row">
               <button
@@ -249,7 +248,7 @@ export function Compare({ base, head }: Props) {
                     <a href={fileViewerHref(runs[0], runs[1], after.test_id, metrics[metric].key)}>
                       Artifacts diff viewer →
                     </a>
-                    <a href={source.url}>{source.label} ↗</a>
+                    <BenchmarkSources benchmark={after.test_id} commit={headResult ? head : base} />
                   </aside>
                 </section>
               )}

--- a/perf/src/FileViewer.tsx
+++ b/perf/src/FileViewer.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { artifactTree, mergeArtifactFiles, type ArtifactNode } from './artifactTree'
 import { loadArtifact, loadViewerRuns } from './data'
 import { useImportProgress } from './importProgress'
@@ -64,6 +65,15 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
   const [sides, setSides] = useState(() => initialArtifactSides(params))
   const [selected, setSelected] = useState(params.get('file') || '')
   const [diffStyle, setDiffStyle] = useState<'split' | 'unified'>('split')
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarWidth, setSidebarWidth] = useState(270)
+  const drag = useRef<{ x: number; width: number } | null>(null)
+  const resizeSidebar = (width: number) => setSidebarWidth(Math.max(200, Math.min(480, width)))
+
+  useEffect(() => {
+    // A new file starts at its first line, rather than the previous file's page offset.
+    window.scrollTo({ top: 0, behavior: 'instant' })
+  }, [selected, activeBenchmark, sides.left, sides.right])
 
   useEffect(() => {
     let cancelled = false
@@ -167,7 +177,35 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
   }
 
   return (
-    <main className="file-viewer">
+    <main
+      className="file-viewer"
+      style={{ '--sidebar-width': `${sidebarWidth}px` } as CSSProperties}
+    >
+      <div className="viewer-toolbar">
+        <button
+          aria-label={sidebarOpen ? 'Hide file tree' : 'Show file tree'}
+          aria-expanded={sidebarOpen}
+          aria-controls="artifact-sidebar"
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+        >
+          {sidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
+        </button>
+        <span className="viewer-filename" title={selectedFile?.path}>
+          {selectedFile?.path || 'Artifacts'}
+        </span>
+        <div className="diff-tools" aria-label="Diff layout">
+          {(['split', 'unified'] as const).map((style) => (
+            <button
+              key={style}
+              className={diffStyle === style ? 'active' : ''}
+              aria-pressed={diffStyle === style}
+              onClick={() => setDiffStyle(style)}
+            >
+              {style === 'split' ? 'Split' : 'Unified'}
+            </button>
+          ))}
+        </div>
+      </div>
       {loadError ? (
         <p className="error">{loadError}</p>
       ) : !runs ? (
@@ -175,8 +213,8 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
           {importProgress || 'Loading files…'}
         </p>
       ) : (
-        <div className="file-viewer-body">
-          <aside>
+        <div className={`file-viewer-body${sidebarOpen ? '' : ' sidebar-collapsed'}`}>
+          <aside id="artifact-sidebar" hidden={!sidebarOpen}>
             <div className="file-selector-head">
               <select
                 aria-label="Benchmark"
@@ -238,6 +276,46 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
               />
             )}
           </aside>
+          {sidebarOpen && (
+            <div
+              className="sidebar-resizer"
+              role="separator"
+              aria-label="Resize file tree"
+              aria-orientation="vertical"
+              aria-controls="artifact-sidebar"
+              aria-valuemin={200}
+              aria-valuemax={480}
+              aria-valuenow={sidebarWidth}
+              tabIndex={0}
+              onPointerDown={(event) => {
+                if (event.button !== 0) return
+                drag.current = { x: event.clientX, width: sidebarWidth }
+                event.currentTarget.setPointerCapture(event.pointerId)
+                event.preventDefault()
+              }}
+              onPointerMove={(event) => {
+                if (drag.current) resizeSidebar(drag.current.width + event.clientX - drag.current.x)
+              }}
+              onPointerUp={(event) => {
+                drag.current = null
+                event.currentTarget.releasePointerCapture(event.pointerId)
+              }}
+              onLostPointerCapture={() => {
+                drag.current = null
+              }}
+              onKeyDown={(event) => {
+                if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+                event.preventDefault()
+                resizeSidebar(
+                  event.key === 'Home'
+                    ? 200
+                    : event.key === 'End'
+                      ? 480
+                      : sidebarWidth + (event.key === 'ArrowLeft' ? -20 : 20),
+                )
+              }}
+            />
+          )}
           <div className="file-diff">
             {loading ? (
               <p className="empty" role="status">
@@ -282,7 +360,6 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
                     language={selectedFile.language}
                     theme={theme}
                     style={diffStyle}
-                    onStyleChange={setDiffStyle}
                   />
                 </Suspense>
               </>

--- a/perf/src/FileViewer.tsx
+++ b/perf/src/FileViewer.tsx
@@ -168,6 +168,7 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
   const updateUrl = (key: string, value: string) => {
     const url = new URL(window.location.href)
     url.searchParams.set(key, value)
+    url.hash = ''
     if (key === 'benchmark') url.searchParams.delete('file')
     replaceUrl(url)
   }
@@ -246,6 +247,7 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
                       url.searchParams.set('right', next.right)
                       url.searchParams.delete('compiler')
                       url.searchParams.delete('against')
+                      url.hash = ''
                       replaceUrl(url)
                     }}
                   >

--- a/perf/src/lineSelection.ts
+++ b/perf/src/lineSelection.ts
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react'
+import { VirtualizedFile, VirtualizedFileDiff } from '@pierre/diffs'
+import type {
+  File,
+  FileDiff,
+  FileDiffMetadata,
+  SelectedLineRange,
+  PostRenderPhase,
+} from '@pierre/diffs'
+
+export function parseLineHash(hash: string): SelectedLineRange | null {
+  const match = /^#([LR])(\d+)(?:-([LR])(\d+))?$/.exec(hash)
+  if (!match) return null
+  const start = Number(match[2])
+  const end = Number(match[4] ?? match[2])
+  if (![start, end].every((line) => Number.isSafeInteger(line) && line > 0)) return null
+  return {
+    start,
+    end,
+    side: match[1] === 'L' ? 'deletions' : 'additions',
+    endSide: (match[3] ?? match[1]) === 'L' ? 'deletions' : 'additions',
+  }
+}
+
+export function lineHash(range: SelectedLineRange | null) {
+  if (!range) return ''
+  const start = `${range.side === 'deletions' ? 'L' : 'R'}${range.start}`
+  const end = `${(range.endSide ?? range.side) === 'deletions' ? 'L' : 'R'}${range.end}`
+  return `#${start}${start === end ? '' : `-${end}`}`
+}
+
+// Pierre owns pointer/Shift-click selection and painting, including virtual rows.
+export function useLineSelection(path: string, diff?: FileDiffMetadata, fileSide = 'R') {
+  const [selectedLines, setSelectedLines] = useState(() => parseLineHash(location.hash))
+  const pendingScroll = useRef(!!selectedLines)
+  const frame = useRef(0)
+  useEffect(() => {
+    const update = () => {
+      cancelAnimationFrame(frame.current)
+      frame.current = 0
+      const selection = parseLineHash(location.hash)
+      pendingScroll.current = !!selection
+      setSelectedLines(selection)
+    }
+    window.addEventListener('hashchange', update)
+    return () => {
+      window.removeEventListener('hashchange', update)
+      cancelAnimationFrame(frame.current)
+      frame.current = 0
+    }
+  }, [])
+  return {
+    selectedLines,
+    options: {
+      enableLineSelection: true,
+      // Unlike onLineSelected, this fires only for pointer interactions, not
+      // when React restores selectedLines from the URL.
+      onLineSelectionEnd(range: SelectedLineRange | null) {
+        if (range && !diff) range = { ...range, side: fileSide === 'L' ? 'deletions' : 'additions' }
+        pendingScroll.current = false
+        cancelAnimationFrame(frame.current)
+        frame.current = 0
+        setSelectedLines(range)
+        const url = new URL(location.href)
+        url.searchParams.set('file', path)
+        url.hash = lineHash(range)
+        window.history.replaceState(null, '', url)
+      },
+      onPostRender(node: HTMLElement, instance: File | FileDiff, phase: PostRenderPhase) {
+        if (phase === 'unmount') {
+          cancelAnimationFrame(frame.current)
+          frame.current = 0
+          return
+        }
+        if (!pendingScroll.current || !selectedLines || frame.current) return
+        if (!(instance instanceof VirtualizedFile || instance instanceof VirtualizedFileDiff))
+          return
+        frame.current = requestAnimationFrame(() => {
+          if (!node.isConnected || !pendingScroll.current) return
+          // Reveal only the context blocks containing the linked endpoints.
+          if (instance instanceof VirtualizedFileDiff && diff) {
+            for (const [line, side] of [
+              [selectedLines.start, selectedLines.side],
+              [selectedLines.end, selectedLines.endSide ?? selectedLines.side],
+            ] as const) {
+              const start = side === 'deletions' ? 'deletionStart' : 'additionStart'
+              const count = side === 'deletions' ? 'deletionCount' : 'additionCount'
+              const next = diff.hunks.findIndex((hunk) => line < hunk[start])
+              if (next >= 0 && line >= diff.hunks[next][start] - diff.hunks[next].collapsedBefore)
+                instance.expandHunk(next, 'up', Infinity)
+              else if (next < 0 && diff.hunks.length) {
+                const last = diff.hunks.at(-1)!
+                if (line >= last[start] + last[count])
+                  instance.expandHunk(diff.hunks.length - 1, 'down', Infinity)
+              }
+            }
+          }
+          frame.current = requestAnimationFrame(() => {
+            frame.current = 0
+            if (!node.isConnected || !pendingScroll.current) return
+            pendingScroll.current = false
+            const position = instance.getLinePosition(selectedLines.start, selectedLines.side)
+            if (!position) return
+            const stickyHeight = ['.viewer-toolbar', '.diff-sides'].reduce(
+              (height, selector) =>
+                height + (document.querySelector(selector)?.getBoundingClientRect().height ?? 0),
+              8,
+            )
+            window.scrollTo({
+              top: window.scrollY + node.getBoundingClientRect().top + position.top - stickyHeight,
+              behavior: 'instant',
+            })
+          })
+        })
+      },
+    },
+  }
+}

--- a/perf/src/server/api.ts
+++ b/perf/src/server/api.ts
@@ -3,7 +3,6 @@ import { historyMetrics, historySeries } from '../historySeries'
 import { requestTiming } from './timing'
 import { responseCache } from '../cache'
 import { measurementColumns } from './publication'
-import { loadBenchmarkSources } from './benchmarkSources'
 
 import { clickHouseConfig, select, type ClickHouseConfig } from './clickhouse'
 import { demoResponse } from './demo'
@@ -36,7 +35,7 @@ async function indexFromClickHouse(config: ClickHouseConfig) {
        anyOrNullIf(commit, branch = 'main') OVER (
          ORDER BY started_at DESC, commit DESC ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING
        ) AS baseCommit
-     FROM (SELECT * EXCEPT (measurements, artifacts) FROM run_snapshots FINAL WHERE source_schema > 0
+     FROM (SELECT * EXCEPT (measurements, artifacts, source_links) FROM run_snapshots FINAL WHERE source_schema > 0
        ORDER BY workflow_run_id DESC, run_attempt DESC, published_at DESC LIMIT 1 BY commit)
      WHERE source_schema > 0 ORDER BY started_at DESC, commit DESC LIMIT 12`,
   )
@@ -113,7 +112,7 @@ async function runsFromClickHouse(
     config,
     `SELECT workflow_run_id, revision, commit, branch, pr, title,
        formatDateTime(started_at, '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS timestamp,
-       ${benchmark === undefined ? 'measurements' : "arrayMap(m -> tuple(m.test_id, '', '', m.compiler, m.status, NULL, NULL, NULL, NULL, NULL, NULL, m.label), measurements) AS measurements"}
+       ${benchmark === undefined ? 'measurements, source_links' : "arrayMap(m -> tuple(m.test_id, '', '', m.compiler, m.status, NULL, NULL, NULL, NULL, NULL, NULL, m.label), measurements) AS measurements"}
        ${includeArtifacts ? `, ${benchmark === undefined ? 'artifacts' : 'arrayFilter(f -> f.test_id = {benchmark:String}, artifacts) AS artifacts'}` : ''}
      FROM run_snapshots FINAL WHERE ${snapshotSelection(commits, revisions)}
      ORDER BY ${snapshotOrder} LIMIT 1 BY commit`,
@@ -121,7 +120,8 @@ async function runsFromClickHouse(
   )
   return Promise.all(
     stored.map(async (run) => {
-      const { measurements, artifacts, ...runMetadata } = run
+      const { measurements, artifacts, source_links, ...runMetadata } = run
+      const sources = (source_links ?? {}) as Record<string, [string, string][]>
       const rows = (Array.isArray(measurements) ? (measurements as unknown[][]) : [])
         .sort(
           (a, b) =>
@@ -138,6 +138,13 @@ async function runsFromClickHouse(
           test_id: testId,
           description: row.description,
           suite: row.suite,
+          ...(benchmark === undefined
+            ? {
+                source_links: (Object.hasOwn(sources, testId) ? sources[testId] : []).map(
+                  ([label, url]) => ({ label, url }),
+                ),
+              }
+            : {}),
           compilers: Object.create(null),
         }
         ;(result.compilers as Record<string, unknown>)[String(row.compiler)] = {
@@ -302,19 +309,6 @@ export function createApi(options: ApiOptions = {}) {
       cacheControl?.startsWith('public,')
     )
       context.header('vercel-cdn-cache-control', cacheControl.replace('max-age=', 's-maxage='))
-  })
-
-  app.get('/api/data/sources/:file', async (context) => {
-    const match = /^([a-f0-9]{40})\.json$/.exec(context.req.param('file'))
-    if (!match) return context.json({ error: 'Expected a full commit SHA' }, 400)
-    try {
-      const sources = await loadBenchmarkSources(match[1])
-      context.header('cache-control', 'public, max-age=3600')
-      return context.json(sources)
-    } catch {
-      context.header('cache-control', 'no-store')
-      return context.json({ error: 'Source metadata unavailable' }, 502)
-    }
   })
 
   app.get('/api/resolve', async (context) => {

--- a/perf/src/server/api.ts
+++ b/perf/src/server/api.ts
@@ -3,6 +3,7 @@ import { historyMetrics, historySeries } from '../historySeries'
 import { requestTiming } from './timing'
 import { responseCache } from '../cache'
 import { measurementColumns } from './publication'
+import { loadBenchmarkSources } from './benchmarkSources'
 
 import { clickHouseConfig, select, type ClickHouseConfig } from './clickhouse'
 import { demoResponse } from './demo'
@@ -301,6 +302,19 @@ export function createApi(options: ApiOptions = {}) {
       cacheControl?.startsWith('public,')
     )
       context.header('vercel-cdn-cache-control', cacheControl.replace('max-age=', 's-maxage='))
+  })
+
+  app.get('/api/data/sources/:file', async (context) => {
+    const match = /^([a-f0-9]{40})\.json$/.exec(context.req.param('file'))
+    if (!match) return context.json({ error: 'Expected a full commit SHA' }, 400)
+    try {
+      const sources = await loadBenchmarkSources(match[1])
+      context.header('cache-control', 'public, max-age=3600')
+      return context.json(sources)
+    } catch {
+      context.header('cache-control', 'no-store')
+      return context.json({ error: 'Source metadata unavailable' }, 502)
+    }
   })
 
   app.get('/api/resolve', async (context) => {

--- a/perf/src/server/backfillSources.ts
+++ b/perf/src/server/backfillSources.ts
@@ -1,0 +1,51 @@
+import { enrichSources, normalizeSourceLinks } from './benchmarkSources.ts'
+import { insert, select, type ClickHouseConfig } from './clickhouse.ts'
+
+// Reinsert the same revision with additive provenance only. No artifact reads,
+// deletions, metric changes, or changes to the selected workflow/attempt.
+export async function backfillSources(config: ClickHouseConfig, limit = 10) {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100)
+    throw new Error('Source backfill limit must be between 1 and 100')
+  const snapshots = await select(
+    config,
+    `
+    SELECT * FROM run_snapshots FINAL
+    WHERE source_schema > 0 AND arrayExists(m -> empty(source_links[m.test_id]), measurements)
+    ORDER BY workflow_run_id DESC, revision LIMIT ${limit}`,
+  )
+  const failed: string[] = []
+  let updated = 0
+  for (const snapshot of snapshots) {
+    try {
+      const sources = (snapshot.source_links ?? {}) as Record<string, [string, string][]>
+      const rows = [
+        ...new Set((snapshot.measurements as unknown[][]).map((row) => String(row[0]))),
+      ].map((test_id) => ({
+        test_id,
+        source_links: (Object.hasOwn(sources, test_id) ? sources[test_id] : []).map(
+          ([label, url]) => ({ label, url }),
+        ),
+      }))
+      await enrichSources(String(snapshot.commit), rows)
+      const missing = rows.filter((row) => !row.source_links.length)
+      if (missing.length)
+        throw new Error(`No source metadata for ${missing.map((row) => row.test_id).join(', ')}`)
+      await insert(config, 'run_snapshots', [
+        {
+          ...snapshot,
+          source_links: Object.fromEntries(
+            rows.map((row) => [
+              row.test_id,
+              normalizeSourceLinks(row.source_links).map((link) => [link.label, link.url]),
+            ]),
+          ),
+        },
+      ])
+      updated++
+    } catch (error) {
+      console.warn(`Could not backfill sources for ${String(snapshot.commit)}`, error)
+      failed.push(String(snapshot.commit))
+    }
+  }
+  return { updated, failed, scanned: snapshots.length }
+}

--- a/perf/src/server/benchmarkSources.ts
+++ b/perf/src/server/benchmarkSources.ts
@@ -1,9 +1,11 @@
-import { responseCache } from '../cache'
-import { benchmarkSources } from '../sources'
+import { responseCache } from '../cache.ts'
+import { benchmarkSources } from './legacySources.ts'
+import type { SourceLink } from '../types.ts'
 
 const catalogs = responseCache<ReturnType<typeof benchmarkSources>>(3_600_000, 2 * 1024 * 1024)
 
 export function loadBenchmarkSources(commit: string) {
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('Expected a full commit SHA')
   return catalogs(commit, async () => {
     const response = await fetch(
       `https://raw.githubusercontent.com/paradigmxyz/solar/${commit}/benches/runtime/cases.py`,
@@ -14,4 +16,37 @@ export function loadBenchmarkSources(commit: string) {
     if (catalog.length > 2 * 1024 * 1024) throw new Error('Benchmark source catalog is too large')
     return benchmarkSources(catalog, commit)
   })
+}
+
+// Solar PR #1449 owns provenance for new runs. Only old results need a catalog.
+export function normalizeSourceLinks(value: unknown): SourceLink[] {
+  if (!Array.isArray(value)) return []
+  const links = new Map<string, SourceLink>()
+  for (const link of value.slice(0, 32)) {
+    if (
+      !link ||
+      typeof link.label !== 'string' ||
+      !link.label.trim() ||
+      link.label.length > 512 ||
+      typeof link.url !== 'string' ||
+      link.url.length > 4096
+    )
+      continue
+    try {
+      const url = new URL(link.url)
+      if (url.protocol !== 'https:' || url.username || url.password) continue
+      links.set(url.href, { label: link.label, url: url.href })
+    } catch {
+      /* Ignore malformed producer metadata. */
+    }
+  }
+  return [...links.values()]
+}
+
+export async function enrichSources(commit: string, rows: Record<string, unknown>[]) {
+  const missing = rows.filter((row) => !normalizeSourceLinks(row.source_links).length)
+  if (!missing.length) return
+  const catalog = await loadBenchmarkSources(commit)
+  for (const row of missing)
+    if (Object.hasOwn(catalog, String(row.test_id))) row.source_links = catalog[String(row.test_id)]
 }

--- a/perf/src/server/benchmarkSources.ts
+++ b/perf/src/server/benchmarkSources.ts
@@ -1,0 +1,17 @@
+import { responseCache } from '../cache'
+import { benchmarkSources } from '../sources'
+
+const catalogs = responseCache<ReturnType<typeof benchmarkSources>>(3_600_000, 2 * 1024 * 1024)
+
+export function loadBenchmarkSources(commit: string) {
+  return catalogs(commit, async () => {
+    const response = await fetch(
+      `https://raw.githubusercontent.com/paradigmxyz/solar/${commit}/benches/runtime/cases.py`,
+      { signal: AbortSignal.timeout(10_000) },
+    )
+    if (!response.ok) throw new Error('Benchmark source catalog is unavailable')
+    const catalog = await response.text()
+    if (catalog.length > 2 * 1024 * 1024) throw new Error('Benchmark source catalog is too large')
+    return benchmarkSources(catalog, commit)
+  })
+}

--- a/perf/src/server/clickhouse.ts
+++ b/perf/src/server/clickhouse.ts
@@ -1,4 +1,4 @@
-import { requestTiming } from './timing'
+import { requestTiming } from './timing.ts'
 import { randomUUID } from 'node:crypto'
 
 export interface ClickHouseConfig {

--- a/perf/src/server/ingest.ts
+++ b/perf/src/server/ingest.ts
@@ -7,6 +7,7 @@ import { clickHouseConfig, insert, select, type ClickHouseConfig } from './click
 import { type GitHubClient, sharedGitHubClient, gitHubConfig, type GitHubRun } from './github'
 import { normalizeResults } from './normalizeResults'
 import { publication, publicationBlobs } from './publication'
+import { enrichSources } from './benchmarkSources'
 import { ImportPendingError, RunNotFoundError } from './pending'
 import { importStage, timeImport } from './importTiming'
 export { ImportPendingError } from './pending'
@@ -326,6 +327,11 @@ async function ingestRun(config: ClickHouseConfig, github: GitHubClient, source:
   // Extraction is streamed while downloading; report the combined stage honestly.
   const archive = await importStage('downloadExtractMs', () => extractArchive(response))
   const normalized = await importStage('normalizeMs', () => normalizeArchive(archive, run))
+  // Missing historical provenance must not prevent publication of measurements.
+  // The backend backfill retries it independently of artifact import.
+  await enrichSources(run.commit, normalized.results).catch((error) =>
+    console.warn('Could not enrich historical benchmark sources', error),
+  )
   const blobs = await importStage('prepareBlobsMs', () => publicationBlobs(normalized.artifacts))
   await importStage('writeBlobsMs', () => insert(config, 'artifact_blobs', blobs))
   await importStage('publishSnapshotMs', () =>

--- a/perf/src/server/legacySources.ts
+++ b/perf/src/server/legacySources.ts
@@ -1,7 +1,4 @@
-export interface SourceLink {
-  label: string
-  url: string
-}
+import type { SourceLink } from '../types.ts'
 
 // Solar benches/runtime/README.md provenance and named release refs resolved to
 // immutable commits. Catalog paths are read from the selected run, not main.
@@ -43,6 +40,26 @@ function sourceLink(repository: string, commit: string, path: string, label: str
 // Read supported literal fields; never execute a fetched Python catalog.
 export function benchmarkSources(catalog: string, commit: string) {
   const sources: Record<string, SourceLink[]> = Object.create(null)
+  // Also cover the rollout window: old importers discarded PR #1449 metadata
+  // even though its catalogs already use shared Project/Source literals.
+  const projects = new Map<string, { file: string; origins: [string, string][] }>()
+  const definitions = [
+    ...catalog.matchAll(
+      /["']([\w.-]+)["']:\s*Project\(\s*["'][\w.-]+["'],\s*["']([\w.-]+\.json\.gz)["']/g,
+    ),
+  ]
+  for (let i = 0; i < definitions.length; i++) {
+    const definition = catalog.slice(
+      definitions[i].index,
+      definitions[i + 1]?.index ?? catalog.length,
+    )
+    projects.set(definitions[i][1], {
+      file: definitions[i][2],
+      origins: [
+        ...definition.matchAll(/Source\(\s*["']([\w.-]+\/[\w.-]+)["'],\s*["']([a-f0-9]{40})["']/g),
+      ].map((match) => [match[1], match[2]]),
+    })
+  }
   const cases = [...catalog.matchAll(/\btest_id\s*=\s*["']([\w.-]+)["']/g)]
   for (let i = 0; i < cases.length; i++) {
     const entry = catalog.slice(cases[i].index, cases[i + 1]?.index ?? catalog.length)
@@ -54,11 +71,23 @@ export function benchmarkSources(catalog: string, commit: string) {
     const links: SourceLink[] = []
     if (local && !local.split('/').includes('..'))
       links.push(sourceLink('paradigmxyz/solar', commit, `testdata/${local}`, local))
-    const archive = literal('project_file')
+    const project = projects.get(
+      entry.match(/\bproject\s*=\s*PROJECTS\[["']([\w.-]+)["']\]/)?.[1] ?? '',
+    )
+    const archive =
+      literal('project_file') ??
+      project?.file ??
+      (literal('project')?.endsWith('.json.gz') ? literal('project') : undefined)
     if (archive && !archive.split('/').includes('..')) {
       const path = archive.includes('/') ? archive : `testdata/projects/${archive}`
       const name = archive.split('/').pop()!
       links.push(sourceLink('paradigmxyz/solar', commit, path, `Input: ${name}`))
+      if (project) {
+        for (const [repository, revision] of project.origins)
+          links.push(sourceLink(repository, revision, '', repository))
+        sources[cases[i][1]] = links
+        continue
+      }
       const origin = upstream[name.replace(/\.json\.gz$/, '')]
       if (origin) {
         // Aave's harness and Solar's wrappers aren't upstream files.

--- a/perf/src/server/normalizeResults.ts
+++ b/perf/src/server/normalizeResults.ts
@@ -1,4 +1,5 @@
 import { validIdentifier } from './artifacts.ts'
+import { normalizeSourceLinks } from './benchmarkSources.ts'
 
 function number(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -46,6 +47,7 @@ export function normalizeResults(
           test_id: testId,
           description: text(result.description, 4_096),
           suite: text(result.suite, 128) || 'unknown',
+          source_links: normalizeSourceLinks(result.source_links),
           compiler,
           status: text(values.status, 64) || 'unknown',
           label: text(values.label, 512),

--- a/perf/src/server/publication.ts
+++ b/perf/src/server/publication.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { normalizeSourceLinks } from './benchmarkSources.ts'
 
 export const measurementColumns = [
   'test_id',
@@ -60,6 +61,14 @@ export function publication(
   return {
     ...snapshot,
     revision: createHash('sha256').update(JSON.stringify(snapshot)).digest('hex'),
+    // Provenance is additive metadata, not artifact identity. This lets the
+    // backfill enrich existing pinned revisions without breaking shared URLs.
+    source_links: Object.fromEntries(
+      results.map((row) => [
+        String(row.test_id),
+        normalizeSourceLinks(row.source_links).map((link) => [link.label, link.url]),
+      ]),
+    ),
   }
 }
 

--- a/perf/src/server/vercel-worker.ts
+++ b/perf/src/server/vercel-worker.ts
@@ -2,6 +2,8 @@ import { Hono } from 'hono'
 import { ingestCommit, ingestRecent } from './ingest'
 import { nodeHandler } from './http'
 import { ImportPendingError, RunNotFoundError } from './pending'
+import { backfillSources } from './backfillSources'
+import { clickHouseConfig } from './clickhouse'
 
 const app = new Hono()
 app.use('*', async (context, next) => {
@@ -15,6 +17,11 @@ app.use('*', async (context, next) => {
   await next()
 })
 app.get('/api/worker/tick', async (context) => context.json(await ingestRecent()))
+app.post('/api/worker/backfill-sources', async (context) => {
+  const config = clickHouseConfig(process.env, 'write')
+  if (!config) throw new Error('ClickHouse write credentials are not configured')
+  return context.json(await backfillSources(config))
+})
 app.post('/api/worker/import', async (context) => {
   const sha = context.req.query('commit') ?? ''
   if (!/^[a-f0-9]{40}$/.test(sha)) return context.json({ error: 'Invalid commit' }, 400)

--- a/perf/src/sources.ts
+++ b/perf/src/sources.ts
@@ -1,8 +1,98 @@
-// Link to the exact repository revision without guessing the producer's script
-// location, source filenames, or benchmark-to-source mapping.
-export function benchmarkSource(_testId: string, solarCommit: string) {
+export interface SourceLink {
+  label: string
+  url: string
+}
+
+// Solar benches/runtime/README.md provenance and named release refs resolved to
+// immutable commits. Catalog paths are read from the selected run, not main.
+const upstream: Record<string, [string, string]> = {
+  'uniswap-v2-pair': ['Uniswap/v2-core', 'ee547b17853e71ed4e0101ccfd52e70d5acded58'],
+  'openzeppelin-runtime': [
+    'OpenZeppelin/openzeppelin-contracts',
+    '6308fdc5e8e0d5e8a94dc9d5d4c79f6331334c81',
+  ],
+  'openzeppelin-5.6.1': [
+    'OpenZeppelin/openzeppelin-contracts',
+    '5fd1781b1454fd1ef8e722282f86f9293cacf256',
+  ],
+  'nitro-one-step-proof': [
+    'OffchainLabs/nitro-contracts',
+    '0b8c04e8f5f66fe6678a4f53aa15f23da417260e',
+  ],
+  'aave-l2-encoder': ['aave/aave-v3-core', '782f51917056a53a2c228701058a6c3fb233684a'],
+  'lilweb3-ens': ['m1guelpf/lil-web3', '7346bd28c2586da3b07102d5290175a276949b15'],
+  'lilweb3-runtime': ['m1guelpf/lil-web3', '7346bd28c2586da3b07102d5290175a276949b15'],
+  'maple-erc20': ['maple-labs/erc20', 'baf791a9f894b0b319a2d42d5b9f8d30349ebaad'],
+  'solady-0.1.26': ['Vectorized/solady', 'acd959aa4bd04720d640bf4e6a5c71037510cc4b'],
+  'seaport-1.6': ['ProjectOpenSea/seaport', '22ea29df3c241ebc17c95268164dde47e1186287'],
+  'v4-core-4.0.0': ['Uniswap/v4-core', 'e50237c43811bd9b526eff40f26772152a42daba'],
+  'morpho-blue-1.0.0': ['morpho-org/morpho-blue', '55d2d99304fb3fb930c688462ae2ccabb1d533ad'],
+  'forge-std-1.16.1': ['foundry-rs/forge-std', '620536fa5277db4e3fd46772d5cbc1ea0696fb43'],
+  'prb-math-4.1.1': ['PaulRBerg/prb-math', 'b51e8631ed28d3cc917c491dd47cd6c3ff652edc'],
+  'solmate-6': ['transmissions11/solmate', 'a9e3ea26a2dc73bfa87f0cb189687d029028e0c5'],
+  'solarray-a547630': ['evmcheb/solarray', 'a547630f9bf7837af9e6919d217672afe7abf7f1'],
+}
+
+function sourceLink(repository: string, commit: string, path: string, label: string): SourceLink {
   return {
-    label: 'Solar repository',
-    url: `https://github.com/paradigmxyz/solar/tree/${solarCommit}`,
+    label,
+    url: `https://github.com/${repository}/${path ? 'blob' : 'tree'}/${commit}${path ? `/${path.split('/').map(encodeURIComponent).join('/')}` : ''}`,
   }
+}
+
+// Read supported literal fields; never execute a fetched Python catalog.
+export function benchmarkSources(catalog: string, commit: string) {
+  const sources: Record<string, SourceLink[]> = Object.create(null)
+  const cases = [...catalog.matchAll(/\btest_id\s*=\s*["']([\w.-]+)["']/g)]
+  for (let i = 0; i < cases.length; i++) {
+    const entry = catalog.slice(cases[i].index, cases[i + 1]?.index ?? catalog.length)
+    const literal = (key: string) =>
+      entry.match(new RegExp(`\\b${key}\\s*=\\s*["']([\\w./-]+)["']`))?.[1]
+    const local =
+      entry.match(/source_code\s*=\s*source\(["']([\w./-]+)["']\)/)?.[1] ??
+      entry.match(/source_code\s*=\s*\(TESTDATA_ROOT\s*\/\s*["']([\w./-]+)["']\)/)?.[1]
+    const links: SourceLink[] = []
+    if (local && !local.split('/').includes('..'))
+      links.push(sourceLink('paradigmxyz/solar', commit, `testdata/${local}`, local))
+    const archive = literal('project_file')
+    if (archive && !archive.split('/').includes('..')) {
+      const path = archive.includes('/') ? archive : `testdata/projects/${archive}`
+      const name = archive.split('/').pop()!
+      links.push(sourceLink('paradigmxyz/solar', commit, path, `Input: ${name}`))
+      const origin = upstream[name.replace(/\.json\.gz$/, '')]
+      if (origin) {
+        // Aave's harness and Solar's wrappers aren't upstream files.
+        const entrypoint =
+          name === 'aave-l2-encoder.json.gz'
+            ? 'contracts/misc/L2Encoder.sol'
+            : local
+              ? ''
+              : (literal('source') ?? '')
+        if (!entrypoint.split('/').includes('..'))
+          links.push(
+            sourceLink(
+              ...origin,
+              entrypoint,
+              `${origin[0]} · ${entrypoint || name.replace(/\.json\.gz$/, '')} @ ${origin[1].slice(0, 8)}`,
+            ),
+          )
+      }
+      if (name === 'lilweb3-runtime.json.gz') {
+        for (const file of [
+          'ERC20.sol',
+          ...(cases[i][1] === 'lilweb3-fractional' ? ['ERC721.sol'] : []),
+        ])
+          links.push(
+            sourceLink(
+              'transmissions11/solmate',
+              'e802bcf2fb24dda2bf7e513bea86d15c48b57486',
+              `src/tokens/${file}`,
+              `solmate · ${file} @ e802bcf2`,
+            ),
+          )
+      }
+    }
+    sources[cases[i][1]] = links
+  }
+  return sources
 }

--- a/perf/src/styles.css
+++ b/perf/src/styles.css
@@ -804,6 +804,37 @@ header.file-header {
   max-width: none;
   min-height: calc(100vh - 60px);
   padding: 0;
+  background: var(--raised);
+  --viewer-toolbar-height: 48px;
+}
+.viewer-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  height: var(--viewer-toolbar-height);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+.viewer-toolbar > button {
+  padding: 6px;
+  display: flex;
+}
+.viewer-filename {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font:
+    12px ui-monospace,
+    monospace;
+}
+.viewer-toolbar .diff-tools {
+  margin: 0 0 0 auto;
+  flex-shrink: 0;
 }
 .file-viewer > .empty {
   width: min(1100px, calc(100% - 48px));
@@ -811,10 +842,30 @@ header.file-header {
 }
 .file-viewer-body {
   display: grid;
-  grid-template-columns: 270px minmax(0, 1fr);
-  min-height: calc(100vh - 60px);
+  grid-template-columns: min(var(--sidebar-width), 40vw) 6px minmax(0, 1fr);
+  min-height: calc(100dvh - 60px - var(--viewer-toolbar-height));
+}
+.file-viewer-body.sidebar-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+.sidebar-resizer {
+  position: sticky;
+  top: var(--viewer-toolbar-height);
+  align-self: start;
+  height: calc(100dvh - 60px - var(--viewer-toolbar-height));
+  cursor: col-resize;
+  touch-action: none;
+  background: var(--surface);
+}
+.sidebar-resizer:hover,
+.sidebar-resizer:focus-visible {
+  background: var(--primary);
 }
 .file-viewer-body aside {
+  position: sticky;
+  top: var(--viewer-toolbar-height);
+  align-self: start;
+  max-height: calc(100dvh - var(--viewer-toolbar-height));
   overflow: auto;
   border-right: 1px solid var(--line);
   background: var(--surface);
@@ -905,7 +956,6 @@ header.file-header {
 }
 .file-diff {
   min-width: 0;
-  overflow: auto;
   background: var(--raised);
 }
 .file-diff .diff-frame {
@@ -913,6 +963,9 @@ header.file-header {
   padding: 16px 20px;
 }
 .diff-sides {
+  position: sticky;
+  top: var(--viewer-toolbar-height);
+  z-index: 4;
   display: grid;
   grid-template-columns: 1fr 1fr;
   border-bottom: 1px solid var(--line);
@@ -948,9 +1001,13 @@ header.file-header {
     grid-template-columns: 1fr;
   }
   .file-viewer-body aside {
-    max-height: 210px;
+    position: static;
+    max-height: none;
     border-right: 0;
     border-bottom: 1px solid var(--line);
+  }
+  .sidebar-resizer {
+    display: none;
   }
   .diff-sides {
     grid-template-columns: 1fr;

--- a/perf/src/styles.css
+++ b/perf/src/styles.css
@@ -1113,6 +1113,7 @@ header.file-header {
   margin: 0 0 4px;
 }
 .benchmark-links a {
+  overflow-wrap: anywhere;
   color: var(--text);
   font-size: 13px;
   text-decoration-color: var(--line);

--- a/perf/src/types.ts
+++ b/perf/src/types.ts
@@ -42,7 +42,13 @@ export interface BenchmarkResult {
   test_id: string
   description?: string
   suite: string
+  source_links?: SourceLink[]
   compilers: Record<string, CompilerResult>
+}
+
+export interface SourceLink {
+  label: string
+  url: string
 }
 
 export interface ArtifactFile {

--- a/perf/tests/api.test.ts
+++ b/perf/tests/api.test.ts
@@ -19,31 +19,22 @@ afterEach(() => {
 })
 
 describe('website API', () => {
-  it('loads pinned source catalogs without database queries and coalesces reads', async () => {
+  it('returns source links with the existing run query, without GitHub calls', async () => {
     const commit = 'd'.repeat(40)
-    globalThis.fetch = vi.fn(
-      async () => new Response('TestCase(test_id="counter", source_code=source("Counter.sol"))'),
+    const url = `https://github.com/paradigmxyz/solar/blob/${commit}/testdata/Counter.sol`
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        commit,
+        measurements: [['counter', '', 'micro', 'solar', 'ok']],
+        source_links: { counter: [['Counter.sol', url]] },
+      }),
     )
-    const app = createApi({ clickHouse: null })
-    const path = `/api/data/sources/${commit}.json`
-    const [first, second] = await Promise.all([app.request(path), app.request(path)])
-    expect(first.status).toBe(200)
-    expect(await first.json()).toEqual(await second.json())
+    const response = await createApi({ clickHouse: config }).request(
+      `/api/data/runs/${commit}/run.json?artifacts=0`,
+    )
+    expect(response.status).toBe(200)
+    expect((await response.json()).results[0].source_links).toEqual([{ label: 'Counter.sol', url }])
     expect(globalThis.fetch).toHaveBeenCalledOnce()
-    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe(
-      `https://raw.githubusercontent.com/paradigmxyz/solar/${commit}/benches/runtime/cases.py`,
-    )
-    expect(first.headers.get('vercel-cdn-cache-control')).toBe('public, s-maxage=3600')
-    expect((await app.request('/api/data/sources/main.json')).status).toBe(400)
-  })
-
-  it('does not cache missing source catalogs as successful source links', async () => {
-    globalThis.fetch = vi.fn(async () => new Response('', { status: 404 }))
-    const response = await createApi({ clickHouse: null }).request(
-      `/api/data/sources/${'e'.repeat(40)}.json`,
-    )
-    expect(response.status).toBe(502)
-    expect(response.headers.get('cache-control')).toBe('no-store')
   })
 
   it('resolves published prefixes with one bounded query without GitHub', async () => {

--- a/perf/tests/api.test.ts
+++ b/perf/tests/api.test.ts
@@ -19,6 +19,33 @@ afterEach(() => {
 })
 
 describe('website API', () => {
+  it('loads pinned source catalogs without database queries and coalesces reads', async () => {
+    const commit = 'd'.repeat(40)
+    globalThis.fetch = vi.fn(
+      async () => new Response('TestCase(test_id="counter", source_code=source("Counter.sol"))'),
+    )
+    const app = createApi({ clickHouse: null })
+    const path = `/api/data/sources/${commit}.json`
+    const [first, second] = await Promise.all([app.request(path), app.request(path)])
+    expect(first.status).toBe(200)
+    expect(await first.json()).toEqual(await second.json())
+    expect(globalThis.fetch).toHaveBeenCalledOnce()
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe(
+      `https://raw.githubusercontent.com/paradigmxyz/solar/${commit}/benches/runtime/cases.py`,
+    )
+    expect(first.headers.get('vercel-cdn-cache-control')).toBe('public, s-maxage=3600')
+    expect((await app.request('/api/data/sources/main.json')).status).toBe(400)
+  })
+
+  it('does not cache missing source catalogs as successful source links', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 404 }))
+    const response = await createApi({ clickHouse: null }).request(
+      `/api/data/sources/${'e'.repeat(40)}.json`,
+    )
+    expect(response.status).toBe(502)
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
   it('resolves published prefixes with one bounded query without GitHub', async () => {
     const commit = 'a'.repeat(40)
     globalThis.fetch = vi.fn(async () => Response.json({ commit }))

--- a/perf/tests/benchmarkSources.test.ts
+++ b/perf/tests/benchmarkSources.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, expect, it, vi } from 'vite-plus/test'
+import { normalizeResults } from '../src/server/normalizeResults'
+import { enrichSources, normalizeSourceLinks } from '../src/server/benchmarkSources'
+import { publication } from '../src/server/publication'
+import { backfillSources } from '../src/server/backfillSources'
+
+afterEach(() => vi.unstubAllGlobals())
+
+const commit = 'f'.repeat(40)
+const links = [
+  { label: 'example/upstream', url: `https://github.com/example/upstream/tree/${commit}` },
+]
+const config = {
+  host: 'https://clickhouse.example',
+  database: 'solar_perf',
+  user: 'writer',
+  password: '',
+}
+
+it('preserves PR 1449 source_links on successful and failed results without fetching catalogs', async () => {
+  const fetch = vi.fn()
+  vi.stubGlobal('fetch', fetch)
+  const rows = normalizeResults(
+    {
+      results: [
+        {
+          test_id: 'new-project',
+          source_links: links,
+          compilers: { solar: { status: 'ok' }, solx: { status: 'failed' } },
+        },
+      ],
+    },
+    { commit, workflowRunId: 1 },
+  )
+  await enrichSources(commit, rows)
+  expect(fetch).not.toHaveBeenCalled()
+  expect(rows.map((row) => row.source_links)).toEqual([links, links])
+  const run = { commit, workflow_run_id: 1 }
+  const snapshot = publication(run, rows, [])
+  expect(snapshot.source_links).toEqual({
+    'new-project': links.map((link) => [link.label, link.url]),
+  })
+  expect(snapshot.revision).toBe(
+    publication(
+      run,
+      rows.map((row) => ({ ...row, source_links: [] })),
+      [],
+    ).revision,
+  )
+})
+
+it('rejects unsafe and malformed links, deduplicates, and bounds producer metadata', () => {
+  expect(
+    normalizeSourceLinks([
+      ...links,
+      ...links,
+      { label: 'unsafe', url: 'javascript:alert(1)' },
+      { label: 'credentials', url: 'https://user:pass@example.com/' },
+      { label: '', url: 'https://example.com/' },
+      null,
+    ]),
+  ).toEqual(links)
+  expect(
+    normalizeSourceLinks(
+      Array.from({ length: 100 }, (_, i) => ({ label: 'source', url: `https://example.com/${i}` })),
+    ),
+  ).toHaveLength(32)
+})
+
+it('backfills historical snapshots without changing revisions, timestamps, metrics, or artifacts', async () => {
+  const old = {
+    commit: 'e'.repeat(40),
+    revision: 'a'.repeat(64),
+    workflow_run_id: 7,
+    run_attempt: 1,
+    published_at: '2026-01-01 00:00:00.000',
+    measurements: [['counter', '', '', 'solar', 'ok']],
+    artifacts: [['counter', 'output.json', 'solar', 2, 'hash', '1.json']],
+    source_links: {},
+  }
+  let written: Record<string, unknown> | undefined
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input, init) => {
+      const url = new URL(String(input))
+      if (url.hostname === 'raw.githubusercontent.com')
+        return new Response('TestCase(test_id="counter", source_code=source("Counter.sol"))')
+      if (url.searchParams.has('query')) {
+        written = JSON.parse(String(init.body).trim())
+        return new Response('')
+      }
+      expect(String(init.body)).toContain('empty(source_links[m.test_id])')
+      return new Response(written ? '' : JSON.stringify(old))
+    }),
+  )
+  expect(await backfillSources(config)).toEqual({ scanned: 1, updated: 1, failed: [] })
+  expect(written).toEqual({
+    ...old,
+    source_links: {
+      counter: [
+        [
+          'Counter.sol',
+          `https://github.com/paradigmxyz/solar/blob/${old.commit}/testdata/Counter.sol`,
+        ],
+      ],
+    },
+  })
+  expect(await backfillSources(config)).toEqual({ scanned: 0, updated: 0, failed: [] })
+})
+
+it('reports unresolved historical benchmarks without publishing incomplete metadata', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const fetch = vi.fn(async (input) =>
+    String(input).includes('raw.githubusercontent.com')
+      ? new Response('')
+      : Response.json({ commit: 'b'.repeat(40), measurements: [['unknown']] }),
+  )
+  vi.stubGlobal('fetch', fetch)
+  expect(await backfillSources(config)).toEqual({
+    scanned: 1,
+    updated: 0,
+    failed: ['b'.repeat(40)],
+  })
+  expect(fetch).toHaveBeenCalledTimes(2)
+  warn.mockRestore()
+})

--- a/perf/tests/lineSelection.test.ts
+++ b/perf/tests/lineSelection.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { lineHash, parseLineHash } from '../src/lineSelection'
+
+test('line anchors round-trip sides, ranges, and backwards selections', () => {
+  for (const hash of ['#L12', '#R7', '#R12-R20', '#L20-L12', '#L12-R20'])
+    expect(lineHash(parseLineHash(hash))).toBe(hash)
+  expect(lineHash(null)).toBe('')
+})
+
+test('rejects malformed, zero, negative, and unsafe line numbers', () => {
+  for (const hash of ['', '#L0', '#L-1', '#R1-R0', '#L1.5', '#R9007199254740992', '#L2oops'])
+    expect(parseLineHash(hash)).toBeNull()
+})

--- a/perf/tests/sources.test.ts
+++ b/perf/tests/sources.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { benchmarkSources } from '../src/sources'
+import { benchmarkSources } from '../src/server/legacySources'
+
+it('backfills shared Project/Source catalogs from the producer rollout window', () => {
+  const commit = 'a'.repeat(40)
+  const sources = benchmarkSources(
+    `
+    PROJECTS = {"example": Project("example", "example.json.gz", (Source("owner/example", "${commit}"),))}
+    TestCase(test_id="new-case", project=PROJECTS["example"], source="src/Example.sol")
+  `,
+    commit,
+  )
+  expect(sources['new-case']).toEqual([
+    {
+      label: 'Input: example.json.gz',
+      url: `https://github.com/paradigmxyz/solar/blob/${commit}/testdata/projects/example.json.gz`,
+    },
+    { label: 'owner/example', url: `https://github.com/owner/example/tree/${commit}` },
+  ])
+})
 
 describe('benchmark sources', () => {
   const commit = 'a'.repeat(40)

--- a/perf/tests/sources.test.ts
+++ b/perf/tests/sources.test.ts
@@ -1,13 +1,70 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { benchmarkSource } from '../src/sources'
+import { benchmarkSources } from '../src/sources'
 
 describe('benchmark sources', () => {
-  it('does not assume a benchmark script or file location', () => {
-    const commit = 'a'.repeat(40)
-    for (const name of ['factorial', 'new-test']) {
-      expect(benchmarkSource(name, commit).url).toBe(
-        `https://github.com/paradigmxyz/solar/tree/${commit}`,
-      )
-    }
+  const commit = 'a'.repeat(40)
+  it('links literal local sources to the selected Solar commit', () => {
+    const sources = benchmarkSources(
+      `TestCase(test_id="factorial", source_code=source("Factorial.sol")),
+      TestCase(test_id="new-test", source_code=(TESTDATA_ROOT / "runtime/New.sol").read_text())`,
+      commit,
+    )
+    expect(sources.factorial[0].url).toBe(
+      `https://github.com/paradigmxyz/solar/blob/${commit}/testdata/Factorial.sol`,
+    )
+    expect(sources['new-test'][0].url).toContain(`/testdata/runtime/New.sol`)
+  })
+  it('links Lil Web3 input, exact source and pinned Solmate dependencies', () => {
+    const links = benchmarkSources(
+      `TestCase(test_id="lilweb3-fractional", project_file="lilweb3-runtime.json.gz", source="src/LilFractional.sol")`,
+      commit,
+    )['lilweb3-fractional']
+    expect(links.map((link) => link.url)).toEqual([
+      `https://github.com/paradigmxyz/solar/blob/${commit}/testdata/projects/lilweb3-runtime.json.gz`,
+      'https://github.com/m1guelpf/lil-web3/blob/7346bd28c2586da3b07102d5290175a276949b15/src/LilFractional.sol',
+      'https://github.com/transmissions11/solmate/blob/e802bcf2fb24dda2bf7e513bea86d15c48b57486/src/tokens/ERC20.sol',
+      'https://github.com/transmissions11/solmate/blob/e802bcf2fb24dda2bf7e513bea86d15c48b57486/src/tokens/ERC721.sol',
+    ])
+  })
+  it('preserves historical archive locations and OpenZeppelin revisions', () => {
+    const links = benchmarkSources(
+      `TestCase(test_id="openzeppelin-erc20-mock", project_file="testdata/codegen-runtime/projects/openzeppelin-runtime.json.gz", source="contracts/mocks/token/ERC20Mock.sol")`,
+      commit,
+    )['openzeppelin-erc20-mock']
+    expect(links[0].url).toContain(
+      '/testdata/codegen-runtime/projects/openzeppelin-runtime.json.gz',
+    )
+    expect(links[1].url).toContain(
+      '/6308fdc5e8e0d5e8a94dc9d5d4c79f6331334c81/contracts/mocks/token/ERC20Mock.sol',
+    )
+  })
+  it('handles versioned whole-project IDs', () => {
+    const links = benchmarkSources(
+      `TestCase(test_id="forge-std-1.16.1-project", project_file="forge-std-1.16.1.json.gz", whole_project=True)`,
+      commit,
+    )['forge-std-1.16.1-project']
+    expect(links).toHaveLength(2)
+    expect(links[1].url).toBe(
+      'https://github.com/foundry-rs/forge-std/tree/620536fa5277db4e3fd46772d5cbc1ea0696fb43',
+    )
+  })
+  it('includes both local wrapper and archive without inventing an upstream wrapper', () => {
+    const links = benchmarkSources(
+      `TestCase(test_id="solady-encoding", source_code=(TESTDATA_ROOT / "runtime/Encoding.sol").read_text(), project_file="solady-0.1.26.json.gz", source="Encoding.sol")`,
+      commit,
+    )['solady-encoding']
+    expect(links).toHaveLength(3)
+    expect(links[0].url).toContain('/testdata/runtime/Encoding.sol')
+    expect(links[2].url).toBe(
+      'https://github.com/Vectorized/solady/tree/acd959aa4bd04720d640bf4e6a5c71037510cc4b',
+    )
+  })
+  it('does not invent sources for unsupported expressions or traversal paths', () => {
+    expect(
+      benchmarkSources(
+        `TestCase(test_id="unknown", source_code=generate()), TestCase(test_id="invalid", source_code=source("../secret"))`,
+        commit,
+      ),
+    ).toEqual({ unknown: [], invalid: [] })
   })
 })


### PR DESCRIPTION
## What

Use normal page scrolling with Pierre's document-backed virtualization. Keep the diff toolbar and compiler labels sticky; let the file tree collapse or resize with mouse or keyboard. Sidebar settings reset on reload and narrow screens stack the tree above the diff.

Native gutter clicks, Shift-clicks, and dragging select lines. Side-aware URL fragments preserve selections and reopen collapsed/virtualized lines below the sticky toolbar.

Import the `source_links` emitted by [Solar #1449](https://github.com/paradigmxyz/solar/pull/1449), including failed results, into snapshot metadata. Return links in the existing run query: expanding a benchmark no longer makes a source request. Historical catalogs are parsed only by the importer/backfill; producer-supplied links need no dashboard mapping updates.

Add a resumable source backfill CLI and a CRON_SECRET-protected worker endpoint. They enrich existing revisions without changing metrics, manifests, revision IDs, or publication timestamps. No artifact downloads are needed.

## Rollout

Before deploying, apply the additive `run_snapshots.source_links` column from `perf/schema/snapshots.sql` and ensure the read account can SELECT it. Then run `pnpm run db:backfill-sources` with write credentials, or call authenticated `POST /api/worker/backfill-sources` in batches until `scanned` is zero. Failures are reported and do not overwrite incomplete metadata. Backfill is explicit, not part of the import cron.

The live schema migration and source backfill are complete: all 205 stored snapshots (204 commits) have source links, with zero missing benchmarks. Measurements, artifacts, revision IDs, and publication timestamps retain the same before/after checksum. The existing table-level read grant covers the new column; no permission changes were needed. Historical runtime-corpus fixtures are covered as well.

![LibString diff with sticky toolbar and file tree](https://github.com/user-attachments/assets/099f6670-aa82-4d53-b820-7abed9f6a520)

![Pinned benchmark inputs and upstream sources](https://github.com/user-attachments/assets/0d9773b7-7533-46a6-8cbf-584fd687139d)

AI assistance: implemented and reviewed with Codex.
