### PR TITLE
docs: fix Docker command argument forwarding

### DIFF
--- a/src/pages/guides/docker.mdx
+++ b/src/pages/guides/docker.mdx
@@ -36,7 +36,7 @@ The Docker commands described below can be run with Podman by replacing `docker`
 
 ```bash
 # Run forge build using Podman
-$ podman run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge build
+$ podman run --rm -v $(pwd):/app -w /app --entrypoint forge ghcr.io/foundry-rs/foundry build
 ```
 
 > **Note**
@@ -45,25 +45,37 @@ $ podman run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge build
 
 ### Running Foundry commands
 
+The image uses `/bin/sh -c` as its entrypoint. Set `--entrypoint` to the Foundry executable so it receives the arguments after the image name:
+
 ```bash
 # Run forge build
-$ docker run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge build
+$ docker run --rm -v $(pwd):/app -w /app --entrypoint forge ghcr.io/foundry-rs/foundry build
 
 # Run tests
-$ docker run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge test
+$ docker run --rm -v $(pwd):/app -w /app --entrypoint forge ghcr.io/foundry-rs/foundry test
 
 # Run cast
-$ docker run --rm ghcr.io/foundry-rs/foundry cast block-number --rpc-url https://ethereum.reth.rs/rpc
+$ docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry block-number --rpc-url https://ethereum.reth.rs/rpc
 ```
+
+Alternatively, keep the default entrypoint and quote the entire command as one argument:
+
+```bash
+$ docker run --rm ghcr.io/foundry-rs/foundry "cast wallet new-mnemonic"
+```
+
+:::tip
+If you only see help output, check your entrypoint and quoting. Without an entrypoint override or quotes, `docker run --rm ghcr.io/foundry-rs/foundry cast wallet new-mnemonic` runs only `cast`. The shell consumes the remaining words as its own positional parameters instead of passing them to Cast, so Cast displays help. The same applies to Forge and Anvil arguments.
+:::
 
 ### Shell alias for convenience
 
 Add to your shell profile:
 
 ```bash [~/.bashrc]
-$ alias dforge='docker run --rm -v $(pwd):/app -w /app ghcr.io/foundry-rs/foundry forge'
-$ alias dcast='docker run --rm ghcr.io/foundry-rs/foundry cast'
-$ alias danvil='docker run --rm -p 8545:8545 ghcr.io/foundry-rs/foundry anvil --host 0.0.0.0'
+$ alias dforge='docker run --rm -v $(pwd):/app -w /app --entrypoint forge ghcr.io/foundry-rs/foundry'
+$ alias dcast='docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry'
+$ alias danvil='docker run --rm -p 8545:8545 --entrypoint anvil ghcr.io/foundry-rs/foundry --host 0.0.0.0'
 ```
 
 Then use:
@@ -100,7 +112,8 @@ COPY lib ./lib
 RUN forge build
 
 # Default command
-CMD ["forge", "test"]
+ENTRYPOINT ["forge"]
+CMD ["test"]
 ```
 
 Build and run:
@@ -108,7 +121,7 @@ Build and run:
 ```bash
 $ docker build -t my-project .
 $ docker run --rm my-project
-$ docker run --rm my-project forge test -vvv
+$ docker run --rm my-project test -vvv
 ```
 
 ### Docker Compose setup
@@ -119,7 +132,8 @@ For projects needing Anvil alongside tests:
 services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:latest
-    command: anvil --host 0.0.0.0
+    entrypoint: ["anvil"]
+    command: ["--host", "0.0.0.0"]
     ports:
       - "8545:8545"
     healthcheck:
@@ -130,23 +144,25 @@ services:
 
   test:
     image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ["forge"]
     volumes:
       - .:/app
     working_dir: /app
     depends_on:
       anvil:
         condition: service_healthy
-    command: forge test --fork-url http://anvil:8545
+    command: ["test", "--fork-url", "http://anvil:8545"]
 
   deploy:
     image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ["forge"]
     volumes:
       - .:/app
     working_dir: /app
     depends_on:
       anvil:
         condition: service_healthy
-    command: forge script script/Deploy.s.sol --broadcast --rpc-url http://anvil:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+    command: script script/Deploy.s.sol --broadcast --rpc-url http://anvil:8545 --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ```
 
 Run tests:
@@ -242,7 +258,7 @@ Or in CI:
 Expose Anvil to your host machine:
 
 ```bash
-$ docker run --rm -p 8545:8545 ghcr.io/foundry-rs/foundry anvil --host 0.0.0.0
+$ docker run --rm -p 8545:8545 --entrypoint anvil ghcr.io/foundry-rs/foundry --host 0.0.0.0
 ```
 
 Anvil must bind to `0.0.0.0` (not `127.0.0.1`) to be accessible from outside the container.
@@ -250,8 +266,8 @@ Anvil must bind to `0.0.0.0` (not `127.0.0.1`) to be accessible from outside the
 With persistent state:
 
 ```bash
-$ docker run --rm -p 8545:8545 -v anvil-state:/state ghcr.io/foundry-rs/foundry \
-    anvil --host 0.0.0.0 --state /state/anvil.json
+$ docker run --rm -p 8545:8545 -v anvil-state:/state --entrypoint anvil ghcr.io/foundry-rs/foundry \
+    --host 0.0.0.0 --state /state/anvil.json
 ```
 
 ### Multi-stage builds
@@ -274,7 +290,8 @@ COPY --from=builder /app/out ./out
 COPY --from=builder /app/broadcast ./broadcast
 
 # Only include what's needed for deployment
-CMD ["forge", "script", "script/Deploy.s.sol", "--broadcast"]
+ENTRYPOINT ["forge"]
+CMD ["script", "script/Deploy.s.sol", "--broadcast"]
 ```
 
 ### Environment variables
@@ -287,8 +304,9 @@ $ docker run --rm \
     -w /app \
     -e PRIVATE_KEY \
     -e ETHERSCAN_API_KEY \
+    --entrypoint forge \
     ghcr.io/foundry-rs/foundry \
-    forge script script/Deploy.s.sol --broadcast --verify
+    script script/Deploy.s.sol --broadcast --verify
 ```
 
 Or with an env file:
@@ -298,8 +316,9 @@ $ docker run --rm \
     -v $(pwd):/app \
     -w /app \
     --env-file .env \
+    --entrypoint forge \
     ghcr.io/foundry-rs/foundry \
-    forge script script/Deploy.s.sol --broadcast
+    script script/Deploy.s.sol --broadcast
 ```
 
 ### Best practices


### PR DESCRIPTION
The Docker guide passes separate command arguments to an image whose entrypoint is `/bin/sh -c`, so examples such as `docker run --rm ghcr.io/foundry-rs/foundry cast wallet new-mnemonic` invoke only `cast` and display help. Set explicit executable entrypoints in Docker, Podman, aliases, Compose, and derived-image examples, and explain the fully quoted command alternative and help-only symptom.

Local shell argument probes confirm that the unquoted form forwards zero arguments and the quoted form forwards both wallet subcommands. The Vocs build, narrative command check, and whitespace check pass. Docker execution could not be verified because this sandbox has no Docker daemon.

This PR was written with AI assistance (Centaur).

Prompted by: @grandizzy
